### PR TITLE
Support multiple signing keys, based on authorization. Fixes #5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,16 @@ env:
     - DOCKER_USERNAME=jvehent
     - secure: "UtDpLEZJLDhGjKyh0SzuvOfsZ5dMS3RZfwNQjUyHfIqDMopTloXTYFiaXUCFwvqRIPl4blZIsGJVRKeDMYY1diH70Gv/Dhe0ka2YfU4wOafrBTJ6CaYu3+TLbJa4eW+7mWgRP5Ev4QEHXIJQQwbSc4xQd35pu07effIzE8tu9GR1a89QB5snE7ZtPM0nV7sMtahI9lUgkWipfkG1ilNu/QVV3w1JtToOloB+rbswnETnk7cgyk1Yt5lubRbE26kRxIaLyguz6A6mNp9nmKL9CUiwW7QszcODpvmCd3oMCyyiBTX/RFTHpMunpIj6C/+KD/JUhhplU/0aqN/o+lrckCUFgyqsKawYeHc33v4H32SSXESl4X49PyRD/FnAjYaUQz1DdemlrFN90Ry5XvR37IDHF5kvU4xvbrZU5ubPrAxwNItA1br54/avxniD0l6pLZX2rlLodo6sC0GIRcL51xVI5TqGmpuK3VtwJC+zikYGVlTIN4ta9OOHpy8oWnEnZsKWIT2UaxukSsGslJngGS9l8P5kLwYMBP8BFL8BbNiCTCKkGEb+jv3RqQiveTAyil5f3UG1hn4W11B39/susxv/GGQdGBllv4Jly8vOhnUCYPPjDtbp7l3We6bGl1HARbwrn33iZm+hvzDrAi0DmZbYTJE+cGpnN/FKnq7oJJY="
 
+before_install:
+    - go get github.com/mattn/goveralls
+
 install:
     - docker build -t jvehent/autograph -f Dockerfile .
 
 script:
     - make
+    - go test -v -covermode=count -coverprofile=coverage.out github.com/mozilla-services/autograph
+    - goveralls -coverprofile=coverage.out -service travis-ci -repotoken $COVERALLS_TOKEN
 
 after_success:
     # push containers into docker hub

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ install:
 
 script:
     - make
-    - docker run -d jvehent/autograph
-    - "if [ $(docker ps --filter 'name=jvehent/autograph' | wc -l) -ne 1 ]; then echo 'Should have found one container running and did not'; exit 666; fi"
-    - docker stop $(docker ps -q)
 
 after_success:
     # push containers into docker hub

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Autograph is a cryptographic signature service that implements
 and other signing methods.
 
 [![Build Status](https://travis-ci.org/mozilla-services/autograph.svg?branch=master)](https://travis-ci.org/mozilla-services/autograph)
+[![Coverage Status](https://coveralls.io/repos/github/mozilla-services/autograph/badge.svg?branch=master)](https://coveralls.io/github/mozilla-services/autograph?branch=master)
 
 ## Rationale
 

--- a/README.md
+++ b/README.md
@@ -151,3 +151,96 @@ A successful request return a `201 Created` with a response body containing sign
   }
 ]
 ```
+
+## Configuration
+
+The configuration lives in `autograph.yaml` and is expected in
+`/etc/autograph/autograph.yaml` (use flag `-c` to provide an alternate
+location).
+
+Define an address and port for the API to listen on:
+```yaml
+server:
+    listen: "192.168.1.28:8000"
+```
+
+Then configure the signers. Each signer is composed of an identifier
+and a private key (the public key is extracted from the private key).
+
+To generate a key pair with openssl, use:
+```bash
+$ openssl ecparam -out /tmp/testkey2 -name secp384r1 -genkey
+
+$ openssl ec -in /tmp/testkey2 -text
+...
+-----BEGIN EC PRIVATE KEY-----
+MIGkAgEBBDC32Lv42JlmEnaPHe+UG6wtrG39vHZAQtvUPTPgJP8Bflfsy0T30Q/5
+AMXvh0EgFbigBwYFK4EEACKhZANiAAS74cJMSG3ZjlTcjBZl5pHnimoCxAM+XL3f
+jLy0FvStcQqyWkMacmAY3MqM4YxvyBNv5J+JJPAkskYVomQzk3/8La+D2UQuj6Xu
+ReTKJie8EppVvrXwMAjhSy5zsuq7/gI=
+-----END EC PRIVATE KEY-----
+```
+
+Take the base64 keys from the BEGIN blocks are add them to the configuration
+file unwrapped:
+```yaml
+signers:
+    - id: appkey2
+      privatekey: "MIGkAgEBBDC32Lv42JlmEnaPHe+UG6wtrG39vHZAQtvUPTPgJP8Bflfsy0T30Q/5AMXvh0EgFbigBwYFK4EEACKhZANiAAS74cJMSG3ZjlTcjBZl5pHnimoCxAM+XL3fjLy0FvStcQqyWkMacmAY3MqM4YxvyBNv5J+JJPAkskYVomQzk3/8La+D2UQuj6XuReTKJie8EppVvrXwMAjhSy5zsuq7/gI="
+```
+
+Authorizations map an arbitrary username and key to a list of signers. The
+key does not need to be generated in any special way, but you can use the tool
+in `tools/maketoken/main.go` to obtain a random 256bits string:
+```bash
+$ go run tools/maketoken/main.go
+256bits random token: xsdxco7uy0pn1ei004pdkl4ex1krdu6z6o1rl1dweooo7t7tk0
+```
+
+Then add it to the configuration as follows:
+```yaml
+authorizations:
+    - id: alice
+      key: fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu
+      signers:
+          - appkey1
+          - appkey2
+    - id: bob
+      key: 9vh6bhlc10y63ow2k4zke7k0c3l9hpr8mo96p92jmbfqngs9e7d
+      signers:
+          - appkey2
+```
+
+The configuration above allows `alice` to request signatures from both `appkey1`
+and `appkey2`, while `bob` is only allowed to request signatures from `appkey2`.
+
+Note that, when a user is allowed to sign with more than one signer, and no
+specific signer key id is provided in the signing request, autograph will use
+the first signer in the list. For example, if alice requests a signature without
+providing a key id, the private key from `appkey1` will be used to sign her
+request.
+
+### Build and running
+
+Build the autograph binary using make:
+```bash
+$ make
+GO15VENDOREXPERIMENT=1 go test github.com/mozilla-services/autograph
+ok      github.com/mozilla-services/autograph   0.070s
+GO15VENDOREXPERIMENT=1 go vet github.com/mozilla-services/autograph
+GO15VENDOREXPERIMENT=1 go generate
+GO15VENDOREXPERIMENT=1 go install github.com/mozilla-services/autograph
+```
+
+The binary is located in `$GOPATH/bin/autograph` and can be started with the
+configuration file:
+```bash
+$ $GOPATH/bin/autograph -c autograph.yaml 
+{"Timestamp":1453721399358695130,"Type":"app.log","Logger":"Autograph","Hostname":"gator1","EnvVersion":"2.0","Pid":17287,"Fields":{"msg":"main.go:74: Starting Autograph API on localhost:8000"}}
+```
+
+You can test that the API is alive by querying its heartbeat URL:
+```bash
+$ curl localhost:8000/__heartbeat__
+ohai
+```

--- a/authorize.go
+++ b/authorize.go
@@ -88,11 +88,15 @@ func (a *autographer) lookupNonce(val string, ts time.Time, creds *hawk.Credenti
 }
 
 // getSignerId returns the signer identifier for the user. If a keyid is specified,
-// the corresponding signer is returned. If no signer is found, an error is returned.
+// the corresponding signer is returned. If no signer is found, an error is returned
+// and the signer identifier is set to -1.
 func (a *autographer) getSignerID(userid, keyid string) (int, error) {
 	tag := userid + "+" + keyid
 	if _, ok := a.signerIndex[tag]; !ok {
-		return -1, fmt.Errorf("no signer found for auth ID %q and key ID %q", userid, keyid)
+		if keyid == "" {
+			return -1, fmt.Errorf("%q does not have a default signing key", userid)
+		}
+		return -1, fmt.Errorf("%q is not authorized to sign with key ID %q", userid, keyid)
 	}
 	return a.signerIndex[tag], nil
 }

--- a/authorize.go
+++ b/authorize.go
@@ -15,7 +15,12 @@ import (
 	"github.com/mozilla-services/hawk-go"
 )
 
-const maxauthage time.Duration = 60 * time.Second
+// an authorization
+type authorization struct {
+	ID      string
+	Key     string
+	Signers []string
+}
 
 // authorize validates the hawk authorization header on a request
 // and returns the userid and a boolean indicating authorization status
@@ -29,9 +34,6 @@ func (a *autographer) authorize(r *http.Request, body []byte) (userid string, au
 	auth, err = hawk.ParseRequestHeader(r.Header.Get("Authorization"))
 	if err != nil {
 		return "", false, err
-	}
-	if time.Now().UTC().Sub(auth.Timestamp) > maxauthage {
-		return "", false, fmt.Errorf("authorization header is older than %s", maxauthage.String())
 	}
 	userid = auth.Credentials.ID
 	auth, err = hawk.NewAuthFromRequest(r, a.lookupCred(auth.Credentials.ID), a.lookupNonce)
@@ -50,17 +52,16 @@ func (a *autographer) authorize(r *http.Request, body []byte) (userid string, au
 	return userid, true, nil
 }
 
+// lookupCred searches the authorizations for a user whose id matches the provided
+// id string. If found, a Credential function is return to complete the hawk authorization.
+// If not found, a function that returns an error is returned.
 func (a *autographer) lookupCred(id string) hawk.CredentialsLookupFunc {
-	for _, signer := range a.signers {
-		for _, autheduser := range signer.AuthorizedUsers {
-			if autheduser == id {
-				// matching user found, return its token
-				return func(creds *hawk.Credentials) error {
-					creds.Key = signer.HawkToken
-					creds.Hash = sha256.New
-					return nil
-				}
-			}
+	if _, ok := a.auths[id]; ok {
+		// matching user found, return its token
+		return func(creds *hawk.Credentials) error {
+			creds.Key = a.auths[id].Key
+			creds.Hash = sha256.New
+			return nil
 		}
 	}
 	// credentials not found, return a function that returns a CredentialError
@@ -76,6 +77,8 @@ func (a *autographer) lookupCred(id string) hawk.CredentialsLookupFunc {
 	}
 }
 
+// lookupNonce searches the LRU cache for a previous nonce that matches the value provided in
+// val. If found, this is a replay attack, and `false` is returned.
 func (a *autographer) lookupNonce(val string, ts time.Time, creds *hawk.Credentials) bool {
 	if a.nonces.Contains(val) {
 		return false
@@ -86,6 +89,10 @@ func (a *autographer) lookupNonce(val string, ts time.Time, creds *hawk.Credenti
 
 // getSignerId returns the signer identifier for the user. If a keyid is specified,
 // the corresponding signer is returned. If no signer is found, an error is returned.
-func (a *autographer) getSignerID(userid, keyid string) (signerID int, err error) {
-	return 0, nil
+func (a *autographer) getSignerID(userid, keyid string) (int, error) {
+	tag := userid + "+" + keyid
+	if _, ok := a.signerIndex[tag]; !ok {
+		return -1, fmt.Errorf("no signer found for auth ID %q and key ID %q", userid, keyid)
+	}
+	return a.signerIndex[tag], nil
 }

--- a/authorize_test.go
+++ b/authorize_test.go
@@ -147,3 +147,10 @@ func TestSignerNotFound(t *testing.T) {
 		t.Errorf("expected to fail lookup up a signer but succeeded")
 	}
 }
+
+func TestDefaultSignerNotFound(t *testing.T) {
+	pos, err := ag.getSignerID(`unknown018qoegdxc`, ``)
+	if err == nil || pos != -1 {
+		t.Errorf("expected to fail lookup up a signer but succeeded")
+	}
+}

--- a/authorize_test.go
+++ b/authorize_test.go
@@ -9,7 +9,6 @@ package main
 import (
 	"bytes"
 	"crypto/sha256"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -49,6 +48,24 @@ func TestBogusAuthorization(t *testing.T) {
 	}
 }
 
+func TestBadPayload(t *testing.T) {
+	body := []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	bodyrdr := bytes.NewReader(body)
+	req, err := http.NewRequest("POST", "http://foo.bar/signature", bodyrdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authheader := getAuthHeader(req, ag.auths[conf.Authorizations[0].ID].ID, ag.auths[conf.Authorizations[0].ID].Key, sha256.New, id(), "application/json", []byte(`9247oldfjd18weohfa`))
+	req.Header.Set("Authorization", authheader)
+	_, authorize, err := ag.authorize(req, body)
+	if authorize {
+		t.Errorf("expected auth to fail with payload validation failed but succeeded")
+	}
+	if err.Error() != "payload validation failed" {
+		t.Errorf("expected auth to fail with payload validation failed but got error: %v", err)
+	}
+}
+
 func TestExpiredAuth(t *testing.T) {
 	body := []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	bodyrdr := bytes.NewReader(body)
@@ -57,12 +74,12 @@ func TestExpiredAuth(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", `Hawk id="tester", mac="nVg5STp2fD+P7G3ELmUztb3hP/LQajwD+FDQM7rZvhw=", ts="1453681057", nonce="TKLzwtGS", hash="sL12YYG2CnALd5o5dqHRKjNO0AvgmPPeIqlfZQfszfo=", ext="59d2rtbmji6617pthvwa1h370"`)
+	req.Header.Set("Authorization", `Hawk id="bob", mac="nVg5STp2fD+P7G3ELmUztb3hP/LQajwD+FDQM7rZvhw=", ts="1453681057", nonce="TKLzwtGS", hash="sL12YYG2CnALd5o5dqHRKjNO0AvgmPPeIqlfZQfszfo=", ext="59d2rtbmji6617pthvwa1h370"`)
 	_, authorize, err := ag.authorize(req, body)
 	if authorize {
 		t.Errorf("expected auth to fail with expired timestamp but succeeded")
 	}
-	if err.Error() != fmt.Sprintf("authorization header is older than %s", maxauthage.String()) {
+	if err.Error() != hawk.ErrTimestampSkew.Error() {
 		t.Errorf("expected auth to fail with expired timestamp but got error: %v", err)
 	}
 }
@@ -75,7 +92,7 @@ func TestDuplicateNonce(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	authheader := getAuthHeader(req, ag.signers[0].AuthorizedUsers[0], ag.signers[0].HawkToken, sha256.New, id(), "application/json", body)
+	authheader := getAuthHeader(req, ag.auths[conf.Authorizations[0].ID].ID, ag.auths[conf.Authorizations[0].ID].Key, sha256.New, id(), "application/json", body)
 	req.Header.Set("Authorization", authheader)
 	// run it once
 	_, authorize, err := ag.authorize(req, body)
@@ -90,7 +107,7 @@ func TestDuplicateNonce(t *testing.T) {
 
 }
 
-func TestRemoveExpiredNonce(t *testing.T) {
+func TestNonceFromLRU(t *testing.T) {
 	req, err := http.NewRequest("POST", "http://foo.bar/signature", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -98,8 +115,8 @@ func TestRemoveExpiredNonce(t *testing.T) {
 
 	auth1 := hawk.NewRequestAuth(req,
 		&hawk.Credentials{
-			ID:   ag.signers[0].AuthorizedUsers[0],
-			Key:  ag.signers[0].HawkToken,
+			ID:   ag.auths[conf.Authorizations[0].ID].ID,
+			Key:  ag.auths[conf.Authorizations[0].ID].Key,
 			Hash: sha256.New},
 		0)
 	req.Header.Set("Authorization", auth1.RequestHeader())
@@ -107,8 +124,8 @@ func TestRemoveExpiredNonce(t *testing.T) {
 
 	auth2 := hawk.NewRequestAuth(req,
 		&hawk.Credentials{
-			ID:   ag.signers[0].AuthorizedUsers[0],
-			Key:  ag.signers[0].HawkToken,
+			ID:   ag.auths[conf.Authorizations[0].ID].ID,
+			Key:  ag.auths[conf.Authorizations[0].ID].Key,
 			Hash: sha256.New},
 		0)
 	req.Header.Set("Authorization", auth2.RequestHeader())
@@ -121,5 +138,12 @@ func TestRemoveExpiredNonce(t *testing.T) {
 	if !ag.nonces.Contains(auth2.Nonce) {
 		t.Errorf("Second nonce %q not found in cache, should have been present", auth2.Nonce)
 		t.Logf("nonces: %+v", ag.nonces.Keys())
+	}
+}
+
+func TestSignerNotFound(t *testing.T) {
+	pos, err := ag.getSignerID(`unknown018qoegdxc`, `unkown093ytid`)
+	if err == nil || pos != -1 {
+		t.Errorf("expected to fail lookup up a signer but succeeded")
 	}
 }

--- a/autograph.yaml
+++ b/autograph.yaml
@@ -4,8 +4,18 @@ server:
     noncecachesize: 524288
 
 signers:
-    - privatekey: "MIGkAgEBBDAzX2TrGOr0WE92AbAl+nqnpqh25pKCLYNMTV2hJHztrkVPWOp8w0mhscIodK8RMpagBwYFK4EEACKhZANiAATiTcWYbt0Wg63dO7OXvpptNG0ryxv+v+JsJJ5Upr3pFus5fZyKxzP9NPzB+oFhL/xw3jMx7X5/vBGaQ2sJSiNlHVkqZgzYF6JQ4yUyiqTY7v67CyfUPA1BJg/nxOS9m3o="
-      publickey: "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE4k3FmG7dFoOt3Tuzl76abTRtK8sb/r/ibCSeVKa96RbrOX2ciscz/TT8wfqBYS/8cN4zMe1+f7wRmkNrCUojZR1ZKmYM2BeiUOMlMoqk2O7+uwsn1DwNQSYP58TkvZt6"
-      authorizedusers:
-          - tester
-      hawktoken: fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu
+    - id: appkey1
+      privatekey: "MIGkAgEBBDAzX2TrGOr0WE92AbAl+nqnpqh25pKCLYNMTV2hJHztrkVPWOp8w0mhscIodK8RMpagBwYFK4EEACKhZANiAATiTcWYbt0Wg63dO7OXvpptNG0ryxv+v+JsJJ5Upr3pFus5fZyKxzP9NPzB+oFhL/xw3jMx7X5/vBGaQ2sJSiNlHVkqZgzYF6JQ4yUyiqTY7v67CyfUPA1BJg/nxOS9m3o="
+    - id: appkey2
+      privatekey: "MIGkAgEBBDC32Lv42JlmEnaPHe+UG6wtrG39vHZAQtvUPTPgJP8Bflfsy0T30Q/5AMXvh0EgFbigBwYFK4EEACKhZANiAAS74cJMSG3ZjlTcjBZl5pHnimoCxAM+XL3fjLy0FvStcQqyWkMacmAY3MqM4YxvyBNv5J+JJPAkskYVomQzk3/8La+D2UQuj6XuReTKJie8EppVvrXwMAjhSy5zsuq7/gI="
+
+authorizations:
+    - id: alice
+      key: fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu
+      signers:
+          - appkey1
+          - appkey2
+    - id: bob
+      key: 9vh6bhlc10y63ow2k4zke7k0c3l9hpr8mo96p92jmbfqngs9e7d
+      signers:
+          - appkey2

--- a/digest.go
+++ b/digest.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
+	"fmt"
 	"hash"
 )
 
@@ -24,6 +25,8 @@ func digest(data []byte, alg string) (hashed []byte, err error) {
 		md = sha512.New384()
 	case "sha512":
 		md = sha512.New()
+	default:
+		return nil, fmt.Errorf("unsupported digest algorithm %q", alg)
 	}
 	md.Write(data)
 	hashed = md.Sum(nil)

--- a/handlers.go
+++ b/handlers.go
@@ -124,7 +124,7 @@ func (a *autographer) handleSignature(w http.ResponseWriter, r *http.Request) {
 		}
 		signerID, err := a.getSignerID(userid, sigreq.KeyID)
 		if err != nil || signerID < 0 {
-			httpError(w, http.StatusInternalServerError, "could not get signer: %v", err)
+			httpError(w, http.StatusUnauthorized, "%v", err)
 			return
 		}
 		rawsig, err := a.signers[signerID].sign(hash)

--- a/handlers.go
+++ b/handlers.go
@@ -17,18 +17,75 @@ import (
 
 // A autographer signs input data with a private key
 type autographer struct {
-	signers []Signer
-	nonces  *lru.Cache
+	signers     []signer
+	auths       map[string]authorization
+	signerIndex map[string]int
+	nonces      *lru.Cache
 }
 
-func (a *autographer) addSigner(signer Signer) {
-	a.signers = append(a.signers, signer)
-}
-
-func NewAutographer(cachesize int) (a *autographer, err error) {
+func newAutographer(cachesize int) (a *autographer, err error) {
 	a = new(autographer)
 	a.nonces, err = lru.New(cachesize)
 	return
+}
+
+// addSigners initializes each signer specified in the configuration by parsing
+// and loading their private keys. The signers are then copied over to the
+// autographer handler.
+func (a *autographer) addSigners(signers []signer) {
+	for _, signer := range signers {
+		err := signer.init()
+		if err != nil {
+			panic(err)
+		}
+		a.signers = append(a.signers, signer)
+	}
+}
+
+// addAuthorizations reads a list of authorizations from the configuration and
+// stores them into the autographer handler as a map indexed by user id, for fast lookup.
+func (a *autographer) addAuthorizations(auths []authorization) {
+	a.auths = make(map[string]authorization)
+	for _, auth := range auths {
+		if _, ok := a.auths[auth.ID]; ok {
+			panic("authorization id '" + auth.ID + "' already defined, duplicates are not permitted")
+		}
+		a.auths[auth.ID] = auth
+	}
+}
+
+// makeSignerIndex creates a map of authorization IDs and signer IDs to
+// quickly locate a signer based on the user requesting the signature.
+func (a *autographer) makeSignerIndex() {
+	a.signerIndex = make(map[string]int)
+	// add an entry for each authid+signerid pair
+	for _, auth := range a.auths {
+		for _, sid := range auth.Signers {
+			for pos, s := range a.signers {
+				if sid == s.ID {
+					log.Printf("Mapping auth id %q and signer id %q to signer %d", auth.ID, s.ID, pos)
+					tag := auth.ID + "+" + s.ID
+					a.signerIndex[tag] = pos
+				}
+			}
+		}
+	}
+	// add a fallback entry with just the authid, to use when no signerid
+	// is specified in the signing request. This entry maps to the first
+	// authorized signer
+	for _, auth := range a.auths {
+		if len(auth.Signers) < 1 {
+			continue
+		}
+		for pos, signer := range a.signers {
+			if auth.Signers[0] == signer.ID {
+				log.Printf("Mapping auth id %q to default signer %d", auth.ID, pos)
+				tag := auth.ID + "+"
+				a.signerIndex[tag] = pos
+				break
+			}
+		}
+	}
 }
 
 // handleSignature endpoint accepts a list of signature requests in a HAWK authenticated POST request
@@ -66,8 +123,8 @@ func (a *autographer) handleSignature(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		signerID, err := a.getSignerID(userid, sigreq.KeyID)
-		if err != nil || (signerID > (len(a.signers) - 1)) {
-			httpError(w, http.StatusInternalServerError, "no valid signer found for userid %q", userid)
+		if err != nil || signerID < 0 {
+			httpError(w, http.StatusInternalServerError, "could not get signer: %v", err)
 			return
 		}
 		rawsig, err := a.signers[signerID].sign(hash)

--- a/handlers.go
+++ b/handlers.go
@@ -74,6 +74,7 @@ func (a *autographer) makeSignerIndex() {
 	// is specified in the signing request. This entry maps to the first
 	// authorized signer
 	for _, auth := range a.auths {
+		// if the authorization has no signer configured, skip it
 		if len(auth.Signers) < 1 {
 			continue
 		}
@@ -101,12 +102,8 @@ func (a *autographer) handleSignature(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	userid, authorized, err := a.authorize(r, body)
-	if err != nil {
-		httpError(w, http.StatusInternalServerError, "authorization verification failed: %v", err)
-		return
-	}
-	if !authorized {
-		httpError(w, http.StatusUnauthorized, "request is not authorized; provide a valid HAWK authorization")
+	if err != nil || !authorized {
+		httpError(w, http.StatusUnauthorized, "authorization verification failed: %v", err)
 		return
 	}
 	var sigreqs []signaturerequest

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -13,6 +13,7 @@ import (
 	"crypto/sha512"
 	"encoding/json"
 	"hash"
+	"log"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -40,6 +41,7 @@ func TestSignaturePass(t *testing.T) {
 			Input:    "Q29udGVudC1TaWduYXR1cmU6ADwhRE9DVFlQRSBIVE1MPgo8aHRtbD4KPCEtLSBodHRwczovL2J1Z3ppbGxhLm1vemlsbGEub3JnL3Nob3dfYnVnLmNnaT9pZD0xMjI2OTI4IC0tPgo8aGVhZD4KICA8bWV0YSBjaGFyc2V0PSJ1dGYtOCI+CiAgPHRpdGxlPlRlc3RwYWdlIGZvciBidWcgMTIyNjkyODwvdGl0bGU+CjwvaGVhZD4KPGJvZHk+CiAgSnVzdCBhIGZ1bGx5IGdvb2QgdGVzdHBhZ2UgZm9yIEJ1ZyAxMjI2OTI4PGJyLz4KPC9ib2R5Pgo8L2h0bWw+Cg==",
 		},
 	}
+	userid := conf.Authorizations[0].ID
 	body, err := json.Marshal(TESTCASES)
 	if err != nil {
 		t.Fatal(err)
@@ -50,7 +52,8 @@ func TestSignaturePass(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	authheader := getAuthHeader(req, ag.auths[conf.Authorizations[0].ID].ID, ag.auths[conf.Authorizations[0].ID].Key, sha256.New, id(), "application/json", body)
+	authheader := getAuthHeader(req, ag.auths[userid].ID, ag.auths[userid].Key,
+		sha256.New, id(), "application/json", body)
 	req.Header.Set("Authorization", authheader)
 	w := httptest.NewRecorder()
 	ag.handleSignature(w, req)
@@ -69,31 +72,10 @@ func TestSignaturePass(t *testing.T) {
 			len(responses), len(TESTCASES))
 	}
 	for i, response := range responses {
-		if !verify(t, TESTCASES[i], response) {
+		if !verify(t, TESTCASES[i], response, userid) {
 			t.Errorf("signature verification failed in response %d; request was: %+v", i, req)
 		}
 	}
-}
-
-// verify an ecdsa signature
-func verify(t *testing.T, request signaturerequest, response signatureresponse) bool {
-	hash, err := getInputHash(request)
-	if err != nil {
-		t.Errorf("%v", err)
-	}
-	for _, sig := range response.Signatures {
-		sigBytes, err := fromBase64URL(sig.Signature)
-		if err != nil {
-			t.Errorf("failed to decode base65 signature data: %v", err)
-		}
-		r, s := new(big.Int), new(big.Int)
-		r.SetBytes(sigBytes[:len(sigBytes)/2])
-		s.SetBytes(sigBytes[len(sigBytes)/2:])
-		if !ecdsa.Verify(ag.signers[0].ecdsaPrivKey.Public().(*ecdsa.PublicKey), hash, r, s) {
-			return false
-		}
-	}
-	return true
 }
 
 func TestSignatureFail(t *testing.T) {
@@ -161,20 +143,6 @@ func TestAuthFail(t *testing.T) {
 	}
 }
 
-func getAuthHeader(req *http.Request, user, token string, hash func() hash.Hash, ext, contenttype string, payload []byte) string {
-	auth := hawk.NewRequestAuth(req,
-		&hawk.Credentials{
-			ID:   user,
-			Key:  token,
-			Hash: hash},
-		0)
-	auth.Ext = ext
-	payloadhash := auth.PayloadHash(contenttype)
-	payloadhash.Write(payload)
-	auth.SetHash(payloadhash)
-	return auth.RequestHeader()
-}
-
 func TestHeartbeat(t *testing.T) {
 	var TESTCASES = []struct {
 		expect int
@@ -215,5 +183,172 @@ func TestAddDuplicateAuthorization(t *testing.T) {
 			}
 		}
 	}()
-	ag.addAuthorizations(authorizations)
+	tmpag, err := newAutographer(1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tmpag.addSigners(conf.Signers)
+	tmpag.addAuthorizations(authorizations)
+}
+
+// verify that user `alice` and `bob` are allowed to sign
+// with their respective keys:
+// * `appkey1` and `appkey2` for `alice`
+// * `appkey2` only for `bob`
+func TestSignerAuthorized(t *testing.T) {
+	var TESTCASES = []struct {
+		userid string
+		sgs    []signaturerequest
+	}{
+		{
+			userid: conf.Authorizations[0].ID,
+			sgs: []signaturerequest{
+				signaturerequest{
+					Template: "content-signature",
+					HashWith: "sha384",
+					Input:    "PCFET0NUWVBFIEhUTUw+CjxodG1sPgo8IS0tIGh0dHBzOi8vYnVnemlsbGEubW96aWxsYS5vcmcvc2hvd19idWcuY2dpP2lkPTEyMjY5MjggLS0+CjxoZWFkPgogIDxtZXRhIGNoYXJzZXQ9InV0Zi04Ij4KICA8dGl0bGU+VGVzdHBhZ2UgZm9yIGJ1ZyAxMjI2OTI4PC90aXRsZT4KPC9oZWFkPgo8Ym9keT4KICBKdXN0IGEgZnVsbHkgZ29vZCB0ZXN0cGFnZSBmb3IgQnVnIDEyMjY5Mjg8YnIvPgo8L2JvZHk+CjwvaHRtbD4K",
+					KeyID:    conf.Authorizations[0].Signers[0],
+				},
+				signaturerequest{
+					Input: "y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d",
+					KeyID: conf.Authorizations[0].Signers[0],
+				},
+				signaturerequest{
+					HashWith: "sha384",
+					Input:    "Q29udGVudC1TaWduYXR1cmU6ADwhRE9DVFlQRSBIVE1MPgo8aHRtbD4KPCEtLSBodHRwczovL2J1Z3ppbGxhLm1vemlsbGEub3JnL3Nob3dfYnVnLmNnaT9pZD0xMjI2OTI4IC0tPgo8aGVhZD4KICA8bWV0YSBjaGFyc2V0PSJ1dGYtOCI+CiAgPHRpdGxlPlRlc3RwYWdlIGZvciBidWcgMTIyNjkyODwvdGl0bGU+CjwvaGVhZD4KPGJvZHk+CiAgSnVzdCBhIGZ1bGx5IGdvb2QgdGVzdHBhZ2UgZm9yIEJ1ZyAxMjI2OTI4PGJyLz4KPC9ib2R5Pgo8L2h0bWw+Cg==",
+					KeyID:    conf.Authorizations[0].Signers[1],
+				},
+			},
+		},
+		{
+			userid: conf.Authorizations[1].ID,
+			sgs: []signaturerequest{
+				signaturerequest{
+					Template: "content-signature",
+					HashWith: "sha384",
+					Input:    "PCFET0NUWVBFIEhUTUw+CjxodG1sPgo8IS0tIGh0dHBzOi8vYnVnemlsbGEubW96aWxsYS5vcmcvc2hvd19idWcuY2dpP2lkPTEyMjY5MjggLS0+CjxoZWFkPgogIDxtZXRhIGNoYXJzZXQ9InV0Zi04Ij4KICA8dGl0bGU+VGVzdHBhZ2UgZm9yIGJ1ZyAxMjI2OTI4PC90aXRsZT4KPC9oZWFkPgo8Ym9keT4KICBKdXN0IGEgZnVsbHkgZ29vZCB0ZXN0cGFnZSBmb3IgQnVnIDEyMjY5Mjg8YnIvPgo8L2JvZHk+CjwvaHRtbD4K",
+					KeyID:    conf.Authorizations[1].Signers[0],
+				},
+				signaturerequest{
+					Input: "y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d",
+					KeyID: conf.Authorizations[1].Signers[0],
+				},
+			},
+		},
+	}
+	for tid, testcase := range TESTCASES {
+		userid := testcase.userid
+		body, err := json.Marshal(testcase.sgs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rdr := bytes.NewReader(body)
+		req, err := http.NewRequest("POST", "http://foo.bar/signature", rdr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		authheader := getAuthHeader(req, ag.auths[userid].ID, ag.auths[userid].Key,
+			sha256.New, id(), "application/json", body)
+		req.Header.Set("Authorization", authheader)
+		w := httptest.NewRecorder()
+		ag.handleSignature(w, req)
+		if w.Code != http.StatusCreated || w.Body.String() == "" {
+			t.Errorf("test case %d failed with %d: %s; request was: %+v",
+				tid, w.Code, w.Body.String(), req)
+		}
+
+		// verify that we got a proper signature response, with a valid signature
+		var responses []signatureresponse
+		err = json.Unmarshal(w.Body.Bytes(), &responses)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(responses) != len(testcase.sgs) {
+			t.Errorf("test case %d failed to receive as many responses (%d) as we sent requests (%d)",
+				tid, len(responses), len(testcase.sgs))
+		}
+		for i, response := range responses {
+			if !verify(t, testcase.sgs[i], response, userid) {
+				t.Errorf("test case %d signature verification failed in response %d; request was: %+v",
+					tid, i, req)
+			}
+		}
+	}
+}
+
+// verify that user `bob` is not allowed to sign with `appkey1`
+func TestSignerUnauthorized(t *testing.T) {
+	var TESTCASES = []signaturerequest{
+		// request signature that need to prepend the content-signature:\x00 header
+		signaturerequest{
+			Template: "content-signature",
+			HashWith: "sha384",
+			Input:    "PCFET0NUWVBFIEhUTUw+CjxodG1sPgo8IS0tIGh0dHBzOi8vYnVnemlsbGEubW96aWxsYS5vcmcvc2hvd19idWcuY2dpP2lkPTEyMjY5MjggLS0+CjxoZWFkPgogIDxtZXRhIGNoYXJzZXQ9InV0Zi04Ij4KICA8dGl0bGU+VGVzdHBhZ2UgZm9yIGJ1ZyAxMjI2OTI4PC90aXRsZT4KPC9oZWFkPgo8Ym9keT4KICBKdXN0IGEgZnVsbHkgZ29vZCB0ZXN0cGFnZSBmb3IgQnVnIDEyMjY5Mjg8YnIvPgo8L2JvZHk+CjwvaHRtbD4K",
+			KeyID:    conf.Authorizations[0].Signers[0],
+		},
+		signaturerequest{
+			Input: "y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d",
+			KeyID: conf.Authorizations[0].Signers[0],
+		},
+	}
+	userid := conf.Authorizations[1].ID
+	body, err := json.Marshal(TESTCASES)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rdr := bytes.NewReader(body)
+	req, err := http.NewRequest("POST", "http://foo.bar/signature", rdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	authheader := getAuthHeader(req, ag.auths[userid].ID, ag.auths[userid].Key,
+		sha256.New, id(), "application/json", body)
+	req.Header.Set("Authorization", authheader)
+	w := httptest.NewRecorder()
+	ag.handleSignature(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected to fail with %d but got %d: %s; request was: %+v", http.StatusUnauthorized, w.Code, w.Body.String(), req)
+	}
+}
+
+func getAuthHeader(req *http.Request, user, token string, hash func() hash.Hash, ext, contenttype string, payload []byte) string {
+	auth := hawk.NewRequestAuth(req,
+		&hawk.Credentials{
+			ID:   user,
+			Key:  token,
+			Hash: hash},
+		0)
+	auth.Ext = ext
+	payloadhash := auth.PayloadHash(contenttype)
+	payloadhash.Write(payload)
+	auth.SetHash(payloadhash)
+	return auth.RequestHeader()
+}
+
+// verify an ecdsa signature
+func verify(t *testing.T, request signaturerequest, response signatureresponse, userid string) bool {
+	hash, err := getInputHash(request)
+	if err != nil {
+		t.Error(err)
+	}
+	signerID, err := ag.getSignerID(userid, request.KeyID)
+	if err != nil || signerID < 0 {
+		t.Error(err)
+	}
+	pubkey := ag.signers[signerID].ecdsaPrivKey.Public()
+	for _, sig := range response.Signatures {
+		sigBytes, err := fromBase64URL(sig.Signature)
+		if err != nil {
+			t.Errorf("failed to decode base65 signature data: %v", err)
+		}
+		r, s := new(big.Int), new(big.Int)
+		r.SetBytes(sigBytes[:len(sigBytes)/2])
+		s.SetBytes(sigBytes[len(sigBytes)/2:])
+		if !ecdsa.Verify(pubkey.(*ecdsa.PublicKey), hash, r, s) {
+			return false
+		}
+	}
+	return true
 }

--- a/main_test.go
+++ b/main_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("%+v\n", conf)
+	log.Printf("configuration: %+v\n", conf)
 	ag, err = newAutographer(1)
 	if err != nil {
 		log.Fatal(err)
@@ -37,6 +37,7 @@ func TestMain(m *testing.M) {
 	ag.addSigners(conf.Signers)
 	ag.addAuthorizations(conf.Authorizations)
 	ag.makeSignerIndex()
+	log.Printf("autographer: %+v\n", ag)
 	// run the tests and exit
 	r := m.Run()
 	os.Exit(r)

--- a/signer_test.go
+++ b/signer_test.go
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Contributor: Julien Vehent jvehent@mozilla.com [:ulfr]
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestInitFail(t *testing.T) {
+	TESTCASES := []struct {
+		expectError string
+		s           signer
+	}{
+		{expectError: "missing signer ID in signer configuration", s: signer{ID: ""}},
+		{expectError: "missing private key in signer configuration", s: signer{ID: "bob"}},
+		{expectError: "illegal base64 data at input byte 0", s: signer{ID: "bob", PrivateKey: "{{{{"}},
+		{expectError: "x509: failed to parse EC private key: asn1: structure error: tags don't match (16 vs {class:1 tag:2 length:111 isCompound:true}) {optional:false explicit:false application:false defaultValue:<nil> tag:<nil> stringType:0 timeType:0 set:false omitEmpty:false} ecPrivateKey @2", s: signer{ID: "bob", PrivateKey: "Ym9iCg=="}},
+	}
+	for _, testcase := range TESTCASES {
+		err := testcase.s.init()
+		if err.Error() != testcase.expectError {
+			t.Errorf("expected to fail with '%v' but failed with '%v' instead", testcase.expectError, err)
+		}
+		if err == nil {
+			t.Errorf("expiected to fail with '%v' but succeeded", testcase.expectError)
+		}
+	}
+}
+
+func TestFromB64URL(t *testing.T) {
+	TESTCASES := []struct {
+		expectError string
+		b64         string
+		sig         []byte
+	}{
+		{"illegal base64 data at input byte 0", "{{{{{{", nil},
+		{"", "XBKzej3i6TAFZc3VZsuCekn-4dYWJBE4-b3OOtKrOV-JIzIvAnAhnOV1aj-kEm07kh-FciIxV-Xk2QUQlRQzHO7oW7E4mXkMKkbbAcvL0CFrItTObhfhKnBnpAE9ql1O", []byte("\x5c\x12\xb3\x7a\x3d\xe2\xe9\x30\x05\x65\xcd\xd5\x66\xcb\x82\x7a\x49\xfe\xe1\xd6\x16\x24\x11\x38\xf9\xbd\xce\x3a\xd2\xab\x39\x5f\x89\x23\x32\x2f\x02\x70\x21\x9c\xe5\x75\x6a\x3f\xa4\x12\x6d\x3b\x92\x1f\x85\x72\x22\x31\x57\xe5\xe4\xd9\x05\x10\x95\x14\x33\x1c\xee\xe8\x5b\xb1\x38\x99\x79\x0c\x2a\x46\xdb\x01\xcb\xcb\xd0\x21\x6b\x22\xd4\xce\x6e\x17\xe1\x2a\x70\x67\xa4\x01\x3d\xaa\x5d\x4e")},
+	}
+	for _, testcase := range TESTCASES {
+		var s signature
+		err := s.fromBase64Url(testcase.b64)
+		if testcase.expectError == "" && err != nil {
+			t.Errorf("failed to load signature from base64 data: %v", err)
+		}
+		if testcase.expectError != "" && testcase.expectError != err.Error() {
+			t.Errorf("expected to fail with error %q but got error %q", testcase.expectError, err)
+		}
+		if testcase.expectError == "" && err == nil {
+			if !bytes.Equal(testcase.sig, s) {
+				t.Errorf("decoded base64 data doesn't match expected data")
+			}
+		}
+	}
+}
+
+func TestGetInputHash(t *testing.T) {
+	TESTCASES := []struct {
+		sigreq      signaturerequest
+		hash        string
+		expectError string
+	}{
+		// hash a string with sha384
+		{sigreq: signaturerequest{Input: "Y2FyaWJvdW1hdXJpY2UK", HashWith: "sha384"}, hash: "7e0509bd09f58d97575f6fcf06358e90fa47dfceecfc93694933352685287f11656fd060f116225c2bfd1954f5a31748"},
+		// apply a template to the string then hash it with sha384
+		{sigreq: signaturerequest{Template: "content-signature", Input: "Y2FyaWJvdW1hdXJpY2UK", HashWith: "sha384"}, hash: "e8c5eecea3e754b7028438b1f61174a695369c3eef603b7ebbf50cf906ce65425855d1d3c7e4a7c5d5e63c765ddd0699"},
+		// string already hashed, return it untouched
+		{sigreq: signaturerequest{Input: "6MXuzqPnVLcChDix9hF0ppU2nD7vYDt+u/UM+QbOZUJYVdHTx+SnxdXmPHZd3QaZ"}, hash: "e8c5eecea3e754b7028438b1f61174a695369c3eef603b7ebbf50cf906ce65425855d1d3c7e4a7c5d5e63c765ddd0699"},
+		// unsupported hash method
+		{sigreq: signaturerequest{Input: "Y2FyaWJvdW1hdXJpY2UK", HashWith: "md5"}, expectError: `unsupported digest algorithm "md5"`},
+		// unsupported template
+		{sigreq: signaturerequest{Template: "caribou", Input: "Y2FyaWJvdW1hdXJpY2UK"}, expectError: `unknown template "caribou"`},
+	}
+	for i, testcase := range TESTCASES {
+		hash, err := getInputHash(testcase.sigreq)
+		if err != nil {
+			if testcase.expectError == "" {
+				t.Errorf("test case %d expected to succeed but failed with error: %v", i, err)
+			} else if testcase.expectError != err.Error() {
+				t.Errorf("test case %d expected to fail with %q but failed with %v", i, testcase.expectError, err)
+			}
+		}
+		if testcase.expectError == "" {
+			if testcase.hash != fmt.Sprintf("%x", hash) {
+				t.Errorf("test case %d failed: expected hash %q, got %q",
+					i, testcase.hash, fmt.Sprintf("%x", hash))
+			}
+		}
+	}
+}

--- a/util.go
+++ b/util.go
@@ -7,13 +7,45 @@
 package main
 
 import (
+	"encoding/base64"
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 )
 
 func httpError(w http.ResponseWriter, errorCode int, errorMessage string, args ...interface{}) {
 	log.Printf("%d: %s", errorCode, fmt.Sprintf(errorMessage, args...))
 	http.Error(w, fmt.Sprintf(errorMessage, args...), errorCode)
 	return
+}
+
+func toBase64URL(b []byte) string {
+	return b64Tob64url(base64.StdEncoding.EncodeToString(b))
+}
+
+func b64Tob64url(s string) string {
+	// convert base64url characters back to regular base64 alphabet
+	s = strings.Replace(s, "+", "-", -1)
+	s = strings.Replace(s, "/", "_", -1)
+	s = strings.TrimRight(s, "=")
+	return s
+}
+
+func fromBase64URL(s string) ([]byte, error) {
+	b, err := base64.StdEncoding.DecodeString(b64urlTob64(s))
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func b64urlTob64(s string) string {
+	// convert base64url characters back to regular base64 alphabet
+	s = strings.Replace(s, "-", "+", -1)
+	s = strings.Replace(s, "_", "/", -1)
+	if l := len(s) % 4; l > 0 {
+		s += strings.Repeat("=", 4-l)
+	}
+	return s
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const version = "20160127.0-fdb51c2"
+const version = "20160131.0-9c5bcb6"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const version = "20160124.0-8818726"
+const version = "20160127.0-fdb51c2"


### PR DESCRIPTION
This should be the last of the critical PRs for phase 1. It implements mapping signing keys to user IDs, and checks which user is allowed to use which key prior to signing. The user ID is passed in the hawk authorization header.

@ncloudioj & @mostlygeek : If you would be so inclined, I would welcome your comments.