### PR TITLE
Input rework: split /signature into /sign/data and /sign/hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,10 @@ Each signature response contains the following fields:
   be trusted by applications through other means (like a local truststore).
 
 * `content-signature` is the raw HTTP header of the Content-Signature protocol.
-  This value should not be interpreted by the client application, but passed
-  along unmodified to verifying libraries, such as the Content Verifier in Firefox.
+  This value is only returned if the signature requested a `content-signature`
+  template to be applied to the data. It should not be interpreted by client
+  applications, but passed unmodified to verifying libraries, such as the Content
+  Verifier in Firefox.
 
 ### /sign/hash
 
@@ -196,6 +198,8 @@ Each signature response contains the following fields:
 
 Request a signature on a hash. The hash is provided as a base64 encoded bytes
 array, and is not manipulated at all by autograph before signing.
+
+This endpoint always returns a `content-signature` with every response.
 
 example:
 ```bash

--- a/authorize_test.go
+++ b/authorize_test.go
@@ -9,6 +9,7 @@ package main
 import (
 	"bytes"
 	"crypto/sha256"
+	"log"
 	"net/http"
 	"testing"
 
@@ -153,4 +154,29 @@ func TestDefaultSignerNotFound(t *testing.T) {
 	if err == nil || pos != -1 {
 		t.Errorf("expected to fail lookup up a signer but succeeded")
 	}
+}
+
+// Two authorizations sharing the same ID should fail
+func TestAddDuplicateAuthorization(t *testing.T) {
+	var authorizations = []authorization{
+		authorization{
+			ID: "alice",
+		},
+		authorization{
+			ID: "alice",
+		},
+	}
+	defer func() {
+		if e := recover(); e != nil {
+			if e != `authorization id 'alice' already defined, duplicates are not permitted` {
+				t.Fatalf("expected authorization loading to fail with duplicate error but got: %v", e)
+			}
+		}
+	}()
+	tmpag, err := newAutographer(1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tmpag.addSigners(conf.Signers)
+	tmpag.addAuthorizations(authorizations)
 }

--- a/autograph.yaml
+++ b/autograph.yaml
@@ -4,11 +4,16 @@ server:
     noncecachesize: 524288
 
 signers:
+    # a p384 key, the standard
     - id: appkey1
       privatekey: "MIGkAgEBBDAzX2TrGOr0WE92AbAl+nqnpqh25pKCLYNMTV2hJHztrkVPWOp8w0mhscIodK8RMpagBwYFK4EEACKhZANiAATiTcWYbt0Wg63dO7OXvpptNG0ryxv+v+JsJJ5Upr3pFus5fZyKxzP9NPzB+oFhL/xw3jMx7X5/vBGaQ2sJSiNlHVkqZgzYF6JQ4yUyiqTY7v67CyfUPA1BJg/nxOS9m3o="
+    # a p256 key
     - id: appkey2
-      privatekey: "MIGkAgEBBDC32Lv42JlmEnaPHe+UG6wtrG39vHZAQtvUPTPgJP8Bflfsy0T30Q/5AMXvh0EgFbigBwYFK4EEACKhZANiAAS74cJMSG3ZjlTcjBZl5pHnimoCxAM+XL3fjLy0FvStcQqyWkMacmAY3MqM4YxvyBNv5J+JJPAkskYVomQzk3/8La+D2UQuj6XuReTKJie8EppVvrXwMAjhSy5zsuq7/gI="
+      privatekey: "MHcCAQEEIFB72ld2Ga9bAiVE8/IzNfFskDCnu7Ws8iJDcgzDbwlToAoGCCqGSM49AwEHoUQDQgAESGiwKilbISFLmmeEI83U5qtAuq3ktoKfWKgzbC5rkpEVIzaaYOpdbrtLkvBqK0SxIJOf2nVgmdIfLYY8JXWH5Q=="
       x5u: https://bucket.example.net/appkey2.pem
+    # p521, for testing, don't use p521
+    - id: appkey3
+      privatekey: "MIHcAgEBBEIAE1XrqPG1wKb/3TTlmZ4abd+aJQ1eT7xmTA+hIY5Nj6B4wY4G570M9Xxke5LP0kx1nMZRAoQGG5w5M1mE6oFWw2GgBwYFK4EEACOhgYkDgYYABAAYziNDPmlSc82ukUtXpI/Hc7TQ9GeVKGd4FXVY79wpzS4DwPRalfOdI1/EIPQheNHHXCMupZFVzC01cQSQ1gM16QH+AoQSjixV0lrbeJQgzz6lAFTyTjEYZw6rzx5ur+ubt/dWBMO6XkYYgIpr7AesDlN5OPyy7bKHxTWArci+2DXekw=="
 
 authorizations:
     - id: alice
@@ -16,6 +21,7 @@ authorizations:
       signers:
           - appkey1
           - appkey2
+          - appkey3
     - id: bob
       key: 9vh6bhlc10y63ow2k4zke7k0c3l9hpr8mo96p92jmbfqngs9e7d
       signers:

--- a/encoders.go
+++ b/encoders.go
@@ -31,6 +31,9 @@ const (
 )
 
 func encode(sig *ecdsaSignature, siglen int, format string) (str string, err error) {
+	if len(sig.R.Bytes()) < 1 || len(sig.S.Bytes()) < 1 {
+		return "", fmt.Errorf("empty values R and S cannot be encoded")
+	}
 	if format == "" {
 		// use this format by default, if none is set
 		format = RSB64URL

--- a/handlers.go
+++ b/handlers.go
@@ -19,11 +19,11 @@ import (
 // a signaturerequest is sent by an autograph client to request
 // a signature on input data
 type signaturerequest struct {
-	Template string `json:"template"`
-	HashWith string `json:"hashwith"`
+	Template string `json:"template,omitempty"`
+	HashWith string `json:"hashwith,omitempty"`
 	Input    string `json:"input"`
-	KeyID    string `json:"keyid"`
-	Encoding string `json:"signature_encoding"`
+	KeyID    string `json:"keyid,omitempty"`
+	Encoding string `json:"signature_encoding,omitempty"`
 }
 
 // a signatureresponse is returned by autograph to a client with
@@ -140,15 +140,47 @@ func (a *autographer) handleSignature(w http.ResponseWriter, r *http.Request) {
 	// For each, a signer is looked up, and used to compute a raw signature
 	// the signature is then encoded appropriately, and added to the response slice
 	for i, sigreq := range sigreqs {
-		hash, err := getInputHash(sigreq)
-		if err != nil {
-			httpError(w, http.StatusBadRequest, "%v", err)
-			return
-		}
+		var (
+			hash []byte
+			alg  string
+		)
 		signerID, err := a.getSignerID(userid, sigreq.KeyID)
 		if err != nil || signerID < 0 {
 			httpError(w, http.StatusUnauthorized, "%v", err)
 			return
+		}
+		switch r.URL.RequestURI() {
+		case "/sign/hash":
+			// the '/sign/hash' endpoint does not allow requesting a particular hash or template
+			// since those need to be computed before calling autograph.
+			if sigreq.HashWith != "" || sigreq.Template != "" {
+				httpError(w, http.StatusBadRequest,
+					"hashwith and template parameters are not permitted on the /sign/hash endpoint")
+				return
+			}
+			hash, err = fromBase64URL(sigreq.Input)
+			if err != nil {
+				httpError(w, http.StatusBadRequest, "%v", err)
+				return
+			}
+		case "/sign/data":
+			// other endpoints, like '/sign/data', will template and hash the input prior to signing
+			alg, hash, err = templateAndHash(sigreq, a.signers[signerID].ecdsaPrivKey.Curve.Params().Name)
+			if err != nil {
+				httpError(w, http.StatusBadRequest, "%v", err)
+				return
+			}
+		// TODO: remove this case as soon as backward compat is no longer needed, or on 2016-06-01
+		case "/signature":
+			if sigreq.HashWith == "" {
+				hash, err = fromBase64URL(sigreq.Input)
+			} else {
+				alg, hash, err = templateAndHash(sigreq, a.signers[signerID].ecdsaPrivKey.Curve.Params().Name)
+			}
+			if err != nil {
+				httpError(w, http.StatusBadRequest, "%v", err)
+				return
+			}
 		}
 		ecdsaSig, err := a.signers[signerID].sign(hash)
 		if err != nil {
@@ -169,7 +201,7 @@ func (a *autographer) handleSignature(w http.ResponseWriter, r *http.Request) {
 			Ref:              id(),
 			X5U:              a.signers[signerID].X5U,
 			PublicKey:        a.signers[signerID].PublicKey,
-			Hash:             sigreq.HashWith,
+			Hash:             alg,
 			Encoding:         sigreq.Encoding,
 			Signature:        encodedsig,
 			ContentSignature: encodedcs,

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -24,6 +24,97 @@ import (
 )
 
 func TestSignaturePass(t *testing.T) {
+	var TESTCASES = []struct {
+		endpoint   string
+		signatures []signaturerequest
+	}{
+		{
+			"/signature",
+			[]signaturerequest{
+				// request signature that need to prepend the content-signature:\x00 header
+				signaturerequest{
+					Template: "content-signature",
+					HashWith: "sha384",
+					Input:    "PCFET0NUWVBFIEhUTUw+CjxodG1sPgo8IS0tIGh0dHBzOi8vYnVnemlsbGEubW96aWxsYS5vcmcvc2hvd19idWcuY2dpP2lkPTEyMjY5MjggLS0+CjxoZWFkPgogIDxtZXRhIGNoYXJzZXQ9InV0Zi04Ij4KICA8dGl0bGU+VGVzdHBhZ2UgZm9yIGJ1ZyAxMjI2OTI4PC90aXRsZT4KPC9oZWFkPgo8Ym9keT4KICBKdXN0IGEgZnVsbHkgZ29vZCB0ZXN0cGFnZSBmb3IgQnVnIDEyMjY5Mjg8YnIvPgo8L2JvZHk+CjwvaHRtbD4K",
+				},
+				// request signature of a precomputed sha384 hash
+				signaturerequest{
+					Input: "y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d",
+				},
+				// request signature of raw data that already has the content-signature header prepended
+				signaturerequest{
+					HashWith: "sha384",
+					Input:    "Q29udGVudC1TaWduYXR1cmU6ADwhRE9DVFlQRSBIVE1MPgo8aHRtbD4KPCEtLSBodHRwczovL2J1Z3ppbGxhLm1vemlsbGEub3JnL3Nob3dfYnVnLmNnaT9pZD0xMjI2OTI4IC0tPgo8aGVhZD4KICA8bWV0YSBjaGFyc2V0PSJ1dGYtOCI+CiAgPHRpdGxlPlRlc3RwYWdlIGZvciBidWcgMTIyNjkyODwvdGl0bGU+CjwvaGVhZD4KPGJvZHk+CiAgSnVzdCBhIGZ1bGx5IGdvb2QgdGVzdHBhZ2UgZm9yIEJ1ZyAxMjI2OTI4PGJyLz4KPC9ib2R5Pgo8L2h0bWw+Cg==",
+				},
+			}},
+		{
+			"/sign/data",
+			[]signaturerequest{
+				// request signature that need to prepend the content-signature:\x00 header
+				signaturerequest{
+					Template: "content-signature",
+					HashWith: "sha384",
+					Input:    "PCFET0NUWVBFIEhUTUw+CjxodG1sPgo8IS0tIGh0dHBzOi8vYnVnemlsbGEubW96aWxsYS5vcmcvc2hvd19idWcuY2dpP2lkPTEyMjY5MjggLS0+CjxoZWFkPgogIDxtZXRhIGNoYXJzZXQ9InV0Zi04Ij4KICA8dGl0bGU+VGVzdHBhZ2UgZm9yIGJ1ZyAxMjI2OTI4PC90aXRsZT4KPC9oZWFkPgo8Ym9keT4KICBKdXN0IGEgZnVsbHkgZ29vZCB0ZXN0cGFnZSBmb3IgQnVnIDEyMjY5Mjg8YnIvPgo8L2JvZHk+CjwvaHRtbD4K",
+				},
+				// request signature that will use the default hash function
+				signaturerequest{
+					Input: "PCFET0NUWVBFIEhUTUw+CjxodG1sPgo8IS0tIGh0dHBzOi8vYnVnemlsbGEubW96aWxsYS5vcmcvc2hvd19idWcuY2dpP2lkPTEyMjY5MjggLS0+CjxoZWFkPgogIDxtZXRhIGNoYXJzZXQ9InV0Zi04Ij4KICA8dGl0bGU+VGVzdHBhZ2UgZm9yIGJ1ZyAxMjI2OTI4PC90aXRsZT4KPC9oZWFkPgo8Ym9keT4KICBKdXN0IGEgZnVsbHkgZ29vZCB0ZXN0cGFnZSBmb3IgQnVnIDEyMjY5Mjg8YnIvPgo8L2JvZHk+CjwvaHRtbD4K",
+				},
+				// request signature of raw data that already has the content-signature header prepended
+				signaturerequest{
+					HashWith: "sha384",
+					Input:    "Q29udGVudC1TaWduYXR1cmU6ADwhRE9DVFlQRSBIVE1MPgo8aHRtbD4KPCEtLSBodHRwczovL2J1Z3ppbGxhLm1vemlsbGEub3JnL3Nob3dfYnVnLmNnaT9pZD0xMjI2OTI4IC0tPgo8aGVhZD4KICA8bWV0YSBjaGFyc2V0PSJ1dGYtOCI+CiAgPHRpdGxlPlRlc3RwYWdlIGZvciBidWcgMTIyNjkyODwvdGl0bGU+CjwvaGVhZD4KPGJvZHk+CiAgSnVzdCBhIGZ1bGx5IGdvb2QgdGVzdHBhZ2UgZm9yIEJ1ZyAxMjI2OTI4PGJyLz4KPC9ib2R5Pgo8L2h0bWw+Cg==",
+				},
+			}},
+		{
+			"/sign/hash",
+			[]signaturerequest{
+				// request signature of a precomputed sha384 hash
+				signaturerequest{
+					Input: "y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d",
+				},
+			}},
+	}
+	for i, testcase := range TESTCASES {
+		userid := conf.Authorizations[0].ID
+		body, err := json.Marshal(testcase.signatures)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rdr := bytes.NewReader(body)
+		req, err := http.NewRequest("POST", "http://foo.bar"+testcase.endpoint, rdr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		authheader := getAuthHeader(req, ag.auths[userid].ID, ag.auths[userid].Key,
+			sha256.New, id(), "application/json", body)
+		req.Header.Set("Authorization", authheader)
+		w := httptest.NewRecorder()
+		ag.handleSignature(w, req)
+		if w.Code != http.StatusCreated || w.Body.String() == "" {
+			t.Fatalf("failed with %d: %s; request was: %+v", w.Code, w.Body.String(), req)
+		}
+		// verify that we got a proper signature response, with a valid signature
+		var responses []signatureresponse
+		err = json.Unmarshal(w.Body.Bytes(), &responses)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(responses) != len(testcase.signatures) {
+			t.Fatalf("in test case %d, failed to receive as many responses (%d) as we sent requests (%d)",
+				i, len(responses), len(testcase.signatures))
+		}
+		for j, response := range responses {
+			if !verify(t, testcase.signatures[j], response, userid, testcase.endpoint) {
+				t.Fatalf("in test case %d on endpoint %q, signature verification failed in response %d; request was: %+v",
+					i, testcase.endpoint, j, req)
+			}
+		}
+	}
+}
+
+func TestSignHashFail(t *testing.T) {
 	var TESTCASES = []signaturerequest{
 		// request signature that need to prepend the content-signature:\x00 header
 		signaturerequest{
@@ -58,7 +149,7 @@ func TestSignaturePass(t *testing.T) {
 	w := httptest.NewRecorder()
 	ag.handleSignature(w, req)
 	if w.Code != http.StatusCreated || w.Body.String() == "" {
-		t.Errorf("failed with %d: %s; request was: %+v", w.Code, w.Body.String(), req)
+		t.Fatalf("failed with %d: %s; request was: %+v", w.Code, w.Body.String(), req)
 	}
 
 	// verify that we got a proper signature response, with a valid signature
@@ -68,29 +159,41 @@ func TestSignaturePass(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(responses) != len(TESTCASES) {
-		t.Errorf("failed to receive as many responses (%d) as we sent requests (%d)",
+		t.Fatalf("failed to receive as many responses (%d) as we sent requests (%d)",
 			len(responses), len(TESTCASES))
 	}
 	for i, response := range responses {
-		if !verify(t, TESTCASES[i], response, userid) {
-			t.Errorf("signature verification failed in response %d; request was: %+v", i, req)
+		if !verify(t, TESTCASES[i], response, userid, "/signature") {
+			t.Fatalf("signature verification failed in response %d; request was: %+v", i, req)
 		}
 	}
 }
 
 func TestSignatureFail(t *testing.T) {
 	var TESTCASES = []struct {
-		method string
-		body   string
+		endpoint string
+		method   string
+		body     string
 	}{
-		{`GET`, `[{"input":"y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d"}]`},
-		{`POST`, ``},
-		{`PUT`, ``},
-		{`HEAD`, ``},
+		{`/signature`, `GET`, `[{"input":"y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d"}]`},
+		{`/signature`, `POST`, ``},
+		{`/signature`, `PUT`, ``},
+		{`/signature`, `HEAD`, ``},
+		{`/sign/data`, `GET`, `[{"input":"y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d"}]`},
+		{`/sign/data`, `POST`, `[{"hashwith":"md5", "input":"y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d"}]`},
+		{`/sign/data`, `POST`, ``},
+		{`/sign/data`, `PUT`, ``},
+		{`/sign/data`, `HEAD`, ``},
+		{`/sign/hash`, `GET`, `[{"input":"y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d"}]`},
+		{`/sign/hash`, `POST`, `[{"hashwith": "sha384", "input":"y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d"}]`},
+		{`/sign/hash`, `POST`, `[{"template":"content-signature", "hashwith": "sha384", "input":"y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d"}]`},
+		{`/sign/hash`, `POST`, ``},
+		{`/sign/hash`, `PUT`, ``},
+		{`/sign/hash`, `HEAD`, ``},
 	}
 	for i, testcase := range TESTCASES {
 		body := strings.NewReader(testcase.body)
-		req, err := http.NewRequest(testcase.method, "http://foo.bar/signature", body)
+		req, err := http.NewRequest(testcase.method, "http://foo.bar"+testcase.endpoint, body)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -100,7 +203,7 @@ func TestSignatureFail(t *testing.T) {
 		w := httptest.NewRecorder()
 		ag.handleSignature(w, req)
 		if w.Code == http.StatusCreated {
-			t.Errorf("test case %d failed with %d: %s", i, w.Code, w.Body.String())
+			t.Fatalf("test case %d failed with %d: %s", i, w.Code, w.Body.String())
 		}
 	}
 }
@@ -137,7 +240,7 @@ func TestAuthFail(t *testing.T) {
 		w := httptest.NewRecorder()
 		ag.handleSignature(w, req)
 		if w.Code != http.StatusUnauthorized {
-			t.Errorf("test case %d was authorized with %d and should have failed; authorization header was: %s; response was: %s",
+			t.Fatalf("test case %d was authorized with %d and should have failed; authorization header was: %s; response was: %s",
 				i, w.Code, req.Header.Get("Authorization"), w.Body.String())
 		}
 	}
@@ -161,7 +264,7 @@ func TestHeartbeat(t *testing.T) {
 		w := httptest.NewRecorder()
 		ag.handleHeartbeat(w, req)
 		if w.Code != testcase.expect {
-			t.Errorf("test case %d failed with code %d but %d was expected",
+			t.Fatalf("test case %d failed with code %d but %d was expected",
 				i, w.Code, testcase.expect)
 		}
 	}
@@ -185,35 +288,10 @@ func TestVersion(t *testing.T) {
 		w := httptest.NewRecorder()
 		ag.handleVersion(w, req)
 		if w.Code != testcase.expect {
-			t.Errorf("test case %d failed with code %d but %d was expected",
+			t.Fatalf("test case %d failed with code %d but %d was expected",
 				i, w.Code, testcase.expect)
 		}
 	}
-}
-
-// Two authorizations sharing the same ID should fail
-func TestAddDuplicateAuthorization(t *testing.T) {
-	var authorizations = []authorization{
-		authorization{
-			ID: "alice",
-		},
-		authorization{
-			ID: "alice",
-		},
-	}
-	defer func() {
-		if e := recover(); e != nil {
-			if e != `authorization id 'alice' already defined, duplicates are not permitted` {
-				t.Errorf("expected authorization loading to fail with duplicate error but got: %v", e)
-			}
-		}
-	}()
-	tmpag, err := newAutographer(1)
-	if err != nil {
-		log.Fatal(err)
-	}
-	tmpag.addSigners(conf.Signers)
-	tmpag.addAuthorizations(authorizations)
 }
 
 // An authorization without at least one signer configured should not have
@@ -232,7 +310,7 @@ func TestAuthWithoutSigner(t *testing.T) {
 	tmpag.addAuthorizations(authorizations)
 	tmpag.makeSignerIndex()
 	if _, ok := tmpag.signerIndex[authorizations[0].ID+"+"]; ok {
-		t.Errorf("found a default signer but shouldn't have")
+		t.Fatalf("found a default signer but shouldn't have")
 	}
 }
 
@@ -287,6 +365,7 @@ func TestSignerAuthorized(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		t.Logf("%s", body)
 		rdr := bytes.NewReader(body)
 		req, err := http.NewRequest("POST", "http://foo.bar/signature", rdr)
 		if err != nil {
@@ -299,7 +378,7 @@ func TestSignerAuthorized(t *testing.T) {
 		w := httptest.NewRecorder()
 		ag.handleSignature(w, req)
 		if w.Code != http.StatusCreated || w.Body.String() == "" {
-			t.Errorf("test case %d failed with %d: %s; request was: %+v",
+			t.Fatalf("test case %d failed with %d: %s; request was: %+v",
 				tid, w.Code, w.Body.String(), req)
 		}
 
@@ -310,12 +389,12 @@ func TestSignerAuthorized(t *testing.T) {
 			t.Fatal(err)
 		}
 		if len(responses) != len(testcase.sgs) {
-			t.Errorf("test case %d failed to receive as many responses (%d) as we sent requests (%d)",
+			t.Fatalf("test case %d failed to receive as many responses (%d) as we sent requests (%d)",
 				tid, len(responses), len(testcase.sgs))
 		}
 		for i, response := range responses {
-			if !verify(t, testcase.sgs[i], response, userid) {
-				t.Errorf("test case %d signature verification failed in response %d; request was: %+v",
+			if !verify(t, testcase.sgs[i], response, userid, "/signature") {
+				t.Fatalf("test case %d signature verification failed in response %d; request was: %+v",
 					tid, i, req)
 			}
 		}
@@ -354,7 +433,7 @@ func TestSignerUnauthorized(t *testing.T) {
 	w := httptest.NewRecorder()
 	ag.handleSignature(w, req)
 	if w.Code != http.StatusUnauthorized {
-		t.Errorf("expected to fail with %d but got %d: %s; request was: %+v", http.StatusUnauthorized, w.Code, w.Body.String(), req)
+		t.Fatalf("expected to fail with %d but got %d: %s; request was: %+v", http.StatusUnauthorized, w.Code, w.Body.String(), req)
 	}
 }
 
@@ -389,7 +468,7 @@ func TestHashWith(t *testing.T) {
 	w := httptest.NewRecorder()
 	ag.handleSignature(w, req)
 	if w.Code != http.StatusCreated {
-		t.Errorf("expected to succeed with %d but got %d: %s; request was: %+v", http.StatusCreated, w.Code, w.Body.String(), req)
+		t.Fatalf("expected to succeed with %d but got %d: %s; request was: %+v", http.StatusCreated, w.Code, w.Body.String(), req)
 	}
 	var responses []signatureresponse
 	err = json.Unmarshal(w.Body.Bytes(), &responses)
@@ -397,12 +476,12 @@ func TestHashWith(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(responses) != len(TESTCASES) {
-		t.Errorf("failed to receive as many responses (%d) as we sent requests (%d)",
+		t.Fatalf("failed to receive as many responses (%d) as we sent requests (%d)",
 			len(responses), len(TESTCASES))
 	}
 	for i, response := range responses {
 		if response.Hash != TESTCASES[i].HashWith {
-			t.Errorf("expected to get hash %q in response but got %q instead",
+			t.Fatalf("expected to get hash %q in response but got %q instead",
 				TESTCASES[i].HashWith, response.Hash)
 		}
 	}
@@ -433,7 +512,7 @@ func TestContentType(t *testing.T) {
 	w := httptest.NewRecorder()
 	ag.handleSignature(w, req)
 	if w.Header().Get("Content-Type") != "application/json" {
-		t.Errorf("expected response with content type 'application/json' but got %q instead",
+		t.Fatalf("expected response with content type 'application/json' but got %q instead",
 			w.Header().Get("Content-Type"))
 	}
 }
@@ -453,19 +532,25 @@ func getAuthHeader(req *http.Request, user, token string, hash func() hash.Hash,
 }
 
 // verify an ecdsa signature
-func verify(t *testing.T, request signaturerequest, response signatureresponse, userid string) bool {
-	hash, err := getInputHash(request)
-	if err != nil {
-		t.Error(err)
-	}
+func verify(t *testing.T, request signaturerequest, response signatureresponse, userid, endpoint string) bool {
 	signerID, err := ag.getSignerID(userid, request.KeyID)
-	if err != nil || signerID < 0 {
-		t.Error(err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var hash []byte
+	// TODO: remove when backward compat with "/signature" can be removed
+	if endpoint == "/sign/hash" || (endpoint == "/signature" && request.HashWith == "") {
+		hash, err = fromBase64URL(request.Input)
+	} else {
+		_, hash, err = templateAndHash(request, ag.signers[signerID].ecdsaPrivKey.Curve.Params().Name)
+	}
+	if err != nil {
+		t.Fatal(err)
 	}
 	pubkey := ag.signers[signerID].ecdsaPrivKey.Public()
 	sigBytes, err := fromBase64URL(response.Signature)
 	if err != nil {
-		t.Errorf("failed to decode base65 signature data: %v", err)
+		t.Fatalf("failed to decode base65 signature data: %v", err)
 	}
 	r, s := new(big.Int), new(big.Int)
 	r.SetBytes(sigBytes[:len(sigBytes)/2])

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -34,17 +34,19 @@ func TestSignaturePass(t *testing.T) {
 				// request signature that need to prepend the content-signature:\x00 header
 				signaturerequest{
 					Template: "content-signature",
-					HashWith: "sha384",
 					Input:    "PCFET0NUWVBFIEhUTUw+CjxodG1sPgo8IS0tIGh0dHBzOi8vYnVnemlsbGEubW96aWxsYS5vcmcvc2hvd19idWcuY2dpP2lkPTEyMjY5MjggLS0+CjxoZWFkPgogIDxtZXRhIGNoYXJzZXQ9InV0Zi04Ij4KICA8dGl0bGU+VGVzdHBhZ2UgZm9yIGJ1ZyAxMjI2OTI4PC90aXRsZT4KPC9oZWFkPgo8Ym9keT4KICBKdXN0IGEgZnVsbHkgZ29vZCB0ZXN0cGFnZSBmb3IgQnVnIDEyMjY5Mjg8YnIvPgo8L2JvZHk+CjwvaHRtbD4K",
+					KeyID:    "appkey1",
 				},
 				// request signature of a precomputed sha384 hash
 				signaturerequest{
 					Input: "y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d",
+					KeyID: "appkey2",
 				},
 				// request signature of raw data that already has the content-signature header prepended
 				signaturerequest{
 					HashWith: "sha384",
 					Input:    "Q29udGVudC1TaWduYXR1cmU6ADwhRE9DVFlQRSBIVE1MPgo8aHRtbD4KPCEtLSBodHRwczovL2J1Z3ppbGxhLm1vemlsbGEub3JnL3Nob3dfYnVnLmNnaT9pZD0xMjI2OTI4IC0tPgo8aGVhZD4KICA8bWV0YSBjaGFyc2V0PSJ1dGYtOCI+CiAgPHRpdGxlPlRlc3RwYWdlIGZvciBidWcgMTIyNjkyODwvdGl0bGU+CjwvaGVhZD4KPGJvZHk+CiAgSnVzdCBhIGZ1bGx5IGdvb2QgdGVzdHBhZ2UgZm9yIEJ1ZyAxMjI2OTI4PGJyLz4KPC9ib2R5Pgo8L2h0bWw+Cg==",
+					KeyID:    "appkey3",
 				},
 			}},
 		{
@@ -55,15 +57,18 @@ func TestSignaturePass(t *testing.T) {
 					Template: "content-signature",
 					HashWith: "sha384",
 					Input:    "PCFET0NUWVBFIEhUTUw+CjxodG1sPgo8IS0tIGh0dHBzOi8vYnVnemlsbGEubW96aWxsYS5vcmcvc2hvd19idWcuY2dpP2lkPTEyMjY5MjggLS0+CjxoZWFkPgogIDxtZXRhIGNoYXJzZXQ9InV0Zi04Ij4KICA8dGl0bGU+VGVzdHBhZ2UgZm9yIGJ1ZyAxMjI2OTI4PC90aXRsZT4KPC9oZWFkPgo8Ym9keT4KICBKdXN0IGEgZnVsbHkgZ29vZCB0ZXN0cGFnZSBmb3IgQnVnIDEyMjY5Mjg8YnIvPgo8L2JvZHk+CjwvaHRtbD4K",
+					KeyID:    "appkey2",
 				},
 				// request signature that will use the default hash function
 				signaturerequest{
 					Input: "PCFET0NUWVBFIEhUTUw+CjxodG1sPgo8IS0tIGh0dHBzOi8vYnVnemlsbGEubW96aWxsYS5vcmcvc2hvd19idWcuY2dpP2lkPTEyMjY5MjggLS0+CjxoZWFkPgogIDxtZXRhIGNoYXJzZXQ9InV0Zi04Ij4KICA8dGl0bGU+VGVzdHBhZ2UgZm9yIGJ1ZyAxMjI2OTI4PC90aXRsZT4KPC9oZWFkPgo8Ym9keT4KICBKdXN0IGEgZnVsbHkgZ29vZCB0ZXN0cGFnZSBmb3IgQnVnIDEyMjY5Mjg8YnIvPgo8L2JvZHk+CjwvaHRtbD4K",
+					KeyID: "appkey3",
 				},
 				// request signature of raw data that already has the content-signature header prepended
 				signaturerequest{
 					HashWith: "sha384",
 					Input:    "Q29udGVudC1TaWduYXR1cmU6ADwhRE9DVFlQRSBIVE1MPgo8aHRtbD4KPCEtLSBodHRwczovL2J1Z3ppbGxhLm1vemlsbGEub3JnL3Nob3dfYnVnLmNnaT9pZD0xMjI2OTI4IC0tPgo8aGVhZD4KICA8bWV0YSBjaGFyc2V0PSJ1dGYtOCI+CiAgPHRpdGxlPlRlc3RwYWdlIGZvciBidWcgMTIyNjkyODwvdGl0bGU+CjwvaGVhZD4KPGJvZHk+CiAgSnVzdCBhIGZ1bGx5IGdvb2QgdGVzdHBhZ2UgZm9yIEJ1ZyAxMjI2OTI4PGJyLz4KPC9ib2R5Pgo8L2h0bWw+Cg==",
+					KeyID:    "appkey1",
 				},
 			}},
 		{
@@ -114,80 +119,30 @@ func TestSignaturePass(t *testing.T) {
 	}
 }
 
-func TestSignHashFail(t *testing.T) {
-	var TESTCASES = []signaturerequest{
-		// request signature that need to prepend the content-signature:\x00 header
-		signaturerequest{
-			Template: "content-signature",
-			HashWith: "sha384",
-			Input:    "PCFET0NUWVBFIEhUTUw+CjxodG1sPgo8IS0tIGh0dHBzOi8vYnVnemlsbGEubW96aWxsYS5vcmcvc2hvd19idWcuY2dpP2lkPTEyMjY5MjggLS0+CjxoZWFkPgogIDxtZXRhIGNoYXJzZXQ9InV0Zi04Ij4KICA8dGl0bGU+VGVzdHBhZ2UgZm9yIGJ1ZyAxMjI2OTI4PC90aXRsZT4KPC9oZWFkPgo8Ym9keT4KICBKdXN0IGEgZnVsbHkgZ29vZCB0ZXN0cGFnZSBmb3IgQnVnIDEyMjY5Mjg8YnIvPgo8L2JvZHk+CjwvaHRtbD4K",
-		},
-		// request signature of a precomputed sha384 hash
-		signaturerequest{
-			Input: "y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d",
-		},
-		// request signature of raw data that already has the content-signature header prepended
-		signaturerequest{
-			HashWith: "sha384",
-			Input:    "Q29udGVudC1TaWduYXR1cmU6ADwhRE9DVFlQRSBIVE1MPgo8aHRtbD4KPCEtLSBodHRwczovL2J1Z3ppbGxhLm1vemlsbGEub3JnL3Nob3dfYnVnLmNnaT9pZD0xMjI2OTI4IC0tPgo8aGVhZD4KICA8bWV0YSBjaGFyc2V0PSJ1dGYtOCI+CiAgPHRpdGxlPlRlc3RwYWdlIGZvciBidWcgMTIyNjkyODwvdGl0bGU+CjwvaGVhZD4KPGJvZHk+CiAgSnVzdCBhIGZ1bGx5IGdvb2QgdGVzdHBhZ2UgZm9yIEJ1ZyAxMjI2OTI4PGJyLz4KPC9ib2R5Pgo8L2h0bWw+Cg==",
-		},
-	}
-	userid := conf.Authorizations[0].ID
-	body, err := json.Marshal(TESTCASES)
-	if err != nil {
-		t.Fatal(err)
-	}
-	rdr := bytes.NewReader(body)
-	req, err := http.NewRequest("POST", "http://foo.bar/signature", rdr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	authheader := getAuthHeader(req, ag.auths[userid].ID, ag.auths[userid].Key,
-		sha256.New, id(), "application/json", body)
-	req.Header.Set("Authorization", authheader)
-	w := httptest.NewRecorder()
-	ag.handleSignature(w, req)
-	if w.Code != http.StatusCreated || w.Body.String() == "" {
-		t.Fatalf("failed with %d: %s; request was: %+v", w.Code, w.Body.String(), req)
-	}
-
-	// verify that we got a proper signature response, with a valid signature
-	var responses []signatureresponse
-	err = json.Unmarshal(w.Body.Bytes(), &responses)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(responses) != len(TESTCASES) {
-		t.Fatalf("failed to receive as many responses (%d) as we sent requests (%d)",
-			len(responses), len(TESTCASES))
-	}
-	for i, response := range responses {
-		if !verify(t, TESTCASES[i], response, userid, "/signature") {
-			t.Fatalf("signature verification failed in response %d; request was: %+v", i, req)
-		}
-	}
-}
-
 func TestSignatureFail(t *testing.T) {
 	var TESTCASES = []struct {
 		endpoint string
 		method   string
 		body     string
 	}{
-		{`/signature`, `GET`, `[{"input":"y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d"}]`},
+		// missing request body
 		{`/signature`, `POST`, ``},
+		{`/sign/data`, `POST`, ``},
+		{`/sign/hash`, `POST`, ``},
+		// bad hashwith algorithm
+		{`/signature`, `POST`, `[{"hashwith":"md5", "input":"y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d"}]`},
+		{`/sign/data`, `POST`, `[{"hashwith":"md5", "input":"y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d"}]`},
+		// hashwith and template parameters are forbidden on this endpoint
+		{`/sign/hash`, `POST`, `[{"hashwith": "sha384", "input":"y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d"}]`},
+		{`/sign/hash`, `POST`, `[{"template":"content-signature", "input":"y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d"}]`},
+		// no GET, PUT or HEAD requests on these endpoints
+		{`/signature`, `GET`, `[{"input":"y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d"}]`},
 		{`/signature`, `PUT`, ``},
 		{`/signature`, `HEAD`, ``},
 		{`/sign/data`, `GET`, `[{"input":"y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d"}]`},
-		{`/sign/data`, `POST`, `[{"hashwith":"md5", "input":"y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d"}]`},
-		{`/sign/data`, `POST`, ``},
 		{`/sign/data`, `PUT`, ``},
 		{`/sign/data`, `HEAD`, ``},
 		{`/sign/hash`, `GET`, `[{"input":"y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d"}]`},
-		{`/sign/hash`, `POST`, `[{"hashwith": "sha384", "input":"y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d"}]`},
-		{`/sign/hash`, `POST`, `[{"template":"content-signature", "hashwith": "sha384", "input":"y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d"}]`},
-		{`/sign/hash`, `POST`, ``},
 		{`/sign/hash`, `PUT`, ``},
 		{`/sign/hash`, `HEAD`, ``},
 	}
@@ -246,6 +201,49 @@ func TestAuthFail(t *testing.T) {
 	}
 }
 
+func TestContentSignatureInResponse(t *testing.T) {
+	var TESTCASES = []struct {
+		expect   bool
+		endpoint string
+		body     string
+	}{
+		{true, `/sign/data`, `[{"template": "content-signature", "hashwith": "sha384", "input":"PCFET0NUWVBFIEhUTUw+CjxodG1sPgo8IS0tIGh0dHBzOi8vYnVnemlsbGEubW96aWxsYS5vcmcvc2hvd19idWcuY2dpP2lkPTEyMjY5MjggLS0+CjxoZWFkPgogIDxtZXRhIGNo"}]`},
+		{true, `/signature`, `[{"template": "content-signature", "hashwith": "sha384", "input":"PCFET0NUWVBFIEhUTUw+CjxodG1sPgo8IS0tIGh0dHBzOi8vYnVnemlsbGEubW96aWxsYS5vcmcvc2hvd19idWcuY2dpP2lkPTEyMjY5MjggLS0+CjxoZWFkPgogIDxtZXRhIGNo"}]`},
+		{true, `/sign/hash`, `[{"input":"y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d"}]`},
+		{false, `/sign/data`, `[{"hashwith": "sha384", "input":"PCFET0NUWVBFIEhUTUw+CjxodG1sPgo8IS0tIGh0dHBzOi8vYnVnemlsbGEubW96aWxsYS5vcmcvc2hvd19idWcuY2dpP2lkPTEyMjY5MjggLS0+CjxoZWFkPgogIDxtZXRhIGNo"}]`},
+		{false, `/signature`, `[{"hashwith": "sha384", "input":"PCFET0NUWVBFIEhUTUw+CjxodG1sPgo8IS0tIGh0dHBzOi8vYnVnemlsbGEubW96aWxsYS5vcmcvc2hvd19idWcuY2dpP2lkPTEyMjY5MjggLS0+CjxoZWFkPgogIDxtZXRhIGNo"}]`},
+	}
+	for i, testcase := range TESTCASES {
+		body := strings.NewReader(testcase.body)
+		req, err := http.NewRequest("POST", "http://foo.bar"+testcase.endpoint, body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		authheader := getAuthHeader(req, ag.auths[conf.Authorizations[0].ID].ID, ag.auths[conf.Authorizations[0].ID].Key, sha256.New, id(), "application/json", []byte(testcase.body))
+		req.Header.Set("Authorization", authheader)
+		w := httptest.NewRecorder()
+		ag.handleSignature(w, req)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("test case %d failed with %d: %s", i, w.Code, w.Body.String())
+		}
+		var responses []signatureresponse
+		err = json.Unmarshal(w.Body.Bytes(), &responses)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for j, response := range responses {
+			if testcase.expect && response.ContentSignature == "" {
+				t.Fatalf("in test case %d on endpoint %q, expected to find content-signature but didn't; request was %+v",
+					i, testcase.endpoint, j, req)
+			}
+			if !testcase.expect && response.ContentSignature != "" {
+				t.Fatalf("in test case %d on endpoint %q, expected to not find content-signature but did; request was %+v",
+					i, testcase.endpoint, j, req)
+			}
+		}
+	}
+}
 func TestHeartbeat(t *testing.T) {
 	var TESTCASES = []struct {
 		expect int
@@ -550,7 +548,7 @@ func verify(t *testing.T, request signaturerequest, response signatureresponse, 
 	pubkey := ag.signers[signerID].ecdsaPrivKey.Public()
 	sigBytes, err := fromBase64URL(response.Signature)
 	if err != nil {
-		t.Fatalf("failed to decode base65 signature data: %v", err)
+		t.Fatalf("failed to decode base64 signature data: %v", err)
 	}
 	r, s := new(big.Int), new(big.Int)
 	r.SetBytes(sigBytes[:len(sigBytes)/2])

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -234,12 +234,12 @@ func TestContentSignatureInResponse(t *testing.T) {
 		}
 		for j, response := range responses {
 			if testcase.expect && response.ContentSignature == "" {
-				t.Fatalf("in test case %d on endpoint %q, expected to find content-signature but didn't; request was %+v",
-					i, testcase.endpoint, j, req)
+				t.Fatalf("in test case %d response %d on endpoint %q, expected to find content-signature but didn't; request was %+v",
+					i, j, testcase.endpoint, req)
 			}
 			if !testcase.expect && response.ContentSignature != "" {
-				t.Fatalf("in test case %d on endpoint %q, expected to not find content-signature but did; request was %+v",
-					i, testcase.endpoint, j, req)
+				t.Fatalf("in test case %d response %d on endpoint %q, expected to not find content-signature but did; request was %+v",
+					i, j, testcase.endpoint, req)
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -72,7 +72,9 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/__heartbeat__", ag.handleHeartbeat)
 	mux.HandleFunc("/__version__", ag.handleVersion)
-	mux.HandleFunc("/signature", ag.handleSignature)
+	mux.HandleFunc("/signature", ag.handleSignature) // TODO: remove on or after 2016-06-01
+	mux.HandleFunc("/sign/data", ag.handleSignature)
+	mux.HandleFunc("/sign/hash", ag.handleSignature)
 	server := &http.Server{
 		Addr:    conf.Server.Listen,
 		Handler: mux,

--- a/signer.go
+++ b/signer.go
@@ -117,9 +117,10 @@ func templateAndHash(sigreq signaturerequest, curveName string) (string, []byte,
 	case "P-384":
 		hash, err := digest(hashinput, "sha384")
 		return "sha384", hash, err
+	default:
+		hash, err := digest(hashinput, "sha512")
+		return "sha512", hash, err
 	}
-	hash, err := digest(hashinput, "sha512")
-	return "sha512", hash, err
 }
 
 // applyTemplate returns a templated input using custom rules. This is used when requesting a

--- a/signer.go
+++ b/signer.go
@@ -52,7 +52,11 @@ func (s *signer) init() error {
 	s.PublicKey = base64.StdEncoding.EncodeToString(pubkeybytes)
 	// the signature length is double the size size of the curve field, in bytes
 	// (each R and S value is equal to the size of the curve field)
-	s.siglen = (s.ecdsaPrivKey.Params().BitSize / 8) * 2
+	// If the curve field it not a multiple of 8, round to the upper multiple of 8
+	s.siglen = 8 - (s.ecdsaPrivKey.Params().BitSize % 8)
+	s.siglen += s.ecdsaPrivKey.Params().BitSize
+	s.siglen /= 8
+	s.siglen *= 2
 	return nil
 }
 

--- a/signer.go
+++ b/signer.go
@@ -53,10 +53,13 @@ func (s *signer) init() error {
 	// the signature length is double the size size of the curve field, in bytes
 	// (each R and S value is equal to the size of the curve field)
 	// If the curve field it not a multiple of 8, round to the upper multiple of 8
-	s.siglen = 8 - (s.ecdsaPrivKey.Params().BitSize % 8)
+	if s.ecdsaPrivKey.Params().BitSize%8 != 0 {
+		s.siglen = 8 - (s.ecdsaPrivKey.Params().BitSize % 8)
+	}
 	s.siglen += s.ecdsaPrivKey.Params().BitSize
 	s.siglen /= 8
 	s.siglen *= 2
+
 	return nil
 }
 

--- a/signer.go
+++ b/signer.go
@@ -87,26 +87,35 @@ func (s *signer) ContentSignature(ecdsaSig *ecdsaSignature) (string, error) {
 	return fmt.Sprintf("keyid=%s; %s=%s", s.ID, csid, encodedsig), nil
 }
 
-// getInputHash returns a hash of the signature input data. Templating is applied if necessary.
-func getInputHash(sigreq signaturerequest) (hash []byte, err error) {
+// templateAndHash returns a hash of the signature input data. Templating is applied if necessary.
+func templateAndHash(sigreq signaturerequest, curveName string) (string, []byte, error) {
 	hashinput, err := fromBase64URL(sigreq.Input)
+	if err != nil {
+		return "", nil, err
+	}
 	if sigreq.Template != "" {
 		hashinput, err = applyTemplate(hashinput, sigreq.Template)
 		if err != nil {
-			return
+			return "", nil, err
 		}
 	}
-	if sigreq.HashWith == "" {
-		// take the input data as is
-		hash = hashinput
-	} else {
-		// hash the input data with the provided algorithm
-		hash, err = digest(hashinput, sigreq.HashWith)
-		if err != nil {
-			return
-		}
+	// If we have a digest algorithm in the request, use it
+	// otherwise try to infer it from the curve of the signer
+	// and finally default to sha512
+	if sigreq.HashWith != "" {
+		hash, err := digest(hashinput, sigreq.HashWith)
+		return sigreq.HashWith, hash, err
 	}
-	return
+	switch curveName {
+	case "P-256":
+		hash, err := digest(hashinput, "sha256")
+		return "sha256", hash, err
+	case "P-384":
+		hash, err := digest(hashinput, "sha384")
+		return "sha384", hash, err
+	}
+	hash, err := digest(hashinput, "sha512")
+	return "sha512", hash, err
 }
 
 // applyTemplate returns a templated input using custom rules. This is used when requesting a

--- a/signer_test.go
+++ b/signer_test.go
@@ -95,7 +95,7 @@ func TestContentSignatureX5U(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(cs) < 5 {
-		t.Fatal("content signature has bad length %d", len(cs))
+		t.Fatalf("content signature has bad length %d", len(cs))
 	}
 	if !strings.HasPrefix(cs, "x5u=") {
 		t.Fatalf("expected x5u prefix in content-signature but got %q", cs[0:4])
@@ -112,7 +112,7 @@ func TestContentSignatureKeyID(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(cs) < 13 {
-		t.Fatal("content signature has bad length %d", len(cs))
+		t.Fatalf("content signature has bad length %d", len(cs))
 	}
 	if !strings.HasPrefix(cs, "keyid=appkey1") {
 		t.Fatalf("expected keyid prefix in content-signature but got %q", cs[0:13])

--- a/signer_test.go
+++ b/signer_test.go
@@ -36,7 +36,7 @@ func TestInitFail(t *testing.T) {
 	}
 }
 
-func TestGetInputHash(t *testing.T) {
+func TestTemplateAndHash(t *testing.T) {
 	TESTCASES := []struct {
 		sigreq      signaturerequest
 		hash        string
@@ -46,15 +46,13 @@ func TestGetInputHash(t *testing.T) {
 		{sigreq: signaturerequest{Input: "Y2FyaWJvdW1hdXJpY2UK", HashWith: "sha384"}, hash: "7e0509bd09f58d97575f6fcf06358e90fa47dfceecfc93694933352685287f11656fd060f116225c2bfd1954f5a31748"},
 		// apply a template to the string then hash it with sha384
 		{sigreq: signaturerequest{Template: "content-signature", Input: "Y2FyaWJvdW1hdXJpY2UK", HashWith: "sha384"}, hash: "e8c5eecea3e754b7028438b1f61174a695369c3eef603b7ebbf50cf906ce65425855d1d3c7e4a7c5d5e63c765ddd0699"},
-		// string already hashed, return it untouched
-		{sigreq: signaturerequest{Input: "6MXuzqPnVLcChDix9hF0ppU2nD7vYDt+u/UM+QbOZUJYVdHTx+SnxdXmPHZd3QaZ"}, hash: "e8c5eecea3e754b7028438b1f61174a695369c3eef603b7ebbf50cf906ce65425855d1d3c7e4a7c5d5e63c765ddd0699"},
 		// unsupported hash method
 		{sigreq: signaturerequest{Input: "Y2FyaWJvdW1hdXJpY2UK", HashWith: "md5"}, expectError: `unsupported digest algorithm "md5"`},
 		// unsupported template
 		{sigreq: signaturerequest{Template: "caribou", Input: "Y2FyaWJvdW1hdXJpY2UK"}, expectError: `unknown template "caribou"`},
 	}
 	for i, testcase := range TESTCASES {
-		hash, err := getInputHash(testcase.sigreq)
+		_, hash, err := templateAndHash(testcase.sigreq, "P-384")
 		if err != nil {
 			if testcase.expectError == "" {
 				t.Errorf("test case %d expected to succeed but failed with error: %v", i, err)

--- a/tools/client/client.py
+++ b/tools/client/client.py
@@ -18,13 +18,15 @@ def main():
                            help="input string, can be base64, or just raw data")
     argparser.add_argument('--hashwith', dest='hashwith',
                            help="algorithm to hash the input data with (default: none)")
+    argparser.add_argument('--template', dest='template',
+                           help="template to apply to the data before hashing it (default: None)")
     argparser.add_argument('-u', dest='hawkid', default="alice",
                            help="hawk id (default: alice)")
     argparser.add_argument('-p', dest='hawkkey',
                            default="fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu",
                            help="hawk key (default: fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu)")
     argparser.add_argument('-t', dest='target',
-                           default="http://localhost:8000/signature",
+                           default="http://localhost:8000/sign/data",
                            help="signing api URL (default: http://localhost:8000/signature)")
     argparser.add_argument('-e', dest='encoding',
                            default="rs_base64url",
@@ -39,6 +41,7 @@ def main():
 
     # build and run the signature request
     sigreq = [{
+        "template": args.template,
         "input": base64.b64encode(inputdata),
         "hashwith": args.hashwith,
         "signature_encoding": args.encoding
@@ -70,7 +73,10 @@ def main():
             hashfunc = hashlib.sha512
 
     # perform verification
-    print("signature validation: %s" % vk.verify(sigdata, inputdata, hashfunc=hashfunc, sigdecode=ecdsa.util.sigdecode_string))
+    if hashfunc:
+        print("signature validation: %s" % vk.verify(sigdata, inputdata, hashfunc=hashfunc, sigdecode=ecdsa.util.sigdecode_string))
+    else:
+        print("signature validation: %s" % vk.verify_digest(sigdata, inputdata, sigdecode=ecdsa.util.sigdecode_string))
 
 
 def un_urlsafe(input):

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package main
 
-const version = "20160304.0-8e4cb61"
-const commit = "8e4cb61e1d1de29c73f11fd577f5bdee5dd66b67"
+const version = "20160304.0-8694593"
+const commit = "869459394bcc3f2d68afce422bb397478f8277c4"

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package main
 
-const version = "20160304.0-8694593"
-const commit = "869459394bcc3f2d68afce422bb397478f8277c4"
+const version = "20160310.0-ce423a7"
+const commit = "ce423a728e1ba505fd408f1474a260e058e9095f"

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package main
 
-const version = "20160310.0-ce423a7"
-const commit = "ce423a728e1ba505fd408f1474a260e058e9095f"
+const version = "20160310.0-79ba569"
+const commit = "79ba569f560573228f53eedeeeed1688712e106f"


### PR DESCRIPTION
This PR is based on #29 and the commits will change once it is merged.

It implements two new endpoints to simplify integration. The description of each endpoint is included in the README. In a nutshell:

* `/sign/data` is meant to receive input of raw data, template it and hash it. It takes a number of parameters in the signature requests to perform those tasks

* `/sign/hash` is a simplified version of the above that assumes the input data is already templated and hashed, and bypasses those steps entirely.

The response format does not change at all, and I kept the former `/signature` endpoint to ease the migration.