### PR TITLE
Remove /signature endpoint

### DIFF
--- a/authorize_test.go
+++ b/authorize_test.go
@@ -19,7 +19,7 @@ import (
 func TestMissingAuthorization(t *testing.T) {
 	body := []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	bodyrdr := bytes.NewReader(body)
-	req, err := http.NewRequest("POST", "http://foo.bar/signature", bodyrdr)
+	req, err := http.NewRequest("POST", "http://foo.bar/sign/data", bodyrdr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +35,7 @@ func TestMissingAuthorization(t *testing.T) {
 func TestBogusAuthorization(t *testing.T) {
 	body := []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	bodyrdr := bytes.NewReader(body)
-	req, err := http.NewRequest("POST", "http://foo.bar/signature", bodyrdr)
+	req, err := http.NewRequest("POST", "http://foo.bar/sign/data", bodyrdr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +52,7 @@ func TestBogusAuthorization(t *testing.T) {
 func TestBadPayload(t *testing.T) {
 	body := []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	bodyrdr := bytes.NewReader(body)
-	req, err := http.NewRequest("POST", "http://foo.bar/signature", bodyrdr)
+	req, err := http.NewRequest("POST", "http://foo.bar/sign/data", bodyrdr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func TestBadPayload(t *testing.T) {
 func TestExpiredAuth(t *testing.T) {
 	body := []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	bodyrdr := bytes.NewReader(body)
-	req, err := http.NewRequest("POST", "http://foo.bar/signature", bodyrdr)
+	req, err := http.NewRequest("POST", "http://foo.bar/sign/data", bodyrdr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestExpiredAuth(t *testing.T) {
 func TestDuplicateNonce(t *testing.T) {
 	body := []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	bodyrdr := bytes.NewReader(body)
-	req, err := http.NewRequest("POST", "http://foo.bar/signature", bodyrdr)
+	req, err := http.NewRequest("POST", "http://foo.bar/sign/data", bodyrdr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +109,7 @@ func TestDuplicateNonce(t *testing.T) {
 }
 
 func TestNonceFromLRU(t *testing.T) {
-	req, err := http.NewRequest("POST", "http://foo.bar/signature", nil)
+	req, err := http.NewRequest("POST", "http://foo.bar/sign/data", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/handlers.go
+++ b/handlers.go
@@ -172,17 +172,6 @@ func (a *autographer) handleSignature(w http.ResponseWriter, r *http.Request) {
 				httpError(w, http.StatusBadRequest, "%v", err)
 				return
 			}
-		// TODO: remove this case as soon as backward compat is no longer needed, or on 2016-06-01
-		case "/signature":
-			if sigreq.HashWith == "" {
-				hash, err = fromBase64URL(sigreq.Input)
-			} else {
-				alg, hash, err = templateAndHash(sigreq, a.signers[signerID].ecdsaPrivKey.Curve.Params().Name)
-			}
-			if err != nil {
-				httpError(w, http.StatusBadRequest, "%v", err)
-				return
-			}
 		}
 		ecdsaSig, err := a.signers[signerID].sign(hash)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -72,7 +72,6 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/__heartbeat__", ag.handleHeartbeat)
 	mux.HandleFunc("/__version__", ag.handleVersion)
-	mux.HandleFunc("/signature", ag.handleSignature) // TODO: remove on or after 2016-06-01
 	mux.HandleFunc("/sign/data", ag.handleSignature)
 	mux.HandleFunc("/sign/hash", ag.handleSignature)
 	server := &http.Server{

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package main
 
-const version = "20160310.0-79ba569"
-const commit = "79ba569f560573228f53eedeeeed1688712e106f"
+const version = "20160311.0-66a9b33"
+const commit = "66a9b332fa17c95ca0b079c3564d0aedce7cf7cd"


### PR DESCRIPTION
Autograph clients should either call `/sign/data` or `/sign/hash`.

r? @almet & @ncloudioj : let me know when your clients are migrated to the new endpoints and we can merge this. No rush, it can wait a couple weeks if needed.