### PR TITLE
Cleanup python client

### DIFF
--- a/tools/autograph-client-python/client.py
+++ b/tools/autograph-client-python/client.py
@@ -56,35 +56,30 @@ def main():
         print("unable to verify signature: encoding is %s and I only know rs_base64url" % args.encoding)
         return
 
-    # the public key is converted to regular base64, and loaded
-    pubkeystr = un_urlsafe(sigresp[0]["public_key"])
-    vk = ecdsa.VerifyingKey.from_pem(pubkeystr)
+    vk = ecdsa.VerifyingKey.from_pem(sigresp[0]["public_key"])
 
     # the signature is b64 decoded to obtain bytes
-    sigdata = base64.b64decode(un_urlsafe(sigresp[0]["signature"].encode("utf-8")))
+    sigdata = base64.urlsafe_b64decode(bytes(sigresp[0]["signature"]))
 
     hashfunc = None
-    if "hash_algorithm" in sigresp[0]:
-        if sigresp[0]["hash_algorithm"] == "sha384":
+    hash_algorithm = sigresp[0].get('hash_algorithm')
+    if hash_algorithm:
+        if hash_algorithm == "sha384":
             hashfunc = hashlib.sha384
-        if sigresp[0]["hash_algorithm"] == "sha256":
+        elif hash_algorithm == "sha256":
             hashfunc = hashlib.sha256
-        if sigresp[0]["hash_algorithm"] == "sha512":
+        elif hash_algorithm == "sha512":
             hashfunc = hashlib.sha512
+        else:
+            raise ValueError('Unexpected hash_algorithm "%s"' % hash_algorithm)
 
     # perform verification
     if hashfunc:
-        print("signature validation: %s" % vk.verify(sigdata, inputdata, hashfunc=hashfunc, sigdecode=ecdsa.util.sigdecode_string))
+        validation = vk.verify(sigdata, inputdata, hashfunc=hashfunc, sigdecode=ecdsa.util.sigdecode_string)
     else:
-        print("signature validation: %s" % vk.verify_digest(sigdata, inputdata, sigdecode=ecdsa.util.sigdecode_string))
+        validdation = vk.verify_digest(sigdata, inputdata, sigdecode=ecdsa.util.sigdecode_string)
 
-
-def un_urlsafe(input):
-    input = str(input).replace("_", "/")
-    input = str(input).replace("-", "+")
-    if len(input) % 4 > 0:
-        input += "=" * (4 - len(input) % 4)
-    return input
+    print("signature validation: %s", validation)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When the verifier I added to Normandy went through code review in mozilla/normandy#259, several improvements were pointed out. This "backports" those fixes to the autograph client. The main change here is removing the `un_urlsafe` function, since the python base64 module has one built in, and ecdsa is smart enough to detect urlsafe base64.