### PR TITLE
Add helper to print authorizations, fixes #78

### DIFF
--- a/authorize.go
+++ b/authorize.go
@@ -100,3 +100,25 @@ func (a *autographer) getSignerID(userid, keyid string) (int, error) {
 	}
 	return a.signerIndex[tag], nil
 }
+
+func (a *autographer) PrintAuthorizations() {
+	fmt.Println("\n---- Signers ----")
+	for _, signr := range a.signers {
+		fmt.Printf("- %s [%s %s]:\n",
+			signr.Config().ID, signr.Config().Type, signr.Config().Mode)
+		for user, auth := range a.auths {
+			for _, authsigner := range auth.Signers {
+				if authsigner == signr.Config().ID {
+					fmt.Printf("\t* %s\n", user)
+				}
+			}
+		}
+	}
+	fmt.Println("\n---- Authorizations ----")
+	for user, auth := range a.auths {
+		fmt.Printf("-%s: \n", user)
+		for _, authsigner := range auth.Signers {
+			fmt.Printf("\t* %s\n", authsigner)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -52,13 +53,15 @@ type autographer struct {
 
 func main() {
 	var (
-		ag      *autographer
-		conf    configuration
-		cfgFile string
-		debug   bool
-		err     error
+		ag        *autographer
+		conf      configuration
+		cfgFile   string
+		debug     bool
+		authPrint bool
+		err       error
 	)
 	flag.StringVar(&cfgFile, "c", "autograph.yaml", "Path to configuration file")
+	flag.BoolVar(&authPrint, "A", false, "Print authorizations matrix and exit")
 	flag.BoolVar(&debug, "D", false, "Print debug logs")
 	flag.Parse()
 
@@ -85,6 +88,11 @@ func main() {
 	ag.makeSignerIndex()
 	if debug {
 		ag.enableDebug()
+	}
+
+	if authPrint {
+		ag.PrintAuthorizations()
+		os.Exit(0)
 	}
 
 	router := mux.NewRouter().StrictSlash(true)


### PR DESCRIPTION
example output: 
```
---- Signers ----
- appkey1 [contentsignature p384ecdsa]:
        * alice
- appkey2 [contentsignature p256ecdsa]:
        * alice
        * bob
- appkey3 [contentsignature p521ecdsa]:
        * alice
- normankey [contentsignature p384ecdsa]:
        * normandev
        * alice
- webextensions-rsa [xpi add-on]:
        * alice
- extensions-ecdsa [xpi extension]:
        * alice
- testapp-android [apk ]:
        * alice

---- Authorizations ----
-bob: 
        - appkey2
-normandev: 
        - normankey
-monitor: 
-alice: 
        - appkey1
        - appkey2
        - appkey3
        - normankey
        - webextensions-rsa
        - extensions-ecdsa
        - testapp-android
```