### PR TITLE
xpi: add the add-on ID to the dns names of the EE cert

### DIFF
--- a/signer/xpi/x509.go
+++ b/signer/xpi/x509.go
@@ -60,6 +60,12 @@ func (s *PKCS7Signer) MakeEndEntity(cn string) (eeCert *x509.Certificate, eeKey 
 		// https://tools.ietf.org/html/rfc5280#section-4.1.2.2
 		// Setting it to nanoseconds guarantees we'll never have two conflicting serials
 		SerialNumber: big.NewInt(time.Now().UnixNano()),
+
+		// having a dnsname or an email address field is required to comply with webpki
+		// requirement due to the intermediates having constraints
+		// see https://github.com/golang/go/issues/24151
+		DNSNames: []string{cn},
+
 		Subject: pkix.Name{
 			CommonName:         cn,
 			Organization:       []string{"Addons"},

--- a/signer/xpi/x509_test.go
+++ b/signer/xpi/x509_test.go
@@ -1,0 +1,31 @@
+package xpi
+
+import "testing"
+
+func TestMakeEndEntity(t *testing.T) {
+	t.Parallel()
+	s, err := New(PASSINGTESTCASES[3])
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, testid := range []string{
+		"foo@example.net",
+		"foo",
+		"0000",
+		"a0d7ccb3-214d-498b-b4aa-0e8fda9a7bf7",
+	} {
+		cert, _, err := s.MakeEndEntity(testid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cert.Subject.CommonName != testid {
+			t.Fatalf("expected cert cn to match testid %q but got %q", testid, cert.Subject.CommonName)
+		}
+		if len(cert.DNSNames) != 1 {
+			t.Fatalf("expected to find 1 SAN entry but found %d", len(cert.DNSNames))
+		}
+		if cert.DNSNames[0] != testid {
+			t.Fatalf("expected SAN to match testid %q but got %q", testid, cert.Subject.CommonName)
+		}
+	}
+}

--- a/signer/xpi/xpi.go
+++ b/signer/xpi/xpi.go
@@ -217,7 +217,7 @@ type Options struct {
 
 // GetDefaultOptions returns default options of the signer
 func (s *PKCS7Signer) GetDefaultOptions() interface{} {
-	return Options{ID: "test@example.net"}
+	return Options{ID: "ffffffff-ffff-ffff-ffff-ffffffffffff"}
 }
 
 // GetOptions takes a input interface and reflects it into a struct of options


### PR DESCRIPTION
This solves Go 1.10's `issuer has name constraints but leaf doesn't have a SAN extension`.

The issue is the add-ons signing intermediates of the Firefox PKI are constrained to not be usable for content signature, but those constraints also require the EE to have a SAN, which is not needed by Firefox. We work around this by adding the add-on ID to the SAN of the EE.

Note that this works with both email and UUIDs.