### PR TITLE
Port option

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -293,3 +293,11 @@ func TestStartMain(t *testing.T) {
 		t.Errorf("expected response code %d, got %d", http.StatusOK, resp.StatusCode)
 	}
 }
+
+func TestPortOverride(t *testing.T) {
+	expected := "0.0.0.0:8080"
+	_, listen, _, _ := parseArgsAndLoadConfig([]string{"-p", "8080"})
+	if listen != expected {
+		t.Errorf("expected listen %s got %s", expected, listen)
+	}
+}

--- a/signer/xpi/cose.go
+++ b/signer/xpi/cose.go
@@ -69,7 +69,7 @@ func (s *XPISigner) generateCOSEKeyPair(coseAlg *cose.Algorithm) (eeKey crypto.P
 	case nil:
 		err = errors.New("Cannot generate private key for nil cose Algorithm")
 	case cose.PS256:
-		var size int = 2048
+		var size = 2048
 		switch key := s.issuerKey.(type) {
 		case *ecdsa.PrivateKey:
 			if key.D.BitLen() > size {


### PR DESCRIPTION
Fixes #100.

Refactors main logic to use a flagset (to avoid flag redefine errors) and make it testable. 

Functional Tests:

- [x] running without a port uses config value

```
$ autograph -c ./autograph.yaml
...
{"Timestamp":1533943982595972229,"Time":"2018-08-10T23:33:02Z","Type":"app.log","Logger":"autograph","Hostname":"gguthe-ThinkPad-X1-Carbon-6th","EnvVersion":"2.0","Pid":30879,"Severity":6,"Fields":{"msg":"starting autograph on 0.0.0.0:8000"}}
```

- [x] running with a port overrides config value

```
$ autograph -c ./autograph.yaml -p 8080
{"Timestamp":1533944410120833921,"Time":"2018-08-10T23:40:10Z","Type":"app.log","Logger":"autograph","Hostname":"gguthe-ThinkPad-X1-Carbon-6th","EnvVersion":"2.0","Pid":733,"Severity":6,"Fields":{"msg":"Overriding port from config 8000 with 8080 from the commandline"}}
...
{"Timestamp":1533944361295067077,"Time":"2018-08-10T23:39:21Z","Type":"app.log","Logger":"autograph","Hostname":"gguthe-ThinkPad-X1-Carbon-6th","EnvVersion":"2.0","Pid":32745,"Severity":6,"Fields":{"msg":"starting autograph on 0.0.0.0:8080"}}
```

- [x] running with an invalid port errors out

```
$ autograph -c ./autograph.yaml -p -1
... 
{"Timestamp":1533944441324504666,"Time":"2018-08-10T23:40:41Z","Type":"app.log","Logger":"autograph","Hostname":"gguthe-ThinkPad-X1-Carbon-6th","EnvVersion":"2.0","Pid":834,"Severity":2,"Fields":{"msg":"listen tcp: address -1: invalid port"}}
```