### PR TITLE
fix logging overriding port to same port when -p isn't passed

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,13 +66,13 @@ func main() {
 func parseArgsAndLoadConfig(args []string) (conf configuration, listen string, authPrint, debug bool) {
 	var (
 		cfgFile string
-		port    int
+		port    string
 		err     error
 		fset    = flag.NewFlagSet("parseArgsAndLoadConfig", flag.ContinueOnError)
 	)
 
 	fset.StringVar(&cfgFile, "c", "autograph.yaml", "Path to configuration file")
-	fset.IntVar(&port, "p", 8000, "Port to listen on overrides the listen var from the config file")
+	fset.StringVar(&port, "p", "", "Port to listen on. Overrides the listen var from the config file")
 	fset.BoolVar(&authPrint, "A", false, "Print authorizations matrix and exit")
 	fset.BoolVar(&debug, "D", false, "Print debug logs")
 	fset.Parse(args)
@@ -83,9 +83,9 @@ func parseArgsAndLoadConfig(args []string) (conf configuration, listen string, a
 	}
 
 	confListen := strings.Split(conf.Server.Listen, ":")
-	if len(confListen) > 1 && string(port) != confListen[1] {
-		listen = fmt.Sprintf("%s:%d", confListen[0], port)
-		log.Infof("Overriding port from config %s with %d from the commandline", confListen[1], port)
+	if len(confListen) > 1 && port != "" && port != confListen[1] {
+		listen = fmt.Sprintf("%s:%s", confListen[0], port)
+		log.Infof("Overriding listen addr from config %s with new port from the commandline: %s", conf.Server.Listen, listen)
 	} else {
 		listen = conf.Server.Listen
 	}


### PR DESCRIPTION
Per https://github.com/mozilla-services/autograph/pull/116#issuecomment-412936562 and :cgrebs feedback on IRC, I forgot to re-run functional tests on the PR to add the port option after fixing the nit and this broke AMO testing.

This commit treats everything as strings.

Functional Tests:

- [x] without CLI port arg, value from config is used 

```
head -n2 autograph.yaml
server:
    listen: "0.0.0.0:8081"
autograph -c ./autograph.yaml
...
{"Timestamp":1534265357542390656,"Time":"2018-08-14T16:49:17Z","Type":"app.log","Logger":"autograph","Hostname":"gguthe-ThinkPad-X1-Carbon-6th","EnvVersion":"2.0","Pid":12046,"Severity":6,"Fields":{"msg":"starting autograph on 0.0.0.0:8081"}}
```

- [x] with CLI port arg, value from config is overridden

```
head -n2 autograph.yaml
server:
    listen: "0.0.0.0:8081"
autograph -c ./autograph.yaml -p 8080                                                      
...
{"Timestamp":1534265384476673137,"Time":"2018-08-14T16:49:44Z","Type":"app.log","Logger":"autograph","Hostname":"gguthe-ThinkPad-X1-Carbon-6th","EnvVersion":"2.0","Pid":12142,"Severity":6,"Fields":{"msg":"starting autograph on 0.0.0.0:8080"}}
```