### PR TITLE
Log hawk ts validity

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -80,6 +80,7 @@ Then add it to the configuration as follows:
 		# username 'bob' is only allowed to use signer 'appkey2'
 		- id: bob
 		  key: 9vh6bhlc10y63ow2k4zke7k0c3l9hpr8mo96p92jmbfqngs9e7d
+		  hawktimestampvalidity: 10m
 		  signers:
 			  - appkey2
 
@@ -91,6 +92,12 @@ specific signer key id is provided in the signing request, autograph will use
 the first signer in the list. For example, if alice requests a signature without
 providing a key id, the private key from `appkey1` will be used to sign her
 request.
+
+The optional key `hawktimestampvalidity` maps to a string `parsed as a
+time.Duration`_ and allows for different HAWK timestamp skews than the
+default of 1 minute.
+
+.. _`parsed as a time.Duration`: https://golang.org/pkg/time/#ParseDuration
 
 Building and running
 --------------------

--- a/main.go
+++ b/main.go
@@ -304,7 +304,7 @@ func (a *autographer) makeSignerIndex() {
 		for _, sid := range auth.Signers {
 			for pos, s := range a.signers {
 				if sid == s.Config().ID {
-					log.Printf("Mapping auth id %q and signer id %q to signer %d", auth.ID, s.Config().ID, pos)
+					log.Printf("Mapping auth id %q and signer id %q to signer %d with hawk ts validity %s", auth.ID, s.Config().ID, pos, auth.hawkMaxTimestampSkew)
 					tag := auth.ID + "+" + s.Config().ID
 					a.signerIndex[tag] = pos
 				}
@@ -321,7 +321,7 @@ func (a *autographer) makeSignerIndex() {
 		}
 		for pos, signer := range a.signers {
 			if auth.Signers[0] == signer.Config().ID {
-				log.Printf("Mapping auth id %q to default signer %d", auth.ID, pos)
+				log.Printf("Mapping auth id %q to default signer %d with hawk ts validity %s", auth.ID, pos, auth.hawkMaxTimestampSkew)
 				tag := auth.ID + "+"
 				a.signerIndex[tag] = pos
 				break


### PR DESCRIPTION
refs: https://bugzilla.mozilla.org/show_bug.cgi?id=1471197

Changes:
* Log the hawk ts skew for each authorization on start
* document hawk validity option

r? @ajvb 