### PR TITLE
signers: Add missing MD5 digest to xpi metafiles

### DIFF
--- a/signer/xpi/jar.go
+++ b/signer/xpi/jar.go
@@ -29,7 +29,10 @@ func makePKCS7Manifest(input []byte, metafiles []Metafile) (manifest []byte, err
 
 	mw := bytes.NewBuffer(manifest)
 	for _, f := range metafiles {
-		fmt.Fprintf(mw, "Name: %s\nDigest-Algorithms: SHA1 SHA256\n", f.Name)
+		fmt.Fprintf(mw, "Name: %s\nDigest-Algorithms: MD5 SHA1 SHA256\n", f.Name)
+		h0 := md5.New()
+		h0.Write(f.Body)
+		fmt.Fprintf(mw, "MD5-Digest: %s\n", base64.StdEncoding.EncodeToString(h0.Sum(nil)))
 		h1 := sha1.New()
 		h1.Write(f.Body)
 		fmt.Fprintf(mw, "SHA1-Digest: %s\n", base64.StdEncoding.EncodeToString(h1.Sum(nil)))


### PR DESCRIPTION
For backwards compat testing (Fx <58). Has no effect on newer Fx versions. Could impact Fx versions that only check MD5 hashes for manifest file entries (they might have complained or ignored about missing MD5 hashes for cose manifest files). 

Before:

```
cat META-INF/manifest.mf                                                        
Manifest-Version: 1.0                      
...
Digest-Algorithms: MD5 SHA1 SHA256                                                                                                                    MD5-Digest: EBXQsgtl1wN1PVrHh739Fg==                                         
SHA1-Digest: zhMJVKNBbak0KMBbzsIY2ZEsyAE=                                                             
SHA256-Digest: nUo/AZHCkrOHd/Q3hI0Y24Xamdbdil+fPV8TvlVHQn4=            
                                                            
Name: META-INF/cose.manifest                                                                                             
Digest-Algorithms: SHA1 SHA256                                               
SHA1-Digest: rZlZ1evmw1BX38zZKZjocln77AQ=                  
SHA256-Digest: zW40dM7Kvaelt76Pm6SWaXRClWwiuucaasTHplFLDyA=                                                         
                                                                                                                     
Name: META-INF/cose.sig                                                     
Digest-Algorithms: SHA1 SHA256                                                                          
SHA1-Digest: AjS6IKmbko8Bl6+vKmTNXpP+UqY=                                   
SHA256-Digest: ufTjv8Z3K9C3VQh34cINHosDKUBd0r8wt1lE5xLJ8Gg=                              
```

After:

```
...
Name: META-INF/cose.sig
Digest-Algorithms: MD5 SHA1 SHA256
MD5-Digest: WDFzorKGF2F/om6W+Bq3lg==
SHA1-Digest: xyoci+w8VMcLQtGoq1nUhkYOFvI=
SHA256-Digest: n0djlzHCdM5awoLvB4TM6KBPHc/y/hUAxQ8JY+wqC4A=
```

NB: AMO prod unaffected since this is only called from /sign/file with
one or more COSE algs.

calls: https://github.com/mozilla-services/autograph/search?q=makePKCS7Manifest&unscoped_q=makePKCS7Manifest

only call in use: https://github.com/mozilla-services/autograph/blob/d6a77dd438ca1fa453de46426db48cbe722e8d6f/signer/xpi/xpi.go#L207

refs: https://github.com/mozilla-services/autograph/pull/121

r? @ajvb or @jvehent 