### PR TITLE
Fix ckr obj handle invalid errs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ vendor:
 	govend -u --prune
 	#go get -u github.com/golang/dep/...
 	#dep ensure -update
+	# https://github.com/ThalesIgnite/crypto11/issues/9
+	git checkout -f 2210ea80470825094edf8235b35f9565c7940555 vendor/github.com/ThalesIgnite/crypto11/
 
 tag: all
 	git tag -s $(TAGVER) -a -m "$(TAGMSG)"

--- a/vendor/github.com/ThalesIgnite/crypto11/Gopkg.lock
+++ b/vendor/github.com/ThalesIgnite/crypto11/Gopkg.lock
@@ -7,31 +7,9 @@
   packages = ["."]
   revision = "7283ca79f35edb89bc1b4ecae7f86a3680ce737f"
 
-[[projects]]
-  name = "github.com/youtube/vitess"
-  packages = ["go/pools"]
-  revision = "66e84fadcc1a7e956e7ffcebcaaba0b04132ca1f"
-  version = "v2.2"
-
-[[projects]]
-  branch = "master"
-  name = "golang.org/x/net"
-  packages = ["context"]
-  revision = "afe8f62b1d6bbd81f31868121a50b06d8188e1f9"
-
-[[projects]]
-  name = "vitess.io/vitess"
-  packages = [
-    "go/cache",
-    "go/sync2",
-    "go/timer"
-  ]
-  revision = "66e84fadcc1a7e956e7ffcebcaaba0b04132ca1f"
-  version = "v2.2"
-
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8cd1e283a543a5f16f1a28efc4432ba787658c62e70c42078f5910e9b21a3803"
+  inputs-digest = "637fa76bf97d900f27feffdfb5bfc3a5d4fcdbe927f917bafa1bce2648c6fc21"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/ThalesIgnite/crypto11/README.md
+++ b/vendor/github.com/ThalesIgnite/crypto11/README.md
@@ -45,7 +45,7 @@ Clone, ensure deps, and build:
 
 Edit `config` to taste, and then run the test program:
 
-    go test  -count=1
+    go test
 
 Testing Guidance
 ================
@@ -145,15 +145,7 @@ The configuration looks like this:
       "Pin" : "password"
     }
 
-(At time of writing) OAEP is only partial, so expect test skips.
-
-Limitations
-===========
-
- * The [PKCS1v15DecryptOptions SessionKeyLen](https://golang.org/pkg/crypto/rsa/#PKCS1v15DecryptOptions) field
-is not implemented and an error is returned if it is nonzero.
-The reason for this is that it is not possible for crypto11 to guarantee the constant-time behavior in the specification.
-See [issue #5](https://github.com/ThalesIgnite/crypto11/issues/5) for further discussion.
+(At time of writing) PSS and OAEP aren't supported so expect test failures.
 
 Wishlist
 ========

--- a/vendor/github.com/ThalesIgnite/crypto11/keys.go
+++ b/vendor/github.com/ThalesIgnite/crypto11/keys.go
@@ -23,7 +23,6 @@ package crypto11
 
 import (
 	"crypto"
-
 	pkcs11 "github.com/miekg/pkcs11"
 )
 
@@ -35,8 +34,8 @@ func (object *PKCS11Object) Identify() (id []byte, label []byte, err error) {
 		pkcs11.NewAttribute(pkcs11.CKA_ID, nil),
 		pkcs11.NewAttribute(pkcs11.CKA_LABEL, nil),
 	}
-	if err = withSession(object.Slot, func(session *PKCS11Session) error {
-		a, err = libHandle.GetAttributeValue(session.Handle, object.Handle, a)
+	if err = withSession(object.Slot, func(session pkcs11.SessionHandle) error {
+		a, err = libHandle.GetAttributeValue(session, object.Handle, a)
 		return err
 	}); err != nil {
 		return nil, nil, err
@@ -46,10 +45,10 @@ func (object *PKCS11Object) Identify() (id []byte, label []byte, err error) {
 
 // Find a key object.  For asymmetric keys this only finds one half so
 // callers will call it twice.
-func findKey(session *PKCS11Session, id []byte, label []byte, keyclass uint, keytype uint) (pkcs11.ObjectHandle, error) {
+func findKey(session pkcs11.SessionHandle, id []byte, label []byte, keyclass uint, keytype uint) (pkcs11.ObjectHandle, error) {
 	var err error
 	var handles []pkcs11.ObjectHandle
-	var template []*pkcs11.Attribute
+	template := []*pkcs11.Attribute{}
 	if keyclass != ^uint(0) {
 		template = append(template, pkcs11.NewAttribute(pkcs11.CKA_CLASS, keyclass))
 	}
@@ -62,11 +61,11 @@ func findKey(session *PKCS11Session, id []byte, label []byte, keyclass uint, key
 	if label != nil {
 		template = append(template, pkcs11.NewAttribute(pkcs11.CKA_LABEL, label))
 	}
-	if err = session.Ctx.FindObjectsInit(session.Handle, template); err != nil {
+	if err = libHandle.FindObjectsInit(session, template); err != nil {
 		return 0, err
 	}
-	defer session.Ctx.FindObjectsFinal(session.Handle)
-	if handles, _, err = session.Ctx.FindObjects(session.Handle, 1); err != nil {
+	defer libHandle.FindObjectsFinal(session)
+	if handles, _, err = libHandle.FindObjects(session, 1); err != nil {
 		return 0, err
 	}
 	if len(handles) == 0 {
@@ -82,16 +81,16 @@ func FindKeyPair(id []byte, label []byte) (crypto.PrivateKey, error) {
 	return FindKeyPairOnSlot(defaultSlot, id, label)
 }
 
-// FindKeyPairOnSlot retrieves a previously created asymmetric key, using a specified slot.
+// FindKeyPairOnSession retrieves a previously created asymmetric key, using a specified slot.
 //
 // Either (but not both) of id and label may be nil, in which case they are ignored.
 func FindKeyPairOnSlot(slot uint, id []byte, label []byte) (crypto.PrivateKey, error) {
 	var err error
 	var k crypto.PrivateKey
-	if err = ensureSessions(libHandle, slot); err != nil {
+	if err = setupSessions(slot, 0); err != nil {
 		return nil, err
 	}
-	err = withSession(slot, func(session *PKCS11Session) error {
+	err = withSession(slot, func(session pkcs11.SessionHandle) error {
 		k, err = FindKeyPairOnSession(session, slot, id, label)
 		return err
 	})
@@ -101,18 +100,21 @@ func FindKeyPairOnSlot(slot uint, id []byte, label []byte) (crypto.PrivateKey, e
 // FindKeyPairOnSession retrieves a previously created asymmetric key, using a specified session.
 //
 // Either (but not both) of id and label may be nil, in which case they are ignored.
-func FindKeyPairOnSession(session *PKCS11Session, slot uint, id []byte, label []byte) (crypto.PrivateKey, error) {
+func FindKeyPairOnSession(session pkcs11.SessionHandle, slot uint, id []byte, label []byte) (crypto.PrivateKey, error) {
 	var err error
 	var privHandle, pubHandle pkcs11.ObjectHandle
 	var pub crypto.PublicKey
 
+	if libHandle == nil {
+		return nil, ErrNotConfigured
+	}
 	if privHandle, err = findKey(session, id, label, pkcs11.CKO_PRIVATE_KEY, ^uint(0)); err != nil {
 		return nil, err
 	}
 	attributes := []*pkcs11.Attribute{
 		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, 0),
 	}
-	if attributes, err = session.Ctx.GetAttributeValue(session.Handle, privHandle, attributes); err != nil {
+	if attributes, err = libHandle.GetAttributeValue(session, privHandle, attributes); err != nil {
 		return nil, err
 	}
 	keyType := bytesToUlong(attributes[0].Value)

--- a/vendor/github.com/ThalesIgnite/crypto11/rand.go
+++ b/vendor/github.com/ThalesIgnite/crypto11/rand.go
@@ -21,7 +21,11 @@
 
 package crypto11
 
-// PKCS11RandReader is a random number reader that uses PKCS#11.
+import (
+	pkcs11 "github.com/miekg/pkcs11"
+)
+
+// A random number reader that uses PKCS#11.
 type PKCS11RandReader struct {
 }
 
@@ -33,8 +37,8 @@ func (reader PKCS11RandReader) Read(data []byte) (n int, err error) {
 	if libHandle == nil {
 		return 0, ErrNotConfigured
 	}
-	if err = withSession(defaultSlot, func(session *PKCS11Session) error {
-		result, err = libHandle.GenerateRandom(session.Handle, len(data))
+	if err = withSession(defaultSlot, func(session pkcs11.SessionHandle) error {
+		result, err = libHandle.GenerateRandom(session, len(data))
 		return err
 	}); err != nil {
 		return 0, err

--- a/vendor/github.com/ThalesIgnite/crypto11/sessions.go
+++ b/vendor/github.com/ThalesIgnite/crypto11/sessions.go
@@ -22,128 +22,58 @@
 package crypto11
 
 import (
-	"context"
-	"fmt"
+	pkcs11 "github.com/miekg/pkcs11"
 	"sync"
-	"time"
-
-	"github.com/miekg/pkcs11"
-	"github.com/youtube/vitess/go/pools"
-	"errors"
 )
-
-const (
-	idleTimeout       = 30 * time.Second
-	newSessionTimeout = 15 * time.Second
-)
-
-// PKCS11Session is a pair of PKCS#11 context and a reference to a loaded session handle.
-type PKCS11Session struct {
-	Ctx *pkcs11.Ctx
-	Handle pkcs11.SessionHandle
-}
-
-// sessionPool is a thread safe pool of PKCS#11 sessions
-type sessionPool struct {
-	m sync.RWMutex
-	pool map[uint]*pools.ResourcePool
-}
 
 // Map of slot IDs to session pools
-var pool = &sessionPool{pool: map[uint]*pools.ResourcePool{}}
+var sessionPools map[uint]chan pkcs11.SessionHandle = map[uint]chan pkcs11.SessionHandle{}
 
-// Error specifies an event when the requested slot is already set in the sessions pool
-var errSlotBusy = errors.New("pool slot busy")
-// Error when there is no pool at specific slot in the sessions pool
-var errPoolNotFound = errors.New("pool not found")
+// Mutex protecting sessionPools
+var sessionPoolMutex sync.Mutex
 
 // Create a new session for a given slot
-func newSession(ctx *pkcs11.Ctx, slot uint) (*PKCS11Session, error) {
-	session, err := ctx.OpenSession(slot, pkcs11.CKF_SERIAL_SESSION|pkcs11.CKF_RW_SESSION)
-	if err != nil {
-		return nil, err
+func newSession(slot uint) (pkcs11.SessionHandle, error) {
+	if session, err := libHandle.OpenSession(slot, pkcs11.CKF_SERIAL_SESSION|pkcs11.CKF_RW_SESSION); err != nil {
+		return 0, err
+	} else {
+		return session, nil
 	}
-	return &PKCS11Session{ctx, session}, nil
-}
-
-// Close closes the session.
-func (session *PKCS11Session) Close() {
-	session.Ctx.CloseSession(session.Handle)
-}
-
-// Get returns requested resource pool by slot id
-func (p *sessionPool) Get(slot uint) *pools.ResourcePool {
-	p.m.RLock()
-	defer p.m.RUnlock()
-	return p.pool[slot]
-}
-
-// Put stores new resource pool into the pool if the requested slot is free
-func (p *sessionPool) PutIfAbsent(slot uint, pool *pools.ResourcePool) error {
-	p.m.Lock()
-	defer p.m.Unlock()
-	if _, ok := p.pool[slot]; ok {
-		return errSlotBusy
-	}
-	p.pool[slot] = pool
-	return nil
 }
 
 // Run a function with a session
 //
 // setupSessions must have been called for the slot already, otherwise
-// an error will be returned.
-func withSession(slot uint, f func(session *PKCS11Session) error) error {
-	sessionPool := pool.Get(slot)
-	if sessionPool == nil {
-		return fmt.Errorf("crypto11: no session for slot %d", slot)
+// there will be a panic.
+func withSession(slot uint, f func(session pkcs11.SessionHandle) error) error {
+	var session pkcs11.SessionHandle
+	var err error
+	sessionPool := sessionPools[slot]
+	select {
+	case session = <-sessionPool:
+		// nop
+	default:
+		if session, err = newSession(slot); err != nil {
+			return err
+		}
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), newSessionTimeout)
-	defer cancel()
-
-	session, err := sessionPool.Get(ctx)
-	if err != nil {
-		return err
-	}
-	defer sessionPool.Put(session)
-
-	return f(session.(*PKCS11Session))
-}
-
-// Ensures that sessions are setup.
-func ensureSessions(ctx* pkcs11.Ctx, slot uint) error {
-	if err := setupSessions(ctx, slot); err != nil && err != errSlotBusy {
-		return err
-	}
-	return nil
+	defer func() {
+		// TODO better would be to close the session if the pool is full
+		sessionPool <- session
+	}()
+	return f(session)
 }
 
 // Create the session pool for a given slot if it does not exist
 // already.
-func setupSessions(ctx* pkcs11.Ctx, slot uint) error {
-	return pool.PutIfAbsent(slot, pools.NewResourcePool(
-		func() (pools.Resource, error) {
-			return newSession(ctx, slot)
-		},
-		maxSessions,
-		maxSessions,
-		idleTimeout,
-	))
-}
-
-// Releases a sessions specific to the requested slot if present.
-func (p *sessionPool) closeSessions(slot uint) error {
-	p.m.Lock()
-	defer p.m.Unlock()
-
-	rp, ok := p.pool[slot]
-	if !ok {
-		return errPoolNotFound
+func setupSessions(slot uint, max int) error {
+	sessionPoolMutex.Lock()
+	defer sessionPoolMutex.Unlock()
+	if max <= 0 {
+		max = 1024 // could be configurable
 	}
-
-	rp.Close()
-	delete(p.pool, slot)
-
+	if _, ok := sessionPools[slot]; !ok {
+		sessionPools[slot] = make(chan pkcs11.SessionHandle, max)
+	}
 	return nil
 }


### PR DESCRIPTION
For [bug 1488862](https://bugzilla.mozilla.org/show_bug.cgi?id=1488862) debugging CloudHSM failures in stage running 2.2.2, we see requests within 30 seconds of server start or a previous successful request succeed, but those more than 30 seconds later fail with `..."Fields":{"code":500,"msg":"signing failed with error: mar: failed to finalize signature: pkcs11: 0x82: CKR_OBJECT_HANDLE_INVALID","rid":...` 

While we haven't seen `pkcs11: 0x101: CKR_USER_NOT_LOGGED_IN` errors in stage, this still appears to be due to: https://github.com/ThalesIgnite/crypto11/issues/9

The HSM dev instance we successfully load tested earlier is on commit 2210ea80470825094edf8235b35f9565c7940555, so this PR reverts crypto11 to that commit (regression could be further narrowed down to https://github.com/mozilla-services/autograph/compare/2210ea80470825094edf8235b35f9565c7940555...2.2.2 too)

We'll need to pin this version if we switch to vgo for #115 too.

r? @jvehent or @ajvb if you're not swamped