### PR TITLE
Add RSA 4096 key to test MAR sig alg 2

### DIFF
--- a/autograph.softhsm.yaml
+++ b/autograph.softhsm.yaml
@@ -17,6 +17,11 @@ signers:
       type: mar
       # label of the key in the hsm
       privatekey: testrsa2048
+    - id: testmar2
+      # 2 for SignatureAlgorithmID 2
+      type: mar
+      # label of the key in the hsm
+      privatekey: testrsa4096
     - id: testmarecdsa
       type: mar
       # label of the key in the hsm
@@ -27,6 +32,7 @@ authorizations:
       key: fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu
       signers:
           - testmar
+          - testmar2
           - testmarecdsa
 monitoring:
     key: 19zd4w3xirb5syjgdx8atq6g91m03bdsmzjifs2oddivswlu9qs

--- a/tools/softhsm/genkeys.go
+++ b/tools/softhsm/genkeys.go
@@ -39,6 +39,12 @@ func main() {
 	}
 	fmt.Printf("RSA Key: %+v\n", rsakey)
 
+	rsakey2, err := crypto11.GenerateRSAKeyPairOnSlot(slots[0], []byte("testrsa2048"), []byte("testrsa4096"), 4096)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("RSA 4096 Key: %+v\n", rsakey2)
+
 	ecdsakey, err := crypto11.GenerateECDSAKeyPairOnSlot(slots[0], []byte("testecdsap384"), []byte("testecdsap384"), elliptic.P384())
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Adds an E2E CI test for mar sig. alg 2