### PR TITLE
signer: remove MD5 hashes from XPI manifest entires and sig files

### DIFF
--- a/signer/xpi/jar.go
+++ b/signer/xpi/jar.go
@@ -3,7 +3,6 @@ package xpi
 import (
 	"archive/zip"
 	"bytes"
-	"crypto/md5"
 	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/base64"
@@ -29,10 +28,7 @@ func makePKCS7Manifest(input []byte, metafiles []Metafile) (manifest []byte, err
 
 	mw := bytes.NewBuffer(manifest)
 	for _, f := range metafiles {
-		fmt.Fprintf(mw, "Name: %s\nDigest-Algorithms: MD5 SHA1 SHA256\n", f.Name)
-		h0 := md5.New()
-		h0.Write(f.Body)
-		fmt.Fprintf(mw, "MD5-Digest: %s\n", base64.StdEncoding.EncodeToString(h0.Sum(nil)))
+		fmt.Fprintf(mw, "Name: %s\nDigest-Algorithms: SHA1 SHA256\n", f.Name)
 		h1 := sha1.New()
 		h1.Write(f.Body)
 		fmt.Fprintf(mw, "SHA1-Digest: %s\n", base64.StdEncoding.EncodeToString(h1.Sum(nil)))
@@ -69,7 +65,7 @@ func makeJARManifest(input []byte) (manifest []byte, err error) {
 		return
 	}
 
-	// generate the manifest file by calculating an MD5, sha1, and sha256 hash for each zip entry
+	// generate the manifest file by calculating a sha1 and sha256 hashes for each zip entry
 	mw := bytes.NewBuffer(manifest)
 	manifest = []byte(fmt.Sprintf("Manifest-Version: 1.0\n\n"))
 
@@ -90,10 +86,7 @@ func makeJARManifest(input []byte) (manifest []byte, err error) {
 		if err != nil {
 			return manifest, err
 		}
-		fmt.Fprintf(mw, "Name: %s\nDigest-Algorithms: MD5 SHA1 SHA256\n", f.Name)
-		h0 := md5.New()
-		h0.Write(data)
-		fmt.Fprintf(mw, "MD5-Digest: %s\n", base64.StdEncoding.EncodeToString(h0.Sum(nil)))
+		fmt.Fprintf(mw, "Name: %s\nDigest-Algorithms: SHA1 SHA256\n", f.Name)
 		h1 := sha1.New()
 		h1.Write(data)
 		fmt.Fprintf(mw, "SHA1-Digest: %s\n", base64.StdEncoding.EncodeToString(h1.Sum(nil)))
@@ -111,9 +104,6 @@ func makeJARManifest(input []byte) (manifest []byte, err error) {
 func makeJARSignatureFile(manifest []byte) (sigfile []byte, err error) {
 	sw := bytes.NewBuffer(sigfile)
 	fmt.Fprint(sw, "Signature-Version: 1.0\n")
-	h0 := md5.New()
-	h0.Write(manifest)
-	fmt.Fprintf(sw, "MD5-Digest-Manifest: %s\n", base64.StdEncoding.EncodeToString(h0.Sum(nil)))
 	h1 := sha1.New()
 	h1.Write(manifest)
 	fmt.Fprintf(sw, "SHA1-Digest-Manifest: %s\n", base64.StdEncoding.EncodeToString(h1.Sum(nil)))

--- a/signer/xpi/jar_test.go
+++ b/signer/xpi/jar_test.go
@@ -228,29 +228,25 @@ var unsignedBootstrap = []byte("\x50\x4B\x03\x04\x14\x00\x02\x00\x08\x00\x62\x69
 var unsignedBootstrapManifest = []byte(`Manifest-Version: 1.0
 
 Name: bootstrap.js
-Digest-Algorithms: MD5 SHA1 SHA256
-MD5-Digest: X4SEiQxO/fb3xSwAxbPIqw==
+Digest-Algorithms: SHA1 SHA256
 SHA1-Digest: RBQlzx98wYTuqEZZQKdav2H9Gag=
 SHA256-Digest: m186SAMS1n5Q8hOWNE6+vGOXxfxH45sAzDlji1E3qaI=
 
 Name: install.rdf
-Digest-Algorithms: MD5 SHA1 SHA256
-MD5-Digest: VbDrXLNnz3Lrnbk9Vy7/kQ==
+Digest-Algorithms: SHA1 SHA256
 SHA1-Digest: WRohqAlB/BhgUjM2RDI+pTV6ihQ=
 SHA256-Digest: LHIIuDZ3MKJG7tRhByz81k3UThgCjakBe0JxGZhxF9w=
 
 Name: test.txt
-Digest-Algorithms: MD5 SHA1 SHA256
-MD5-Digest: tT4aaxDCqRgFrpVHhe//Wg==
+Digest-Algorithms: SHA1 SHA256
 SHA1-Digest: 8mPWZnQPS9arW9Tu/vmC+JHgnYA=
 SHA256-Digest: 8usFS0xIHQV5njGLlVZofDfPreYQP4+qWMMvYF5fvNw=
 
 `)
 
 var unsignedBootstrapSignatureFile = []byte(`Signature-Version: 1.0
-MD5-Digest-Manifest: JlV8uIxNHuMBFeAhiJ/WUw==
-SHA1-Digest-Manifest: 8uVi/q2jMt4M3wfhpT22pG+bNLA=
-SHA256-Digest-Manifest: 5uUrN1jNcf9D0rMUxMXBSi3bCSSJjumWEFQZI+C4siw=
+SHA1-Digest-Manifest: hWJRXCpbMGcu7pD6jEH4YibF5KQ=
+SHA256-Digest-Manifest: DEeZKUfwfIdRBxyA9IkCXkUaYaTn6mWnljQtELTy4cg=
 
 `)
 


### PR DESCRIPTION
Per email thread with dveditz, these only applied to "ancient
pre-legacy add-on signing" and are now bloat.

reverts:

https://github.com/mozilla-services/autograph/pull/121
https://github.com/mozilla-services/autograph/pull/128

r? @jvehent 