### PR TITLE
set Read and Write timeouts for http.Server

### DIFF
--- a/main.go
+++ b/main.go
@@ -165,7 +165,9 @@ func run(conf configuration, listen string, authPrint, debug bool) {
 	router.HandleFunc("/sign/hash", ag.handleSignature).Methods("POST")
 
 	server := &http.Server{
-		Addr: listen,
+		ReadTimeout:  60 * time.Second,
+		WriteTimeout: 60 * time.Second,
+		Addr:         listen,
 		Handler: handleMiddlewares(
 			router,
 			setRequestID(),


### PR DESCRIPTION
These are obviously pretty significant timeouts, I just picked 60 seconds arbitrarily.

This is because of the following doc from the stdlib: "ReadTimeout is the maximum duration for reading the entire request, including the body."

We reverse proxy with nginx in production, so this isn't a huge factor, but if autograph is exposed without a reverse proxy these timeouts will help protect against a nasty set of issues. See this blog post for more info: https://blog.cloudflare.com/exposing-go-on-the-internet/.