### PR TITLE
add skip hsm arg

### DIFF
--- a/authorize_test.go
+++ b/authorize_test.go
@@ -174,7 +174,7 @@ func TestAddDuplicateAuthorization(t *testing.T) {
 		}
 	}()
 	tmpag := newAutographer(1)
-	tmpag.addSigners(conf.Signers)
+	tmpag.addSigners(conf.Signers, false)
 	tmpag.addAuthorizations(authorizations)
 }
 
@@ -183,7 +183,7 @@ func TestAddDuplicateAuthorization(t *testing.T) {
 func TestHawkTimestampSkewFail(t *testing.T) {
 	t.Parallel()
 	tmpag := newAutographer(1)
-	tmpag.addSigners(conf.Signers)
+	tmpag.addSigners(conf.Signers, false)
 	tmpag.addAuthorizations([]authorization{
 		{
 			ID:  "alice",

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -24,6 +24,8 @@ HAWK nonce cache size to prevent replay attacks:
 Use flag `-p` to provide an alternate port and override any port
 specified in the config.
 
+Use flag `--skip-hsm` to ignore "key not found" errors loading a
+config. Use to test locally without an HSM.
 
 Statsd
 ------

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -411,7 +411,7 @@ func TestAuthWithoutSigner(t *testing.T) {
 		},
 	}
 	tmpag := newAutographer(1)
-	tmpag.addSigners(conf.Signers)
+	tmpag.addSigners(conf.Signers, false)
 	tmpag.addAuthorizations(authorizations)
 	tmpag.makeSignerIndex()
 	if _, ok := tmpag.signerIndex[authorizations[0].ID+"+"]; ok {

--- a/main_test.go
+++ b/main_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 	}
 	log.Printf("configuration: %+v\n", conf)
 	ag = newAutographer(1)
-	err = ag.addSigners(conf.Signers)
+	err = ag.addSigners(conf.Signers, false)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -200,7 +200,7 @@ signers:
 	// initialize signers from the configuration
 	// and store them into the autographer handler
 	dupag := newAutographer(conf.Server.NonceCacheSize)
-	err = dupag.addSigners(conf.Signers)
+	err = dupag.addSigners(conf.Signers, false)
 	if err == nil {
 		t.Fatalf("should have failed with duplicate signers but didn't")
 	}
@@ -260,7 +260,7 @@ authorizations:
 	// initialize signers from the configuration
 	// and store them into the autographer handler
 	dupag := newAutographer(conf.Server.NonceCacheSize)
-	err = dupag.addSigners(conf.Signers)
+	err = dupag.addSigners(conf.Signers, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -303,5 +303,21 @@ func TestPortOverride(t *testing.T) {
 	_, listen, _, _ := parseArgsAndLoadConfig([]string{"-p", "8080"})
 	if listen != expected {
 		t.Errorf("expected listen %s got %s", expected, listen)
+	}
+}
+
+func TestSkipHSMDefault(t *testing.T) {
+	expected := true
+	conf, _, _, _ := parseArgsAndLoadConfig([]string{})
+	if conf.isHsmEnabled != expected {
+		t.Errorf("expected skipHSM %v got %v", expected, conf.isHsmEnabled)
+	}
+}
+
+func TestSkipHSMOverride(t *testing.T) {
+	expected := false
+	conf, _, _, _ := parseArgsAndLoadConfig([]string{"-p", "8080", "--skip-hsm"})
+	if conf.isHsmEnabled != expected {
+		t.Errorf("expected skipHSM %v got %v", expected, conf.isHsmEnabled)
 	}
 }


### PR DESCRIPTION
refs: #167 

Functional Tests:

on a config with an HSM key run in an env without the HSM:

- [x] with `--skip-hsm` is passed, it loads the other signers and starts the server

e.g. w/ the hsm stage config it logs:

```
{"Timestamp":1542117777493603149,"Time":"2018-11-13T14:02:57Z","Type":"app.log","Logger":"autograph","Hostname":"gguthe-ThinkPad-X1-Carbon-6th","EnvVersion":"2.0","Pid":22277,"Severity":6,"Fields":{"msg":"Skipping loading the HSM config"}}                                                 
{"Timestamp":1542117777493723705,"Time":"2018-11-13T14:02:57Z","Type":"app.log","Logger":"autograph","Hostname":"gguthe-ThinkPad-X1-Carbon-6th","EnvVersion":"2.0","Pid":22277,"Severity":6,"Fields":{"msg":"Statsd enabled at 127.0.0.1:8125 with namespace autograph."}}                            
{"Timestamp":1542117777533350912,"Time":"2018-11-13T14:02:57Z","Type":"app.log","Logger":"autograph","Hostname":"gguthe-ThinkPad-X1-Carbon-6th","EnvVersion":"2.0","Pid":22277,"Severity":6,"Fields":{"msg":"Skipping signer \"hwine_mar\" from HSM"}}   
...             
```

- [x] when `--skip-hsm` is not passed, it fails to load the HSM signer and start the server

e.g. w/ the hsm stage config it logs:

```
2018/11/13 09:03:41 Could not open PKCS#11 library: /opt/cloudhsm/lib/libcloudhsm_pkcs11.so
{"Timestamp":1542117821026627388,"Time":"2018-11-13T14:03:41Z","Type":"app.log","Logger":"autograph","Hostname":"gguthe-ThinkPad-X1-Carbon-6th","EnvVersion":"2.0","Pid":22381,"Severity":2,"Fields":{"msg":"crypto11: could not open PKCS#11"}}
```

r? @milescrabill 
