### PR TITLE
signer: change apk signer to default to not compressing files

### DIFF
--- a/signer/apk/apk.go
+++ b/signer/apk/apk.go
@@ -261,7 +261,7 @@ func GetOptions(input interface{}) (options Options, err error) {
 // GetDefaultOptions returns default options of the signer
 func (s *APKSigner) GetDefaultOptions() interface{} {
 	return Options{
-		ZIP:         ZIPMethodCompressAll,
+		ZIP:         ZIPMethodCompressPassthrough,
 		PKCS7Digest: "SHA256",
 	}
 }


### PR DESCRIPTION
refs: https://bugzilla.mozilla.org/show_bug.cgi?id=1506598 https://github.com/mozilla-releng/signingscript/pull/88/

Changes the default zip option to "passthrough", since we want to make "passthrough" the default for new apps and eventually deprecate the compress all option.

Apps using signingscript and "passthrough" will be unaffected. Before deploying with this change, I'll need to change apps using the current default to explicitly use zip option "all" in their config.

r? @jvehent

cc @JohanLorenzo once this is deployed everywhere we can clean up signingscript a bit.