### PR TITLE
signer: remove the sleep populating rsa keys for xpi signing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,4 +98,10 @@ generate:
 dummy-statsd:
 	nc -kluvw 0 localhost 8125
 
-.PHONY: all dummy-statsd test generate vendor
+softhsm-setup:
+	mkdir -p /var/lib/softhsm/tokens
+	softhsm2-util --init-token --slot 0 --label test --pin 0000 --so-pin 0000
+	go run tools/softhsm/genkeys.go
+
+
+.PHONY: all dummy-statsd softhsm-setup test generate vendor

--- a/autograph.softhsm.yaml
+++ b/autograph.softhsm.yaml
@@ -26,6 +26,112 @@ signers:
       type: mar
       # label of the key in the hsm
       privatekey: testecdsap384
+    - id: webextensions-rsa
+      type: xpi
+      # The signing parameters for each type of add-on are
+      # 'add-on' are signed with the OU 'Production' and the provided ID
+      # 'extension' are signed with the OU 'Mozilla Extensions' and the provided ID
+      # 'system add-on' are signed with the OU 'Mozilla Components' and the provided ID
+      # 'hotfix' are signed with the OU 'Production' and the ID 'firefox-hotfix@mozilla.org'
+      mode: add-on
+      certificate: |
+          -----BEGIN CERTIFICATE-----
+          MIIH0zCCBbugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBvDELMAkGA1UEBhMCVVMx
+          CzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRwwGgYDVQQKExNB
+          bGxpem9tIENvcnBvcmF0aW9uMSAwHgYDVQQLExdBbGxpem9tIEFNTyBEZXZlbG9w
+          bWVudDEYMBYGA1UEAxMPZGV2LmFtby5yb290LmNhMS4wLAYJKoZIhvcNAQkBFh9m
+          b3hzZWMrZGV2YW1vcm9vdGNhQG1vemlsbGEuY29tMB4XDTE3MDMyMTIzNDQwNFoX
+          DTI3MDMxOTIzNDQwNFowgbwxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQG
+          A1UEBxMNTW91bnRhaW4gVmlldzEcMBoGA1UEChMTQWxsaXpvbSBDb3Jwb3JhdGlv
+          bjEgMB4GA1UECxMXQWxsaXpvbSBBTU8gRGV2ZWxvcG1lbnQxGDAWBgNVBAMTD2Rl
+          di5hbW8ucm9vdC5jYTEuMCwGCSqGSIb3DQEJARYfZm94c2VjK2RldmFtb3Jvb3Rj
+          YUBtb3ppbGxhLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAMdX
+          5soUuvWnkVHRHN5BKByrgpuU3QioE8SNT7BwRFeqbOySdvu5ecQAdNUoRbRyFmNB
+          ety2rQM9qw6y8eSe9fufIgrv1sg/xj7vweLmuC8Ob+zo5/iwRQw4JUdXnDjwX3W0
+          auh0QRYfxWGK3hVrP9j1zIJk/yRBornCvXTtn8C/hVSE/PWc6CuV8vTcpyj+TPni
+          Lvulq17NdlX5qgUdn1yougJxnznkwnoIaBYLdAyZJJIUEomiEIxfabjnh8rfSMIw
+          AqmslrC8F73yo4JrCqJPt1ipggfpO3ZAjlEoTMcTUgyqR8B35GyuywWR0XrkJV7N
+          A7BM1qNjLb2to0XQSrGyWA7uPw88LuVk2aUPDE5uNK5Kv//+SGChUn2fDZTsjj3J
+          KY7f39JVwh/nk8ZkApplne8fKPoknW7er2R+rejyBx1+fJjLegKQsATpgKz4LRf4
+          ct34oWSV6QXrZ/KKW+frWoHncy8C+UnCC3cDBKs272yqOvBoGMQTrF5oMn8i/Rap
+          gBbBdwysdJXb+buf/+ZS0PUt7avKFIlXqCNZjG3xotBsTuCL5zAoVKoXJW1FwrcZ
+          pveQuishKWNf9Id+0HaBdDp/vlbrTwXD1zsxfYvYw8wI7NkNO3TQBni5iyG4B1wh
+          oR+Z5AebWuJqVnsJyjPakNiuhKNsO/xTa4TF/ymfAgMBAAGjggHcMIIB2DAPBgNV
+          HRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjAWBgNVHSUBAf8EDDAKBggrBgEF
+          BQcDAzAdBgNVHQ4EFgQU2LRpqTdeQ1QlBWNA6fYAqHdpSaUwgekGA1UdIwSB4TCB
+          3oAU2LRpqTdeQ1QlBWNA6fYAqHdpSaWhgcKkgb8wgbwxCzAJBgNVBAYTAlVTMQsw
+          CQYDVQQIEwJDQTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEcMBoGA1UEChMTQWxs
+          aXpvbSBDb3Jwb3JhdGlvbjEgMB4GA1UECxMXQWxsaXpvbSBBTU8gRGV2ZWxvcG1l
+          bnQxGDAWBgNVBAMTD2Rldi5hbW8ucm9vdC5jYTEuMCwGCSqGSIb3DQEJARYfZm94
+          c2VjK2RldmFtb3Jvb3RjYUBtb3ppbGxhLmNvbYIBATBCBglghkgBhvhCAQQENRYz
+          aHR0cHM6Ly9jb250ZW50LXNpZ25hdHVyZS5kZXYubW96YXdzLm5ldC9jYS9jcmwu
+          cGVtME4GCCsGAQUFBwEBBEIwQDA+BggrBgEFBQcwAoYyaHR0cHM6Ly9jb250ZW50
+          LXNpZ25hdHVyZS5kZXYubW96YXdzLm5ldC9jYS9jYS5wZW0wDQYJKoZIhvcNAQEL
+          BQADggIBALqVt54WTkxD5U5fHPRUSZA9rFigoIcrHNrq+gTDd057cBDUWNc0cEHV
+          qaP0zgzqD2bIhV/WWlfMDY3VnB8L2+Vjvu2CEt8/9Kh5x9IgBmZt5VUMuEdmQOyH
+          vA7lz3UI+jmUGcojtLsi+sf4kxDZh3QB3T/wGiHg+K7vXnY7GWEy1Cjfwk/dvbT2
+          ODTb5B3SPGsh75VmfzFGgerzsS71LN4FYBRUklLe8ozqKF8r/jGE2vfDR1Cy09pN
+          oR9ti+zaBiEtMlWJjxYrv7HvuoDR9xLmPxyV6gQbo6NnbudkpNdg5LhbY3WV1IgL
+          TnwJ7aHXgzOZ3w/VsSctg4beZZgYnr81vLKyefWJH1VzCe5XTgwXC1R/afGiVJ0P
+          hA1+T4My9oTaQBsiNYA2keXKJbTKerMTupoLgV/lJjxfF5BfQiy9NL18/bzxqf+J
+          7w4P/4oHt3QCdISAIhlG4ttXfRR8oz6obAb6QYdCf3x9b2/3UXKd3UJ+gwchPjj6
+          InnLK8ig9scn4opVNkBkjlMRsq1yd017eQzLSirpKj3br69qyLoyb/nPNJi7bL1K
+          bf6m5mF5GmKR+Glvq74O8rLQZ3a75v6H+NwOqAlZnWSJmC84R2HHsHPBw+2pExJT
+          E5bRcttRlhEdN4NJ2vWJnOH0DENHy6TEwACINJVx6ftucfPfvOxI
+          -----END CERTIFICATE-----
+      privatekey: |
+          -----BEGIN PRIVATE KEY-----
+          MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQDHV+bKFLr1p5FR
+          0RzeQSgcq4KblN0IqBPEjU+wcERXqmzsknb7uXnEAHTVKEW0chZjQXrctq0DPasO
+          svHknvX7nyIK79bIP8Y+78Hi5rgvDm/s6Of4sEUMOCVHV5w48F91tGrodEEWH8Vh
+          it4Vaz/Y9cyCZP8kQaK5wr107Z/Av4VUhPz1nOgrlfL03Kco/kz54i77patezXZV
+          +aoFHZ9cqLoCcZ855MJ6CGgWC3QMmSSSFBKJohCMX2m454fK30jCMAKprJawvBe9
+          8qOCawqiT7dYqYIH6Tt2QI5RKEzHE1IMqkfAd+RsrssFkdF65CVezQOwTNajYy29
+          raNF0EqxslgO7j8PPC7lZNmlDwxObjSuSr///khgoVJ9nw2U7I49ySmO39/SVcIf
+          55PGZAKaZZ3vHyj6JJ1u3q9kfq3o8gcdfnyYy3oCkLAE6YCs+C0X+HLd+KFklekF
+          62fyilvn61qB53MvAvlJwgt3AwSrNu9sqjrwaBjEE6xeaDJ/Iv0WqYAWwXcMrHSV
+          2/m7n//mUtD1Le2ryhSJV6gjWYxt8aLQbE7gi+cwKFSqFyVtRcK3Gab3kLorISlj
+          X/SHftB2gXQ6f75W608Fw9c7MX2L2MPMCOzZDTt00AZ4uYshuAdcIaEfmeQHm1ri
+          alZ7Ccoz2pDYroSjbDv8U2uExf8pnwIDAQABAoICADf7eqgD3GGC1q/Yfzf3qnEq
+          xXo1+0EkGrEXUmrljHvmM8LYeyvEcerWifkW30SGybzENeHoN3xyhCiTnpUrAz/P
+          9/qEUphYOK+SG6xCSTWF427wFb1km2+MEQQRGaFv+A8RRPjVNTYmZAM5wZbYUMz4
+          cp+oB3NCL5Xll9lPpo61+pa65mN/1j/vU5TqptM/X5TJrZIke5UbNIF+pP3czNVz
+          2RE4oZPbp7YnyDtwqf2jwH55vp8CcY1KemFgPGWAAWnvm7/U5Vjq6ewBSWQl9Y2R
+          v5bZu9fG61kRViZ6n91EksVVyOLHiNHw4LlGs0LE8a3G+6M2YQzvnHfpXLINhfwU
+          SZ6BWAJdknVsu6eesYoC08+nyikkq/A3BVD65pT5C9VsmUPbqqpGSYZmAuFgsf9m
+          zdyKVH4fOPx82DqSZEHZBojg3s5K141DmPp6o0OBX8Ydgfkg2sWXuNi/noBDvh9O
+          FXWN2IcgK0dET3pX4xFei0QuZgglDp3VyVVSCSUPsOwecZ2XTjtBZPCQVpp3r+QV
+          LyecFudQ94Ki/0R+M4CrE/mPApDvq+pTjYKFZ10YWtGIdguXq5BVZIMZfZzwIPWN
+          HdoaFnXRTXTlR4pLIM2nlOvyZmSMo0x6nzUMVGdv4Km9pxi6ZKAgAt4DkbCF9mt0
+          QG8RpGJhiIch4kgKFmqxAoIBAQDw4X9Fp9t4f2UiessUDYxLyAtq4acu4ahup5Eb
+          vlDZPf9gInvz5q9aFHtYgtjTlH449f+EB4isKQscVMysgrJK+7z1IXXMm0sg44wT
+          F4oV+kvg3KpAridRHyE456RvCPqXYzty6ywJ9B7Zf2oCvd40JUOTm8z11K4COLut
+          rFIW/24PJA1CWudY/EgzD164k6379On0KryA77iKEZMUztBfHm/bdO8J/zmp7g+E
+          FS2TCBzR4LpN0uhBwp9wh4rVr74LrPDnQJVZKgeFd24UHEtmcVprAFNUexb2yy1s
+          vxnHsRPmv5eF7ED1Wlz2K+7LUWqibYOrjeCrS85+CEcey0ApAoIBAQDT2vmbHosb
+          Qr6ZENt6UX6n0RF8i4g3G4qhucr5hEMQs4H2J8SrUM68QT0GVY0GoDW6f79Pcyr0
+          W1tm7qbAOm1Iv4uNYVL1qgpq1GnD5qpWSACGsVSE3OGELlNaVz8fgVdz6zT+rU2A
+          tp2t795UlrvaLgFI4wITqJF3LoTfy2MZu8JYCzlKM5pZksmEmJfR0RDAot2grtD3
+          H5A+PZfUIZ/8BhmdaOAv5i647unfVF6UpPYejZ0rb67oEazxdeIHK3aD5AjurdsO
+          UpW/PMwsbaltp4iI7hvUfRX7Afb5fPXIhv9pHh1xWYl3djUNWmFoiMMP4tuxpOBo
+          y+T4maQaiDSHAoIBADrlZ9EIMclMnNXJYE4O4fbFesUvV0lHM3+ayQgXiH0Vg5Nl
+          2xjPlqBX0bDajVluPU6AF3GYxfoSLv1GXqTvb9iVpKXrAHp+nef0uxMP9ltZT6Qz
+          UA1wh3x2OBFJ0hK0B1FsmeSHS8VDQye615jEA8iMM/GrbnnM/p7ccEcOkyO8YJSj
+          I/rNbzN6u8yAPZCzyx6Hy4w/xsdf1acslOHJj3kyX/cwqCGxnc/GvVR2OSZyHVnT
+          sLnGj7NEeudwvKlyxuzj5CMmz111wVEI2olgQa9Sl+EBu140mnDNTNYCA7OnwE3z
+          GoFMOrXC2mf2ZfSge4orbL5Nellnt51pOLp2x8ECggEBALM8Mazw/FOF9mbdgjJM
+          PFGSaa7rBcVJwdHttDHBmlPI6wzsvFEMPru6nfx76KJQbORqK9r13sN5fyzof59m
+          TwsbMt/cFSnOQJ39M7YPstDofbl20cDOduUzpEVsRvVKokhqGB3XVRiuZ1y+8WSz
+          Wh7OiTu3AwzKsrcYXkZQdnlRBq0iYcfLPKzHqUJLLzbOH9Q6djL5c8V/qLNfvNI1
+          2HqKVqV8Ex+zKJhBWRAe+x3bKnbS7MPQ6zNfsOdgCmhydwRCquPzpr7JU/PFZh+4
+          b31cHgFrIZR2d2AzW1XcSLzsqa2vUs2RKOIu2deAPaUI/66zCZeTnGBNEFza76Ga
+          1oUCggEAA38oXcnputwL103SeD8+uwHjtTf183Rucr+Ryqz6GymiWjlzELqu7TRd
+          yadAaNg9CuXmYS33Jtk/UNS0k9FvYqGTR+SBXIZr6nt9ZFd0SNlQkwkAQCsuekEs
+          nJlmUZax7DxXMgIHMKDboHZYM/MhgzEGSALmhU5LZ76MS17v3NEPxYpVHxjAotxW
+          g03HjWTltS8Bgt6u0KFTGJKEUcfwvWKZtjk5Fc1heZ49zh1nU3zo9C/h8iiijTy2
+          s/YksP6cxveae4b7soN4rD/vnfsmKcG+DnTf6B8Zbm6tI2TneYOfFSCryp+yDnaJ
+          PIDNiTxNecePOmrD+1ivAEXcoL+e1w==
+          -----END PRIVATE KEY-----
 
 authorizations:
     - id: alice
@@ -34,5 +140,6 @@ authorizations:
           - testmar
           - testmar2
           - testmarecdsa
+          - webextensions-rsa
 monitoring:
     key: 19zd4w3xirb5syjgdx8atq6g91m03bdsmzjifs2oddivswlu9qs

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -10,17 +10,20 @@ import (
 	"crypto"
 	"crypto/dsa"
 	"crypto/ecdsa"
+	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/pem"
 	"errors"
+	"io"
 	"fmt"
 	"math/big"
 	"regexp"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/ThalesIgnite/crypto11"
 )
 
@@ -99,6 +102,18 @@ func (cfg *Configuration) GetPrivateKey() (crypto.PrivateKey, error) {
 		return key, nil
 	}
 	return nil, fmt.Errorf("no suitable key found")
+}
+
+
+// GetRandReader returns the HSM rand reader when available and
+// otherwise returns the golang crypto/rand rand reader
+func (cfg *Configuration) GetRandReader() io.Reader {
+	if cfg.isHsmAvailable {
+		log.Infof("Using HSM RNG for XPI RSA key cache generation")
+		return new(crypto11.PKCS11RandReader)
+	} else {
+		return rand.Reader
+	}
 }
 
 // ParsePrivateKey takes a PEM blocks are returns a crypto.PrivateKey

--- a/signer/xpi/x509.go
+++ b/signer/xpi/x509.go
@@ -8,10 +8,10 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
-	"log"
 	"math/big"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/pkg/errors"
 	"go.mozilla.org/cose"
 )
@@ -37,13 +37,13 @@ func (s *XPISigner) getRsaKey(size int) (*rsa.PrivateKey, error) {
 			// it's theoritically impossible for this to happen
 			// because the end entity has the same key size has
 			// the signer, but we're paranoid so handling it
-			log.Printf("WARNING: xpi rsa cache returned a key of size %d when %d was requested", key.N.BitLen(), size)
+			log.Warnf("WARNING: xpi rsa cache returned a key of size %d when %d was requested", key.N.BitLen(), size)
 			return rsa.GenerateKey(s.rand, size)
 		}
 		return key, nil
 	case <-time.After(100 * time.Millisecond):
 		// generate a key if none available
-		log.Printf("xpi: RSA key cache exhausted. Generating a new key")
+		log.Warnf("xpi: rsa key cache exhausted. Generating a new key")
 		return rsa.GenerateKey(s.rand, size)
 	}
 }

--- a/signer/xpi/x509.go
+++ b/signer/xpi/x509.go
@@ -21,7 +21,7 @@ import (
 // the channel is full then it blocks
 func (s *XPISigner) populateRsaCache(size int) {
 	for {
-		key, err := rsa.GenerateKey(rand.Reader, size)
+		key, err := rsa.GenerateKey(s.rand, size)
 		if err != nil {
 			log.Fatalf("xpi.populateRsaCache: %v", err)
 		}

--- a/signer/xpi/x509.go
+++ b/signer/xpi/x509.go
@@ -44,6 +44,7 @@ func (s *XPISigner) getRsaKey(size int) (*rsa.PrivateKey, error) {
 		return key, nil
 	case <-time.After(100 * time.Millisecond):
 		// generate a key if none available
+		log.Printf("xpi: RSA key cache exhausted. Generating a new key")
 		return rsa.GenerateKey(rand.Reader, size)
 	}
 }

--- a/signer/xpi/x509.go
+++ b/signer/xpi/x509.go
@@ -17,8 +17,8 @@ import (
 	"go.mozilla.org/cose"
 )
 
-// every minute, add an rsa key to the cache. This will block if
-// the cache channel is already full, which is what we want anyway
+// populateRsaCache adds rsa keys of a given size to the cache until
+// the channel is full then it blocks
 func (s *XPISigner) populateRsaCache(size int) {
 	for {
 		key, err := rsa.GenerateKey(rand.Reader, size)
@@ -26,7 +26,6 @@ func (s *XPISigner) populateRsaCache(size int) {
 			log.Fatalf("xpi.populateRsaCache: %v", err)
 		}
 		s.rsaCache <- key
-		time.Sleep(time.Minute)
 	}
 }
 

--- a/signer/xpi/xpi.go
+++ b/signer/xpi/xpi.go
@@ -11,6 +11,7 @@ import (
 	"encoding/pem"
 	"strings"
 	"time"
+	"io"
 
 	"github.com/pkg/errors"
 	"go.mozilla.org/autograph/signer"
@@ -61,6 +62,10 @@ type XPISigner struct {
 	// the ID will be left blank and provided by the requester of the
 	// signature, but for hotfix signers, it is set to a specific value.
 	EndEntityCN string
+
+	// rand is random number generator. It should be
+	// cryptographically secure.
+	rand io.Reader
 
 	// rsa cache is used to pre-generate RSA private keys and speed up
 	// the signing process
@@ -129,6 +134,7 @@ func New(conf signer.Configuration) (s *XPISigner, err error) {
 		return nil, errors.Errorf("xpi: unknown signer mode %q, must be 'add-on', 'extension', 'system add-on' or 'hotfix'", conf.Mode)
 	}
 	s.Mode = conf.Mode
+	s.rand = conf.GetRandReader()
 
 	// If the private key is rsa, launch a go routine that populates
 	// the rsa cache with private keys of the same length

--- a/signer/xpi/xpi.go
+++ b/signer/xpi/xpi.go
@@ -134,7 +134,7 @@ func New(conf signer.Configuration) (s *XPISigner, err error) {
 	// the rsa cache with private keys of the same length
 	if issuerPrivateKey, ok := s.issuerKey.(*rsa.PrivateKey); ok {
 		s.rsaCache = make(chan *rsa.PrivateKey, 100)
-		go s.populateRsaCache(s.issuerKey.(*rsa.PrivateKey).N.BitLen())
+		go s.populateRsaCache(issuerPrivateKey.N.BitLen())
 
 		if issuerPrivateKey.N.BitLen() < 2048 {
 			return nil, errors.Errorf("xpi: issuer RSA key must be at least 2048 bits")


### PR DESCRIPTION
Per IRC discussion about XPI load testing.

I functional tested locally against softhsm2 to make sure it uses the HSM RNG. 

I assume we'll want to decide on whether to deploy to prod based on perf numbers from dev / stage.

We can also tweak:

* the timeout before generating our own rsa keys
* the number of goroutines populating the caching

r? @milescrabill 