### PR TITLE
Add cache metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
 - sudo apt-get install python3 python3-pip
 
 script:
+- make dummy-statsd &
 - make all
 - goveralls -coverprofile=coverage.out -service travis-ci -repotoken $COVERALLS_TOKEN
 

--- a/autograph.yaml
+++ b/autograph.yaml
@@ -90,7 +90,7 @@ signers:
         numgenerators: 2
         generatorsleepduration: 1m
         fetchtimeout: 100ms
-        monitorsamplerate: 1s
+        statssamplerate: 1s
       certificate: |
           -----BEGIN CERTIFICATE-----
           MIIH0zCCBbugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBvDELMAkGA1UEBhMCVVMx

--- a/autograph.yaml
+++ b/autograph.yaml
@@ -90,7 +90,7 @@ signers:
         numgenerators: 2
         generatorsleepduration: 1m
         fetchtimeout: 100ms
-        statssamplerate: 1s
+        statssamplerate: 1m
       certificate: |
           -----BEGIN CERTIFICATE-----
           MIIH0zCCBbugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBvDELMAkGA1UEBhMCVVMx

--- a/autograph.yaml
+++ b/autograph.yaml
@@ -90,6 +90,7 @@ signers:
         numgenerators: 2
         generatorsleepduration: 1m
         fetchtimeout: 100ms
+        monitorsamplerate: 1s
       certificate: |
           -----BEGIN CERTIFICATE-----
           MIIH0zCCBbugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBvDELMAkGA1UEBhMCVVMx

--- a/main.go
+++ b/main.go
@@ -261,8 +261,16 @@ func (a *autographer) addSigners(signerConfs []signer.Configuration, isHsmEnable
 		sids[signerConf.ID] = true
 		var (
 			s   signer.Signer
+			statsClient *signer.StatsClient
 			err error
 		)
+		if a.stats != nil {
+			statsClient, err = signer.NewStatsClient(signerConf, a.stats)
+			if statsClient == nil || err != nil {
+				return errors.Wrapf(err, "failed to add signer stats client %q or got back nil statsClient", signerConf.ID)
+			}
+		}
+
 		switch signerConf.Type {
 		case contentsignature.Type:
 			s, err = contentsignature.New(signerConf)
@@ -270,7 +278,7 @@ func (a *autographer) addSigners(signerConfs []signer.Configuration, isHsmEnable
 				return errors.Wrapf(err, "failed to add signer %q", signerConf.ID)
 			}
 		case xpi.Type:
-			s, err = xpi.New(signerConf, a.stats)
+			s, err = xpi.New(signerConf, statsClient)
 			if err != nil {
 				return errors.Wrapf(err, "failed to add signer %q", signerConf.ID)
 			}

--- a/main.go
+++ b/main.go
@@ -270,7 +270,7 @@ func (a *autographer) addSigners(signerConfs []signer.Configuration, isHsmEnable
 				return errors.Wrapf(err, "failed to add signer %q", signerConf.ID)
 			}
 		case xpi.Type:
-			s, err = xpi.New(signerConf)
+			s, err = xpi.New(signerConf, a.stats)
 			if err != nil {
 				return errors.Wrapf(err, "failed to add signer %q", signerConf.ID)
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -285,7 +285,12 @@ func TestStartMain(t *testing.T) {
 
 	os.Args = []string{"test-autograph", "-D"}
 	go main()
-	time.Sleep(200 * time.Millisecond)
+	if os.Getenv("CI") == "true" {
+		// sleep longer when running in continuous integration
+		time.Sleep(3 * time.Second)
+	} else {
+		time.Sleep(200 * time.Millisecond)
+	}
 	resp, err := http.Get("http://localhost:8000/__heartbeat__")
 	if err != nil {
 		t.Fatal(err)

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -43,9 +43,9 @@ type RSACacheConfig struct {
 	// before generating its own key
 	FetchTimeout time.Duration
 
-	// MonitorSampleRate is how frequently the monitor reports the
+	// StatsSampleRate is how frequently the monitor reports the
 	// cache size and capacity
-	MonitorSampleRate time.Duration
+	StatsSampleRate time.Duration
 }
 
 // Configuration defines the parameters of a signer

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -42,6 +42,10 @@ type RSACacheConfig struct {
 	// FetchTimeout is how long a consumer waits for the cache
 	// before generating its own key
 	FetchTimeout time.Duration
+
+	// MonitorSampleRate is how frequently the monitor reports the
+	// cache size and capacity
+	MonitorSampleRate time.Duration
 }
 
 // Configuration defines the parameters of a signer

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -15,7 +15,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"math/big"
 	"regexp"
@@ -23,6 +22,9 @@ import (
 	"time"
 
 	"github.com/ThalesIgnite/crypto11"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/DataDog/datadog-go/statsd"
 )
 
 // RSACacheConfig is a config for the RSAKeyCache
@@ -214,4 +216,52 @@ func parseDSAPKCS8PrivateKey(der []byte) (*dsa.PrivateKey, error) {
 		},
 		X: x,
 	}, nil
+}
+
+// StatsClient is a helper for sending statsd stats with the relevant
+// tags for the signer and error handling
+type StatsClient struct {
+	// signerTags is the
+	signerTags []string
+
+	// stats is the statsd client for reporting metrics
+	stats *statsd.Client
+}
+
+func NewStatsClient(signerConfig Configuration, stats *statsd.Client) (*StatsClient, error) {
+	if stats == nil {
+		return nil, errors.Errorf("xpi: statsd client is nil. Could not create StatsClient for signer %s", signerConfig.ID)
+	}
+	return &StatsClient{
+		stats: stats,
+		signerTags: []string{signerConfig.ID, signerConfig.Type, signerConfig.Mode},
+	}, nil
+}
+
+// SendGauge checks for a statsd client and when one is present sends
+// a statsd gauge with the given name, int value cast to float64, tags
+// for the signer, and sampling rate of 1
+func (s *StatsClient) SendGauge(name string, value int) {
+	if s.stats == nil {
+		log.Warnf("xpi: statsd client is nil. Could not send gauge %s with value %v", name, value)
+		return
+	}
+	err := s.stats.Gauge(name, float64(value), s.signerTags, 1)
+	if err != nil {
+		log.Warnf("Error sending gauge %s: %s", name, err)
+	}
+}
+
+// SendHistogram checks for a statsd client and when one is present
+// sends a statsd histogram with the given name, time.Duration value
+// cast to float64, tags for the signer, and sampling rate of 1
+func (s *StatsClient) SendHistogram(name string, value time.Duration) {
+	if s.stats == nil {
+		log.Warnf("xpi: statsd client is nil. Could not send histogram %s with value %s", name, value)
+		return
+	}
+	err := s.stats.Histogram(name, float64(value), s.signerTags, 1)
+	if err != nil {
+		log.Warnf("Error sending histogram %s: %s", name, err)
+	}
 }

--- a/signer/xpi/cose_test.go
+++ b/signer/xpi/cose_test.go
@@ -64,7 +64,7 @@ func TestGenerateCOSEKeyPair(t *testing.T) {
 
 	// initialize a signer
 	testcase := PASSINGTESTCASES[0]
-	s, err := New(testcase)
+	s, err := New(testcase, nil)
 	if err != nil {
 		t.Fatalf("signer initialization failed with: %v", err)
 	}
@@ -362,7 +362,7 @@ func TestVerifyCOSESignaturesErrs(t *testing.T) {
 		t.Fatalf("error unmarshaling invalidSigBytes %s", err)
 	}
 
-	s, err := New(PASSINGTESTCASES[0])
+	s, err := New(PASSINGTESTCASES[0], nil)
 	if err != nil {
 		t.Fatalf("signer initialization failed with: %v", err)
 	}
@@ -595,7 +595,7 @@ func TestVerifyCOSESignaturesErrs(t *testing.T) {
 func TestIssueCOSESignatureErrs(t *testing.T) {
 	t.Parallel()
 
-	signer, err := New(PASSINGTESTCASES[0])
+	signer, err := New(PASSINGTESTCASES[0], nil)
 	if err != nil {
 		t.Fatalf("signer initialization failed with: %v", err)
 	}

--- a/signer/xpi/x509.go
+++ b/signer/xpi/x509.go
@@ -119,6 +119,11 @@ func (s *XPISigner) generateIssuerEEKeyPair() (eeKey crypto.PrivateKey, eePublic
 			err = errors.Wrapf(err, "xpi: failed to generate rsa private key of size %d", size)
 			return
 		}
+		if eeKey == nil {
+			err = errors.Wrapf(err, "xpi: failed to get rsa private key of size %d", size)
+			return
+		}
+
 		newKey, ok := eeKey.(*rsa.PrivateKey)
 		if !ok {
 			err = errors.Wrapf(err, "xpi: failed to cast generated key of size %d to *rsa.PrivateKey", size)

--- a/signer/xpi/x509.go
+++ b/signer/xpi/x509.go
@@ -32,6 +32,9 @@ func (s *XPISigner) populateRsaCache(size int) {
 		if err != nil {
 			log.Fatalf("xpi: error generating RSA key for cache: %s", err)
 		}
+		if key == nil {
+			log.Fatal("xpi: error generated nil RSA key for cache")
+		}
 
 		s.SendHistogram("xpi.rsa_cache.gen_key_dur", time.Since(start))
 		s.rsaCache <- key

--- a/signer/xpi/x509.go
+++ b/signer/xpi/x509.go
@@ -119,7 +119,12 @@ func (s *XPISigner) generateIssuerEEKeyPair() (eeKey crypto.PrivateKey, eePublic
 			err = errors.Wrapf(err, "xpi: failed to generate rsa private key of size %d", size)
 			return
 		}
-		eePublicKey = eeKey.(*rsa.PrivateKey).Public()
+		newKey, ok := eeKey.(*rsa.PrivateKey)
+		if !ok {
+			err = errors.Wrapf(err, "xpi: failed to cast generated key of size %d to *rsa.PrivateKey", size)
+			return
+		}
+		eePublicKey = newKey.Public()
 	case *ecdsa.PrivateKey:
 		curve := s.issuerKey.(*ecdsa.PrivateKey).Curve
 		eeKey, err = ecdsa.GenerateKey(curve, rand.Reader)
@@ -127,7 +132,12 @@ func (s *XPISigner) generateIssuerEEKeyPair() (eeKey crypto.PrivateKey, eePublic
 			err = errors.Wrapf(err, "xpi: failed to generate ecdsa private key on curve %s", curve.Params().Name)
 			return
 		}
-		eePublicKey = eeKey.(*ecdsa.PrivateKey).Public()
+		newKey, ok := eeKey.(*ecdsa.PrivateKey)
+		if !ok {
+			err = errors.Wrapf(err, "xpi: failed to cast generated key on curve %s to *ecdsa.PrivateKey", curve)
+			return
+		}
+		eePublicKey = newKey.Public()
 	}
 	return
 }

--- a/signer/xpi/x509.go
+++ b/signer/xpi/x509.go
@@ -30,7 +30,7 @@ func (s *XPISigner) populateRsaCache(size int) {
 		start = time.Now()
 		key, err = rsa.GenerateKey(rand.Reader, size)
 		if err != nil {
-			log.Fatalf("xpi: error generating RSA key for cache:", err)
+			log.Fatalf("xpi: error generating RSA key for cache: %s", err)
 		}
 
 		s.SendHistogram("xpi.rsa_cache.gen_key_dur", time.Since(start))

--- a/signer/xpi/x509.go
+++ b/signer/xpi/x509.go
@@ -116,7 +116,7 @@ func (s *XPISigner) generateIssuerEEKeyPair() (eeKey crypto.PrivateKey, eePublic
 		size := s.issuerKey.(*rsa.PrivateKey).N.BitLen()
 		eeKey, err = s.getRsaKey(size)
 		if err != nil {
-			err = errors.Wrapf(err, "failed to generate rsa private key of size %d", size)
+			err = errors.Wrapf(err, "xpi: failed to generate rsa private key of size %d", size)
 			return
 		}
 		eePublicKey = eeKey.(*rsa.PrivateKey).Public()
@@ -124,7 +124,7 @@ func (s *XPISigner) generateIssuerEEKeyPair() (eeKey crypto.PrivateKey, eePublic
 		curve := s.issuerKey.(*ecdsa.PrivateKey).Curve
 		eeKey, err = ecdsa.GenerateKey(curve, rand.Reader)
 		if err != nil {
-			err = errors.Wrapf(err, "failed to generate ecdsa private key on curve %s", curve.Params().Name)
+			err = errors.Wrapf(err, "xpi: failed to generate ecdsa private key on curve %s", curve.Params().Name)
 			return
 		}
 		eePublicKey = eeKey.(*ecdsa.PrivateKey).Public()

--- a/signer/xpi/x509_test.go
+++ b/signer/xpi/x509_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestMakeEndEntity(t *testing.T) {
 	t.Parallel()
-	s, err := New(PASSINGTESTCASES[3])
+	s, err := New(PASSINGTESTCASES[3], nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/signer/xpi/xpi.go
+++ b/signer/xpi/xpi.go
@@ -155,12 +155,12 @@ func New(conf signer.Configuration, stats *statsd.Client) (s *XPISigner, err err
 		if issuerPrivateKey.N.BitLen() < 2048 {
 			return nil, errors.Errorf("xpi: issuer RSA key must be at least 2048 bits")
 		}
-		if conf.RSACacheConfig.MonitorSampleRate < 5*time.Millisecond {
-			log.Warnf("xpi: sampling rsa cache as rate of %s (less than 5ms)", conf.RSACacheConfig.MonitorSampleRate)
+		if conf.RSACacheConfig.StatsSampleRate < 5*time.Millisecond {
+			log.Warnf("xpi: sampling rsa cache as rate of %s (less than 5ms)", conf.RSACacheConfig.StatsSampleRate)
 		}
 		s.rsaCacheGeneratorSleepDuration = conf.RSACacheConfig.GeneratorSleepDuration
 		s.rsaCacheFetchTimeout = conf.RSACacheConfig.FetchTimeout
-		s.rsaCacheSizeSampleRate = conf.RSACacheConfig.MonitorSampleRate
+		s.rsaCacheSizeSampleRate = conf.RSACacheConfig.StatsSampleRate
 
 		s.rsaCache = make(chan *rsa.PrivateKey, conf.RSACacheConfig.NumKeys)
 		for i := 0; i < int(conf.RSACacheConfig.NumGenerators); i++ {

--- a/signer/xpi/xpi.go
+++ b/signer/xpi/xpi.go
@@ -323,6 +323,42 @@ func (s *XPISigner) signDataWithPKCS7(sigfile []byte, cn string, digest asn1.Obj
 	return p7sig, nil
 }
 
+// SendGauge checks for a client and when one is present sends a
+// statsd gauge with the given name, int value cast to
+// float64, tags for the signer, and sampling rate of 1
+func (s *XPISigner) SendGauge(name string, value int) {
+	if s.stats == nil {
+		log.Warnf("xpi: statsd client is nil. Could not send gauge %s with value %v", name, value)
+		return
+	}
+	var (
+		err        error
+		signerTags []string = []string{s.ID, s.Type, s.Mode}
+	)
+	err = s.stats.Gauge(name, float64(value), signerTags, 1)
+	if err != nil {
+		log.Warnf("Error sending gauge %s: %s", name, err)
+	}
+}
+
+// SendHistogram checks for a client and when one is present sends a
+// statsd histogram with the given name, time.Duration value cast to
+// float64, tags for the signer, and sampling rate of 1
+func (s *XPISigner) SendHistogram(name string, value time.Duration) {
+	if s.stats == nil {
+		log.Warnf("xpi: statsd client is nil. Could not send histogram %s with value %s", name, value)
+		return
+	}
+	var (
+		err        error
+		signerTags []string = []string{s.ID, s.Type, s.Mode}
+	)
+	err = s.stats.Histogram(name, float64(value), signerTags, 1)
+	if err != nil {
+		log.Warnf("Error sending histogram %s: %s", name, err)
+	}
+}
+
 // Options contains specific parameters used to sign XPIs
 type Options struct {
 	// ID is the add-on ID which is stored in the end-entity subject CN

--- a/signer/xpi/xpi.go
+++ b/signer/xpi/xpi.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-go/statsd"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"go.mozilla.org/autograph/signer"
@@ -81,11 +80,11 @@ type XPISigner struct {
 	rsaCacheSizeSampleRate time.Duration
 
 	// stats is the statsd client for reporting metrics
-	stats *statsd.Client
+	stats *signer.StatsClient
 }
 
 // New initializes an XPI signer using a configuration
-func New(conf signer.Configuration, stats *statsd.Client) (s *XPISigner, err error) {
+func New(conf signer.Configuration, stats *signer.StatsClient) (s *XPISigner, err error) {
 	s = new(XPISigner)
 	if conf.Type != Type {
 		return nil, errors.Errorf("xpi: invalid type %q, must be %q", conf.Type, Type)
@@ -321,42 +320,6 @@ func (s *XPISigner) signDataWithPKCS7(sigfile []byte, cn string, digest asn1.Obj
 		return nil, errors.Wrap(err, "xpi: cannot finish signing data")
 	}
 	return p7sig, nil
-}
-
-// SendGauge checks for a client and when one is present sends a
-// statsd gauge with the given name, int value cast to
-// float64, tags for the signer, and sampling rate of 1
-func (s *XPISigner) SendGauge(name string, value int) {
-	if s.stats == nil {
-		log.Warnf("xpi: statsd client is nil. Could not send gauge %s with value %v", name, value)
-		return
-	}
-	var (
-		err        error
-		signerTags []string = []string{s.ID, s.Type, s.Mode}
-	)
-	err = s.stats.Gauge(name, float64(value), signerTags, 1)
-	if err != nil {
-		log.Warnf("Error sending gauge %s: %s", name, err)
-	}
-}
-
-// SendHistogram checks for a client and when one is present sends a
-// statsd histogram with the given name, time.Duration value cast to
-// float64, tags for the signer, and sampling rate of 1
-func (s *XPISigner) SendHistogram(name string, value time.Duration) {
-	if s.stats == nil {
-		log.Warnf("xpi: statsd client is nil. Could not send histogram %s with value %s", name, value)
-		return
-	}
-	var (
-		err        error
-		signerTags []string = []string{s.ID, s.Type, s.Mode}
-	)
-	err = s.stats.Histogram(name, float64(value), signerTags, 1)
-	if err != nil {
-		log.Warnf("Error sending histogram %s: %s", name, err)
-	}
 }
 
 // Options contains specific parameters used to sign XPIs

--- a/signer/xpi/xpi.go
+++ b/signer/xpi/xpi.go
@@ -155,8 +155,8 @@ func New(conf signer.Configuration, stats *statsd.Client) (s *XPISigner, err err
 		if issuerPrivateKey.N.BitLen() < 2048 {
 			return nil, errors.Errorf("xpi: issuer RSA key must be at least 2048 bits")
 		}
-		if conf.RSACacheConfig.StatsSampleRate < 5*time.Millisecond {
-			log.Warnf("xpi: sampling rsa cache as rate of %s (less than 5ms)", conf.RSACacheConfig.StatsSampleRate)
+		if conf.RSACacheConfig.StatsSampleRate < 5*time.Second {
+			log.Warnf("xpi: sampling rsa cache as rate of %s (less than 5s)", conf.RSACacheConfig.StatsSampleRate)
 		}
 		s.rsaCacheGeneratorSleepDuration = conf.RSACacheConfig.GeneratorSleepDuration
 		s.rsaCacheFetchTimeout = conf.RSACacheConfig.FetchTimeout

--- a/signer/xpi/xpi_test.go
+++ b/signer/xpi/xpi_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-go/statsd"
 	"go.mozilla.org/autograph/signer"
 	"go.mozilla.org/pkcs7"
 )
@@ -29,7 +30,14 @@ func TestSignFile(t *testing.T) {
 		FetchTimeout:           100 * time.Millisecond,
 		MonitorSampleRate:      10 * time.Second,
 	}
-	s, err := New(testcase, nil)
+
+	statsdClient, err := statsd.NewBuffered("localhost:8135", 1)
+	if err != nil {
+		t.Fatalf("Error constructing statsdClient: %v", err)
+	}
+	statsdClient.Namespace = "test_autograph_stats_ns"
+
+	s, err := New(testcase, statsdClient)
 	if err != nil {
 		t.Fatalf("signer initialization failed with: %v", err)
 	}

--- a/signer/xpi/xpi_test.go
+++ b/signer/xpi/xpi_test.go
@@ -22,7 +22,7 @@ func TestSignFile(t *testing.T) {
 	input := unsignedBootstrap
 	// initialize a signer
 	testcase := PASSINGTESTCASES[0]
-	s, err := New(testcase)
+	s, err := New(testcase, nil)
 	if err != nil {
 		t.Fatalf("signer initialization failed with: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestSignData(t *testing.T) {
 	input := []byte("foobarbaz1234abcd")
 	for i, testcase := range PASSINGTESTCASES {
 		// initialize a signer
-		s, err := New(testcase)
+		s, err := New(testcase, nil)
 		if err != nil {
 			t.Fatalf("testcase %d signer initialization failed with: %v", i, err)
 		}
@@ -114,7 +114,7 @@ func TestSignDataAndVerifyWithOpenSSL(t *testing.T) {
 	input := []byte("foobarbaz1234abcd")
 
 	// init a signer
-	s, err := New(PASSINGTESTCASES[3])
+	s, err := New(PASSINGTESTCASES[3], nil)
 	if err != nil {
 		t.Fatalf("failed to initialize signer: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestSignDataWithPKCS7VerifiesDigests(t *testing.T) {
 	input := []byte("foobarbaz1234abcd")
 	testcase := PASSINGTESTCASES[3]
 
-	s, err := New(testcase)
+	s, err := New(testcase, nil)
 	if err != nil {
 		t.Fatalf("failed to initialize signer: %v", err)
 	}
@@ -220,7 +220,7 @@ func TestNewFailure(t *testing.T) {
 	t.Parallel()
 
 	for i, testcase := range FAILINGTESTCASES {
-		_, err := New(testcase.cfg)
+		_, err := New(testcase.cfg, nil)
 		if !strings.Contains(err.Error(), testcase.err) {
 			t.Fatalf("testcase %d expected to fail with '%v' but failed with '%v' instead", i, testcase.err, err)
 		}
@@ -234,7 +234,7 @@ func TestOptionsP7Digest(t *testing.T) {
 	t.Parallel()
 
 	testcase := PASSINGTESTCASES[3]
-	s, err := New(testcase)
+	s, err := New(testcase, nil)
 	if err != nil {
 		t.Fatalf("failed to initialize signer: %v", err)
 	}
@@ -270,7 +270,7 @@ func TestNoID(t *testing.T) {
 
 	input := []byte("foobarbaz1234abcd")
 	// init a signer, don't care which one, taking this one because p256 is fast
-	s, err := New(PASSINGTESTCASES[3])
+	s, err := New(PASSINGTESTCASES[3], nil)
 	if err != nil {
 		t.Fatalf("failed to initialize signer: %v", err)
 	}
@@ -288,7 +288,7 @@ func TestBadCOSEAlgsErrs(t *testing.T) {
 
 	input := []byte("foobarbaz1234abcd")
 	// init a signer, don't care which one, taking this one because p256 is fast
-	s, err := New(PASSINGTESTCASES[3])
+	s, err := New(PASSINGTESTCASES[3], nil)
 	if err != nil {
 		t.Fatalf("failed to initialize signer: %v", err)
 	}
@@ -324,7 +324,7 @@ func TestBadPKCS7DigestErrs(t *testing.T) {
 
 	input := []byte("foobarbaz1234abcd")
 	// init a signer, don't care which one, taking this one because p256 is fast
-	s, err := New(PASSINGTESTCASES[3])
+	s, err := New(PASSINGTESTCASES[3], nil)
 	if err != nil {
 		t.Fatalf("failed to initialize signer: %v", err)
 	}
@@ -346,7 +346,7 @@ func TestMarshalUnfinishedSignature(t *testing.T) {
 
 	input := []byte("foobarbaz1234abcd")
 	// init a signer, don't care which one, taking this one because p256 is fast
-	s, err := New(PASSINGTESTCASES[3])
+	s, err := New(PASSINGTESTCASES[3], nil)
 	if err != nil {
 		t.Fatalf("failed to initialize signer: %v", err)
 	}
@@ -366,7 +366,7 @@ func TestMarshalEmptySignature(t *testing.T) {
 
 	input := []byte("foobarbaz1234abcd")
 	// init a signer, don't care which one, taking this one because p256 is fast
-	s, err := New(PASSINGTESTCASES[3])
+	s, err := New(PASSINGTESTCASES[3], nil)
 	if err != nil {
 		t.Fatalf("failed to initialize signer: %v", err)
 	}
@@ -408,7 +408,7 @@ func TestVerifyUnfinishedSignature(t *testing.T) {
 
 	input := []byte("foobarbaz1234abcd")
 	// init a signer, don't care which one, taking this one because p256 is fast
-	s, err := New(PASSINGTESTCASES[3])
+	s, err := New(PASSINGTESTCASES[3], nil)
 	if err != nil {
 		t.Fatalf("failed to initialize signer: %v", err)
 	}
@@ -428,7 +428,7 @@ func TestRsaCaching(t *testing.T) {
 
 	// initialize a rsa signer
 	testcase := PASSINGTESTCASES[0]
-	s, err := New(testcase)
+	s, err := New(testcase, nil)
 	if err != nil {
 		t.Fatalf("signer initialization failed with: %v", err)
 	}
@@ -469,7 +469,7 @@ func TestSignFileWithCOSESignatures(t *testing.T) {
 	input := unsignedBootstrap
 	// initialize a signer
 	testcase := PASSINGTESTCASES[0]
-	s, err := New(testcase)
+	s, err := New(testcase, nil)
 	if err != nil {
 		t.Fatalf("signer initialization failed with: %v", err)
 	}

--- a/signer/xpi/xpi_test.go
+++ b/signer/xpi/xpi_test.go
@@ -22,6 +22,13 @@ func TestSignFile(t *testing.T) {
 	input := unsignedBootstrap
 	// initialize a signer
 	testcase := PASSINGTESTCASES[0]
+	testcase.RSACacheConfig = signer.RSACacheConfig{
+		NumKeys:                5,
+		NumGenerators:          2,
+		GeneratorSleepDuration: time.Minute,
+		FetchTimeout:           100 * time.Millisecond,
+		MonitorSampleRate:      10 * time.Second,
+	}
 	s, err := New(testcase, nil)
 	if err != nil {
 		t.Fatalf("signer initialization failed with: %v", err)

--- a/signer/xpi/xpi_test.go
+++ b/signer/xpi/xpi_test.go
@@ -28,7 +28,7 @@ func TestSignFile(t *testing.T) {
 		NumGenerators:          2,
 		GeneratorSleepDuration: time.Minute,
 		FetchTimeout:           100 * time.Millisecond,
-		MonitorSampleRate:      10 * time.Second,
+		StatsSampleRate:      10 * time.Second,
 	}
 
 	statsdClient, err := statsd.NewBuffered("localhost:8135", 1)

--- a/signer/xpi/xpi_test.go
+++ b/signer/xpi/xpi_test.go
@@ -36,8 +36,12 @@ func TestSignFile(t *testing.T) {
 		t.Fatalf("Error constructing statsdClient: %v", err)
 	}
 	statsdClient.Namespace = "test_autograph_stats_ns"
+	signerStatsClient, err := signer.NewStatsClient(testcase, statsdClient)
+	if err != nil {
+		t.Fatalf("Error constructing signer.StatsdClient: %v", err)
+	}
 
-	s, err := New(testcase, statsdClient)
+	s, err := New(testcase, signerStatsClient)
 	if err != nil {
 		t.Fatalf("signer initialization failed with: %v", err)
 	}

--- a/signer/xpi/xpi_test.go
+++ b/signer/xpi/xpi_test.go
@@ -301,8 +301,8 @@ func TestBadCOSEAlgsErrs(t *testing.T) {
 	}
 	// sign input data with invalid cose algs option
 	_, err = s.SignData(input, Options{
-		ID: "ffffffff-ffff-ffff-ffff-ffffffffffff",
-		PKCS7Digest: "SHA1",
+		ID:             "ffffffff-ffff-ffff-ffff-ffffffffffff",
+		PKCS7Digest:    "SHA1",
 		COSEAlgorithms: []string{"bar"},
 	})
 	expectedErr := "xpi: cannot use /sign/data for COSE signatures. Use /sign/file instead"
@@ -314,8 +314,8 @@ func TestBadCOSEAlgsErrs(t *testing.T) {
 
 	// sign input data with valid cose algs option
 	_, err = s.SignData(input, Options{
-		ID: "ffffffff-ffff-ffff-ffff-ffffffffffff",
-		PKCS7Digest: "SHA1",
+		ID:             "ffffffff-ffff-ffff-ffff-ffffffffffff",
+		PKCS7Digest:    "SHA1",
 		COSEAlgorithms: []string{"ES256"},
 	})
 	expectedErr = "xpi: cannot use /sign/data for COSE signatures. Use /sign/file instead"
@@ -337,7 +337,7 @@ func TestBadPKCS7DigestErrs(t *testing.T) {
 	}
 	// sign input data with invalid pkcs7_digest options
 	_, err = s.SignData(input, Options{
-		ID: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+		ID:          "ffffffff-ffff-ffff-ffff-ffffffffffff",
 		PKCS7Digest: "SHA9000",
 	})
 	expectedErr := "xpi: can only use SHA1 digests with /sign/data. Use /sign/file instead"
@@ -485,7 +485,7 @@ func TestSignFileWithCOSESignatures(t *testing.T) {
 	signOptions := Options{
 		ID:             "test@example.net",
 		COSEAlgorithms: []string{"ES256", "PS256"},
-		PKCS7Digest: "SHA1",
+		PKCS7Digest:    "SHA1",
 	}
 	signedXPI, err := s.SignFile(input, signOptions)
 	if err != nil {


### PR DESCRIPTION
As discussed in IRC #autograph.

Added the histogram on key fetching since it sometimes results in key gen too (and should be bimodal if we aren't pulling from cache).

Also, thought it'd be good to tag metrics with signer ID, Type, and Mode so we can filter on those, identify problematic signers, etc. (this PR and to do more generally in the future).

r? @milescrabill 