### PR TITLE
log req options and signer mode

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -205,6 +205,8 @@ func (a *autographer) handleSignature(w http.ResponseWriter, r *http.Request) {
 		}
 		log.WithFields(log.Fields{
 			"rid":        rid,
+			"options":    sigreq.Options,
+			"mode":       sigresps[i].Mode,
 			"ref":        sigresps[i].Ref,
 			"type":       sigresps[i].Type,
 			"signer_id":  sigresps[i].SignerID,


### PR DESCRIPTION
refs: https://bugzilla.mozilla.org/show_bug.cgi?id=1480596

Log request options and mode (for XPIs) for auditing and debugging.

Functional Test:

- [x] signed an apk w/ sha1 and sha256 digests and checked the correct options were logged 

r? @jvehent 