### PR TITLE
tools: Add reminder to run zipalign when signing APKs

### DIFF
--- a/tools/autograph-client/client.go
+++ b/tools/autograph-client/client.go
@@ -15,6 +15,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -339,6 +340,9 @@ examples:
 						log.Fatal(err)
 					}
 					log.Println("response written to", outfile)
+					if response.Type == apk.Type {
+						fmt.Fprintf(os.Stderr, "Don't forget to run 'zipalign -c -v 4 %s'\n", outfile)
+					}
 				}
 				if outkeyfile != "" {
 					err = ioutil.WriteFile(outkeyfile, []byte(response.PublicKey), 0644)


### PR DESCRIPTION
refs: https://bugzilla.mozilla.org/show_bug.cgi?id=1506598

functional test:

- [x] sign an apk and check for new output:

```console
tools/autograph-client - [client-add-zipalign-warning●] » go run client.go -f ~/Downloads/wrong_signed_enUS_65.0b4_x86.target.apk -o signed.apk -k testapp-android
2018/12/26 12:39:36 signing file "/home/gguthe/Downloads/wrong_signed_enUS_65.0b4_x86.target.apk"
2018/12/26 12:39:44 signature 0 from signer "testapp-android" passes
2018/12/26 12:39:44 response written to signed.apk
Don't forget to run 'zipalign -c -v 4 signed.apk'
```

r? @jvehent 
