### PR TITLE
Support HSM key storage in content signature signer

### DIFF
--- a/autograph.softhsm.yaml
+++ b/autograph.softhsm.yaml
@@ -26,6 +26,10 @@ signers:
       type: mar
       # label of the key in the hsm
       privatekey: testecdsap384
+    - id: testcsp384
+      type: contentsignature
+      privatekey: testcsp384
+
 
 authorizations:
     - id: alice
@@ -34,5 +38,6 @@ authorizations:
           - testmar
           - testmar2
           - testmarecdsa
+          - testcsp384
 monitoring:
     key: 19zd4w3xirb5syjgdx8atq6g91m03bdsmzjifs2oddivswlu9qs

--- a/docs/hsm.rst
+++ b/docs/hsm.rst
@@ -61,7 +61,7 @@ Setting up SoftHSM
 ------------------
 
 * On Ubuntu Xenial, install `softhsm` and create `mkdir /var/lib/softhsm/tokens`
-* On ArchLinux, install `softhsm2` from AUR
+* On ArchLinux, install `softhsm` from AUR
 * Then create a token with `$ softhsm2-util --init-token --slot 0 --label test --pin 0000 --so-pin 0000`
 
 PKCS11 SoftHSM client

--- a/signer/contentsignature/contentsignature.go
+++ b/signer/contentsignature/contentsignature.go
@@ -69,8 +69,8 @@ func New(conf signer.Configuration) (s *ContentSigner, err error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "contentsignature: failed to retrieve signer")
 	}
-	switch s.priv.(type) {
-	case *ecdsa.PrivateKey:
+	switch s.pub.(type) {
+	case *ecdsa.PublicKey:
 	default:
 		return nil, errors.New("contentsignature: invalid private key algorithm, must be ecdsa")
 	}

--- a/signer/contentsignature/contentsignature.go
+++ b/signer/contentsignature/contentsignature.go
@@ -69,6 +69,11 @@ func New(conf signer.Configuration) (s *ContentSigner, err error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "contentsignature: failed to retrieve signer")
 	}
+	switch s.priv.(type) {
+	case *ecdsa.PrivateKey:
+	default:
+		return nil, errors.New("contentsignature: invalid private key algorithm, must be ecdsa")
+	}
 	s.Mode = s.getModeFromCurve()
 	return
 }

--- a/signer/contentsignature/contentsignature_test.go
+++ b/signer/contentsignature/contentsignature_test.go
@@ -160,7 +160,7 @@ func TestNewFailure(t *testing.T) {
 		{err: "contentsignature: invalid type", cfg: signer.Configuration{Type: ""}},
 		{err: "contentsignature: missing signer ID in signer configuration", cfg: signer.Configuration{Type: Type, ID: ""}},
 		{err: "contentsignature: missing private key in signer configuration", cfg: signer.Configuration{Type: Type, ID: "bob"}},
-		{err: "contentsignature: failed to parse private key", cfg: signer.Configuration{Type: Type, ID: "bob", PrivateKey: "Ym9iCg=="}},
+		{err: "contentsignature: failed to retrieve signer: no suitable key found", cfg: signer.Configuration{Type: Type, ID: "bob", PrivateKey: "Ym9iCg=="}},
 		{err: "contentsignature: invalid private key algorithm, must be ecdsa", cfg: signer.Configuration{
 			Type: Type,
 			ID:   "abcd",

--- a/signer/contentsignature/contentsignature_test.go
+++ b/signer/contentsignature/contentsignature_test.go
@@ -221,3 +221,17 @@ func TestUnmarshalBadBase64(t *testing.T) {
 		t.Fatalf("expected to fail with 'unknown signature length', but got %v", err)
 	}
 }
+
+func TestNoShortData(t *testing.T) {
+	s, err := New(PASSINGTESTCASES[0].cfg)
+	if err != nil {
+		t.Fatalf("signer initialization failed with: %v", err)
+	}
+	_, err = s.SignData([]byte("a"), nil)
+	if err == nil {
+		t.Fatal("expected to fail with input data too short but succeeded")
+	}
+	if err.Error() != "contentsignature: refusing to sign input data shorter than 10 bytes" {
+		t.Fatalf("expected to fail with input data too short but failed with: %v", err)
+	}
+}

--- a/signer/contentsignature/signature.go
+++ b/signer/contentsignature/signature.go
@@ -19,6 +19,11 @@ type ContentSignature struct {
 	Finished bool
 }
 
+// a private struct to unmarshal asn1 signatures produced by crypto.Signer
+type ecdsaAsn1Signature struct {
+	R, S *big.Int
+}
+
 func (sig *ContentSignature) storeHashName(alg string) {
 	sig.HashName = alg
 }

--- a/signer/entropy_test.go
+++ b/signer/entropy_test.go
@@ -1,0 +1,76 @@
+package signer
+
+import (
+	"bytes"
+	"math"
+	"testing"
+)
+
+// returns the shannon entropy of a byte string
+func shannonEntropy(data []byte) (entropy float64) {
+	if len(data) == 0 {
+		return 0
+	}
+	for i := 0; i < 256; i++ {
+		var curByte []byte
+		curByte = append(curByte, byte(i))
+		px := float64(bytes.Count(data, curByte)) / float64(len(data))
+		if px > 0 {
+			entropy += -px * math.Log2(px)
+		}
+	}
+	return entropy
+}
+
+func TestRng(t *testing.T) {
+	for i, testcase := range PASSINGTESTCASES {
+		_, _, rng, _, err := testcase.cfg.GetKeysAndRand()
+		if err != nil {
+			t.Fatalf("testcase %d failed to load signer configuration: %v", i, err)
+		}
+		randomData := make([]byte, 512)
+		_, err = rng.Read(randomData)
+		if err != nil {
+			t.Fatalf("testcase %d failed to read from rng: %v", i, err)
+		}
+		entropy := shannonEntropy(randomData)
+		t.Logf("testcase %d returned entropy %f", i, entropy)
+		if entropy < 7.0 {
+			t.Fatalf("testcase %d got low entropy from rng: received %f, expected at least 7", i, entropy)
+		}
+	}
+}
+
+var PASSINGTESTCASES = []struct {
+	cfg Configuration
+}{
+	{cfg: Configuration{
+		PrivateKey: `
+-----BEGIN EC PARAMETERS-----
+BggqhkjOPQMBBw==
+-----END EC PARAMETERS-----
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEII+Is30aP9wrB/H6AkKrJjMG8EVY2WseSFHTfWGCIk7voAoGCCqGSM49
+AwEHoUQDQgAEMdzAsqkWQiP8Fo89qTleJcuEjBtp2c6z16sC7BAS5KXvUGghURYq
+3utZw8En6Ik/4Om8c7EW/+EO+EkHShhgdA==
+-----END EC PRIVATE KEY-----`,
+	}},
+	{cfg: Configuration{
+		PrivateKey: `
+-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQDYU0DX8fqlyaJqha6D0DvHAtde8o3xIxXYX8ONwVbUIJMur+42
+rsXZk8vQkeSzQ9evIAlara5X9aSvCo0O4Lg7VzHjRd5Ip2RwWAknJY942XCBF+CO
+M9NTwjQRlBjNrRK9Qm3gRHLkCsw5mqDkzXXPkKXw5jeiveAsQIES40YgIwIDAQAB
+AoGAESQfqjzRWJuuk/Q9zNIOOom+GRbtKmNWUsvbyfq875gZMYTdQlX89W2ho8g7
+r/y7NXQ7aYUDoJKlVv1mCfzCfEPsl+AppNzRWf7Dsvgv4OHLCMP6pzliSWz+Teh3
+eybe17v8OtmrWWRZpf+mBdIBZ1AUFh9ET9hHsil5I7s2VjkCQQD049sKsFdltnqJ
+nfkFhyxWomNhmY4f37iUOl562gcP71Dqg+IeB7mTaqxc2KwErZYPb0H+ov8NxNLJ
+GPva6FB1AkEA4iOlgES3aIPeoYYoqKRrYxx4kOO0s2cRxlEbt+nbDgdxIjsxeS29
+Fz/p9GCsutHrpAwIBDNrgmG5V0yfE06bNwJBAI7hBmLFIijQ/8udJLaJ+F+PnUZL
+jjWglRO+vnMVFDvC2EYLrnjw7uBIw8nkDPEpyjy1IB8OQJtq88Sq0/8TviUCQH0s
+Jgvd/XeIps7Zp9/RQu/Vbpcks30qbBhOBP3EIFCfpevAwB3HR4d7BVETwgiW8cwY
+LMfGfpfo5+J+sv7I3/kCQEvkxSGguHckNzqV7nZgwskbFfvTVLqMaPy9EVfu2od+
+ZkJ9hRz+l4ZVOsgNPHXPEi0AXWnDV6zrRQBpDYyiGhY=
+-----END RSA PRIVATE KEY-----`,
+	}},
+}

--- a/tools/softhsm/genkeys.go
+++ b/tools/softhsm/genkeys.go
@@ -50,4 +50,10 @@ func main() {
 		log.Fatal(err)
 	}
 	fmt.Printf("ECDSA Key: %+v\n", ecdsakey)
+
+	p384key, err := crypto11.GenerateECDSAKeyPairOnSlot(slots[0], []byte("testcsp384"), []byte("testcsp384"), elliptic.P384())
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("P384 Key: %+v\n", p384key)
 }


### PR DESCRIPTION
Implements support for HSM keys in the contentsignature signer. Should be easily reusable in other signers, but migrating them over to the HSM will be done in separate PRs.

r? @g-k 