### PR TITLE
http timeouts

### DIFF
--- a/autograph.yaml
+++ b/autograph.yaml
@@ -2,6 +2,9 @@ server:
     listen: "0.0.0.0:8000"
     # cache 500k nonces to protect from authorization replay attacks
     noncecachesize: 524288
+    idletimeout: 60s
+    readtimeout: 60s
+    writetimeout: 60s
 
 statsd:
     addr: "127.0.0.1:8125"

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -20,6 +20,9 @@ HAWK nonce cache size to prevent replay attacks:
 	server:
 		listen: "192.168.1.28:8000"
 		noncecachesize: 524288
+		idletimeout: 60s
+		readtimeout: 60s
+		writetimeout: 60s
 
 Use flag `-p` to provide an alternate port and override any port
 specified in the config.

--- a/main.go
+++ b/main.go
@@ -176,7 +176,9 @@ func run(conf configuration, listen string, authPrint, debug bool) {
 	router.HandleFunc("/sign/hash", ag.handleSignature).Methods("POST")
 
 	server := &http.Server{
-		Addr: listen,
+		ReadTimeout:  60 * time.Second,
+		WriteTimeout: 60 * time.Second,
+		Addr:         listen,
 		Handler: handleMiddlewares(
 			router,
 			setRequestID(),

--- a/main.go
+++ b/main.go
@@ -48,6 +48,9 @@ type configuration struct {
 	Server struct {
 		Listen         string
 		NonceCacheSize int
+		IdleTimeout    time.Duration
+		ReadTimeout    time.Duration
+		WriteTimeout   time.Duration
 	}
 	Statsd struct {
 		Addr      string
@@ -176,8 +179,9 @@ func run(conf configuration, listen string, authPrint, debug bool) {
 	router.HandleFunc("/sign/hash", ag.handleSignature).Methods("POST")
 
 	server := &http.Server{
-		ReadTimeout:  60 * time.Second,
-		WriteTimeout: 60 * time.Second,
+		IdleTimeout:  conf.Server.IdleTimeout,
+		ReadTimeout:  conf.Server.ReadTimeout,
+		WriteTimeout: conf.Server.WriteTimeout,
 		Addr:         listen,
 		Handler: handleMiddlewares(
 			router,
@@ -187,7 +191,7 @@ func run(conf configuration, listen string, authPrint, debug bool) {
 			logRequest(),
 		),
 	}
-	log.Println("starting autograph on", listen)
+	log.Infof("starting autograph on %s with timeouts: idle %s read %s write %s", listen, conf.Server.IdleTimeout, conf.Server.ReadTimeout, conf.Server.WriteTimeout)
 	err = server.ListenAndServe()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Rebase of #158 

Having timeouts is a good idea. 

Knowing which timeouts to use is hard and we'll probably want to tune it, so this just reuses the defaults for now.

Functional Tests:

 - [x] when timeouts are defined in config they are properly parsed and used 
 - [x] when timeouts are not defined in the config the http.Server defaults of 0 are used