### PR TITLE
Add code quality ci job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,29 @@
 #
 version: 2
 jobs:
+  lint-vet-fmt:
+    docker:
+      - image: golang:1.11
+    working_directory: /usr/local/go/src/go.mozilla.org/autograph
+    steps:
+      - checkout
+      - run:
+          name: run golint
+          command: make install-golint lint || true
+      - run:
+          name: run gofmt
+          command: |
+              make -s fmt-diff | tee fmt.diff
+              test -z "$(cat fmt.diff)"
+      - run:
+          name: install packages for crypto11 headers for go vet
+          command: |
+              apt-get update
+              apt-get install -y libltdl-dev
+      - run:
+          name: run got vet
+          command: make vet
+
   test:
     docker:
       - image: golang:latest
@@ -175,6 +198,8 @@ workflows:
   version: 2
   test-sign-build-deploy:
     jobs:
+      - lint-vet-fmt
+
       - test:
           filters:
             tags:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 - make install-dev-deps
 
 script:
-- make generate lint vet install
+- make generate install
 - make dummy-statsd &
 - make build-container
 - make test-container-ci

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 GO := go
+GOLINT := golint -set_exit_status
 
 all: generate test vet lint install
 
@@ -42,15 +43,15 @@ tag: all
 	git tag -s $(TAGVER) -a -m "$(TAGMSG)"
 
 lint:
-	golint go.mozilla.org/autograph
-	golint go.mozilla.org/autograph/signer
-	golint go.mozilla.org/autograph/signer/contentsignature
-	golint go.mozilla.org/autograph/signer/xpi
-	golint go.mozilla.org/autograph/signer/apk
-	golint go.mozilla.org/autograph/signer/mar
-	golint go.mozilla.org/autograph/signer/pgp
-	golint go.mozilla.org/autograph/signer/gpg2
-	golint go.mozilla.org/autograph/signer/rsapss
+	$(GOLINT) go.mozilla.org/autograph \
+		go.mozilla.org/autograph/signer \
+		go.mozilla.org/autograph/signer/contentsignature \
+		go.mozilla.org/autograph/signer/xpi \
+		go.mozilla.org/autograph/signer/apk \
+		go.mozilla.org/autograph/signer/mar \
+		go.mozilla.org/autograph/signer/pgp \
+		go.mozilla.org/autograph/signer/gpg2 \
+		go.mozilla.org/autograph/signer/rsapss
 
 vet:
 	$(GO) vet go.mozilla.org/autograph

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ vet:
 fmt-diff:
 	gofmt -d *.go signer/ tools/autograph-client/ $(shell ls tools/autograph-monitor/*.go) tools/softhsm/ tools/hawk-token-maker/
 
+fmt-fix:
+	gofmt -w *.go signer/ tools/autograph-client/ $(shell ls tools/autograph-monitor/*.go) tools/softhsm/ tools/hawk-token-maker/
+
 testautograph:
 	$(GO) test -v -covermode=count -coverprofile=coverage_autograph.out go.mozilla.org/autograph
 

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,9 @@ vet:
 	$(GO) vet go.mozilla.org/autograph/signer/gpg2
 	$(GO) vet go.mozilla.org/autograph/signer/rsapss
 
+fmt-diff:
+	gofmt -d *.go signer/ tools/autograph-client/ $(shell ls tools/autograph-monitor/*.go) tools/softhsm/ tools/hawk-token-maker/
+
 testautograph:
 	$(GO) test -v -covermode=count -coverprofile=coverage_autograph.out go.mozilla.org/autograph
 

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,16 @@ GOLINT := golint -set_exit_status
 
 all: generate test vet lint install
 
-install-dev-deps:
+install-golint:
+	$(GO) get golang.org/x/lint/golint
+
+install-cover:
 	$(GO) get golang.org/x/tools/cmd/cover
-	$(GO) get github.com/golang/lint/golint
+
+install-goveralls:
 	$(GO) get github.com/mattn/goveralls
+
+install-dev-deps: install-golint install-cover install-goveralls
 
 install:
 	$(GO) install go.mozilla.org/autograph

--- a/signer/xpi/xpi_test.go
+++ b/signer/xpi/xpi_test.go
@@ -28,7 +28,7 @@ func TestSignFile(t *testing.T) {
 		NumGenerators:          2,
 		GeneratorSleepDuration: time.Minute,
 		FetchTimeout:           100 * time.Millisecond,
-		StatsSampleRate:      10 * time.Second,
+		StatsSampleRate:        10 * time.Second,
 	}
 
 	statsdClient, err := statsd.NewBuffered("localhost:8135", 1)

--- a/tools/autograph-client/client.go
+++ b/tools/autograph-client/client.go
@@ -80,11 +80,11 @@ func urlToRequestType(url string) requestType {
 func main() {
 	var (
 		userid, pass, data, hash, url, infile, outfile, outkeyfile, keyid, cn, pk7digest, rootPath, rsapssHash, zipMethodOption string
-		iter, maxworkers, sa                                                                                                      int
-		debug                                                                                                                     bool
-		err                                                                                                                       error
-		requests                                                                                                                  []signaturerequest
-		algs                                                                                                                      coseAlgs
+		iter, maxworkers, sa                                                                                                    int
+		debug                                                                                                                   bool
+		err                                                                                                                     error
+		requests                                                                                                                []signaturerequest
+		algs                                                                                                                    coseAlgs
 	)
 	flag.Usage = func() {
 		fmt.Print("autograph-client - simple command line client to the autograph service\n\n")


### PR DESCRIPTION
Changes:
* Move lint and vet checks to CircleCI 
* Fix lint check to output failures for all pkgs and fail on exception (will open issue for renaming the stutter errors and removing the `|| true`)
* Add a check to make sure our code is gofmt'd (NB: will need to add new tools and stuff to path since it's a whitelist to avoid checking all `vendor/` code)
* Add `make fmt-fix` to gofmt code in place (same caveat as above applies)
* gofmt some code to get that check passing