### PR TITLE
signer: fix padding in rsapss signer

### DIFF
--- a/signer/rsapss/README.rst
+++ b/signer/rsapss/README.rst
@@ -7,7 +7,8 @@ RSA-PSS Signing
 This signer implements RSA-PSS signing for Widevine and possibly other
 signature types in the future. It accepts 20-byte SHA1 hashes on
 `/sign/hash` and data to be hashed on `/sign/data`. Both endpoints
-return base64-encoded RSA-PSS signatures of the hashed data.
+return base64-encoded RSA-PSS signatures of the hashed data using
+`rsa.PSSSaltLengthEqualsHash` padding.
 
 Example Usage:
 


### PR DESCRIPTION
refs: https://bugzilla.mozilla.org/show_bug.cgi?id=1505210

Changes:
* switch rsapss signer to use `rsa.PSSSaltLengthEqualsHash` for signing and verification
  * [for SHA1 the PSSSaltLengthEqualsHash will use hash.Size](https://golang.org/src/crypto/rsa/pss.go?s=6982:7095#L239) which is [20 bytes for SHA1](https://golang.org/pkg/crypto/sha1/#pkg-constants), using LengthEqualsHash is more flexible if we need to add more hashes in the future
  * makes explicit PSSOptions arg explicit to `VerifyPSS` instead of using `nil` for the default
* rename b64Input to b64Digest in `VerifySignatureFromB64` to make that arg clearer
* return err from `x509.ParsePKIXPublicKey` in `VerifySignatureFromB64` instead of silently failing
* refactor `TestVerifySignatureFromB64` to reconstruct base64 inputs rather than leaving inscrutable values in the test

Integration tested against the following script and confirmed the output is True (meaning we're outputting signatures python cryptography can verify):

```python
import base64
from io import StringIO

from cryptography.hazmat.backends import default_backend
from cryptography.hazmat.primitives import hashes
from cryptography.hazmat.primitives.asymmetric import padding
from cryptography.hazmat.primitives import serialization
from cryptography.hazmat.primitives.asymmetric import rsa

# From https://github.com/mozilla-services/autograph/blob/b8608834edf5a8a5eeb78ddb42e3ef26d4e7cae3/signer/rsapss/rsapss_test.go#L306
private_key_pem = b"""-----BEGIN RSA PRIVATE KEY-----
MIIEpAIBAAKCAQEAtEM/Vdfd4Vl9wmeVdCYuWYnQl0Zc9RW5hLE4hFA+c277qanE
8XCK+ap/c5so87XngLLfacB3zZhGxIOut/4SlEBOAUmVNCfnTO+YkRk3A8OyJ4XN
qdn+/ov78ZbssGf+0zws2BcwZYwhtuTvro3yi62FQ7T1TpT5VjljH7sHW/iZnS/R
KiY4DwqAN799gkB+Gwovtroabh2w5OX0P+PYyUbJLFQeo5uiAQ8cAXTlHqCkj11G
YgU4ttVDuFGotKRyaRn1F+yKxE4LQcAULx7s0KzvS35mNU+MoywLWjy9a4TcjK0n
q+BjspKX4UkNwVstvH18hQWun7E+dxTi59cRmwIDAQABAoIBAEKpi8aHKfqoSaWX
AOIPLJzYJleLId1Qx2aW0zu7IR03McIwkjBnWj2yG6f4/VADOTWS8KP/FU7mvWT2
/an1P5Grpi07tP2wtAzzngwqsvmlaUDMbp4di/s+cVGKasVh8A7V9g+Do9Yp2F32
k9yNieC1rs63IPCKjxqf5lRZqgMMcL1QYSlJI98riSVGm0m29u1v3pN6qDVNto2d
l6m6D8UT6vx1lfVZFV+Td3FmYHnuYyVwbgJ8dFRBQFpe2tsccK955+lapFe9MA/o
Xa5VfAWJ7YoLcgfssxF7atpHt2wcpvEj6NfIHfeDdExQ+Vd9T8vQGh88wd32QcTa
w1RiQUECgYEA7OFpsduOHqgqVSf1nIH6RPLytzzoXXd8Bs1aXWCxy45xg7lkKG+x
8Fa4aUFDII9RR4N7YFfUh8LwKF56BwFePbP4wwCuhz9v2E24I6/EfLD2GuRSv+B/
gNRG+suE5yCmeGlRC0uhASLr3ZzmGs16Mus/ytL5XPl8CJCmsVMjPHMCgYEAws/1
Sm2KOoYFY1+7ACMF89FyesOpTpqLvND79soNPC4Tl1PrPw4bsNA6p2BD1N2SPFiH
0yo7msNqh5o90wdnYA7i1uDWhcvrFnbg4e8+RhghcG/dJW33Lm5d5knST4NQxnAO
z/0zXgB9PSnsgFzNgm6LE++/KBZs/CbxQUPb9DkCgYEAk58eiVK0TPKr/wm6DOEL
oLBvBjaU8Lqntm1/ZTX/V0XcBCUi//grwgWpQx8CwGXQV2rfFnll331iwSWvknIN
0xI3cv8XxP2JrBkzKjo9jx+RH80urJkxnI2t9lmi5473b47ijNGC8vxaVW+UDxwC
jX0B8lpsQL7Rx1yuJVAUY3UCgYEAtG8gZZsnWCUhgHT+IpZNwRHQ0lu+yIrjujJl
7KIfuAmFI7gaPwC2LQHwEW5b5SCDfVkSFEcdha5RUN9PO9GzsYiYGSWOC8ZfKyNY
DmskZo+bCSTS0wQS2PJoDg95tyONAP5w+bsuhHY3iRr3bbyGq7PvJLv9dQewUatP
8H8FjiECgYBt93fZADyyOoqeYxMc8b38F8sf1FLTOAUfB1ik5R4yNVKDaCanYhYc
poTajMUVdoBcEV1g5Vds8objUIeNNlMPKyUnf/lCiPvp43wYbC3y60JqzXX3bfAS
TDd4Me4PP+sTZeJ3RKvArDiMzEncDeMGZZnd4dBdi3LjzCNGTANAGw==
-----END RSA PRIVATE KEY-----"""

# dumped from rsapss_test.go TestVerifySignatureFromB64
b64Sig = "EVeb4kBUSnMNGhdsyZBk7LCfxErtrlq3U+rFsjHJpiNPLZFe+fWS1Z6/o/jPNLKPWFPI8jM/YjHPCiCRQWVBBH/e7iBvtOg8/cgESE8z568xLA+rXxwvHAuhzKTEMCruLTWDM+OAgOL8fnfbKUcj1tz6NZmpNUpBii9xvLmVJ6mGQPEOpiMRAOhKq3ooY8QC8X0QSESu43M7xpMIXKvmHKPq/cpFT7oaTO2ZQwK+nknt7LrnGVDnKvfWbBOl5085yyHlh5FME/HJCPzZNneV7RUcZZDaga4uU78bHetoEwgQbRziJUAbUTdj3iN7X2JZMny4HJNjxT8dHcwllY1F/Q=="

message = b'this is the sha1 input'


def validate_rsa_pss(public_key, signature, message):
    public_key.verify(
        signature,
        message,
        padding.PSS(mgf=padding.MGF1(hashes.SHA1()), salt_length=20),
        hashes.SHA1(),
    )


private_key = serialization.load_pem_private_key(private_key_pem, password=None, backend=default_backend())
public_key = private_key.public_key()
sig = base64.b64decode(b64Sig, validate=True)

# "If the signature does not match, verify() will raise an InvalidSignature
# exception."
#
# https://cryptography.io/en/latest/hazmat/primitives/asymmetric/rsa/#verification
print(validate_rsa_pss(public_key, sig, message) == None)
```