### PR TITLE
ci: drop -repotoken arg to goveralls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
           name: Report coverage
           command: |
             cd $GOPATH/src/go.mozilla.org/autograph
-            $GOPATH/bin/goveralls -coverprofile=coverage.out -service circle-ci -repotoken $COVERALLS_TOKEN
+            $GOPATH/bin/goveralls -coverprofile=coverage.out -service circle-ci
 
   build:
     # based on the official golang image with more docker stuff


### PR DESCRIPTION
per the docs:

> For a public github repository, it is not necessary to define your
  repository key (COVERALLS_TOKEN).

https://github.com/mattn/goveralls#travis-ci