### PR TITLE
ci: save docker image cache for deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,6 +204,7 @@ jobs:
       - save_cache:
           key: v4-apk-{{ .Branch }}-{{ .Revision }}
           paths:
+            - /go/src/app/cache/docker.tgz
             - /go/src/app/cache/resigned-apks.tgz
 
   verify:


### PR DESCRIPTION
Fix

```
gunzip: /go/src/app/cache/docker.tgz: No such file or directory
open /var/lib/docker/tmp/docker-import-767426517/repositories: no such file or directory
Exited with code 1
```

from https://circleci.com/gh/mozilla-services/autograph/2316