### PR TITLE
parallelize monitor signing

### DIFF
--- a/monitor.go
+++ b/monitor.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -35,33 +36,54 @@ func (a *autographer) handleMonitor(w http.ResponseWriter, r *http.Request) {
 		httpError(w, r, http.StatusUnauthorized, "user is not permitted to call this endpoint")
 		return
 	}
+
+	sigerrstrs := make([]string, len(a.signers))
 	sigresps := make([]signatureresponse, len(a.signers))
+	var wg sync.WaitGroup
 	for i, s := range a.signers {
-		if _, ok := s.(signer.DataSigner); !ok {
-			httpError(w, r, http.StatusInternalServerError, "signer %q does not implement the DataSigner interface", s.Config().ID)
+		wg.Add(1)
+
+		go func(i int, s signer.Signer) {
+			defer wg.Done()
+
+			if _, ok := s.(signer.DataSigner); !ok {
+				sigerrstrs[i] = fmt.Sprintf("signer %q does not implement the DataSigner interface", s.Config().ID)
+				return
+			}
+
+			// base64 of the string 'AUTOGRAPH MONITORING'
+			sig, err := s.(signer.DataSigner).SignData([]byte("AUTOGRAPH MONITORING"), s.(signer.DataSigner).GetDefaultOptions())
+			if err != nil {
+				sigerrstrs[i] = fmt.Sprintf("signing failed with error: %v", err)
+				return
+			}
+
+			encodedsig, err := sig.Marshal()
+			if err != nil {
+				sigerrstrs[i] = fmt.Sprintf("encoding failed with error: %v", err)
+				return
+			}
+
+			sigerrstrs[i] = ""
+			sigresps[i] = signatureresponse{
+				Ref:       id(),
+				Type:      s.Config().Type,
+				Mode:      s.Config().Mode,
+				SignerID:  s.Config().ID,
+				PublicKey: s.Config().PublicKey,
+				Signature: encodedsig,
+				X5U:       s.Config().X5U,
+			}
+		}(i, s)
+	}
+	wg.Wait()
+	for _, errstr := range sigerrstrs {
+		if errstr != "" {
+			httpError(w, r, http.StatusInternalServerError, errstr)
 			return
-		}
-		// base64 of the string 'AUTOGRAPH MONITORING'
-		sig, err := s.(signer.DataSigner).SignData([]byte("AUTOGRAPH MONITORING"), s.(signer.DataSigner).GetDefaultOptions())
-		if err != nil {
-			httpError(w, r, http.StatusInternalServerError, "signing failed with error: %v", err)
-			return
-		}
-		encodedsig, err := sig.Marshal()
-		if err != nil {
-			httpError(w, r, http.StatusInternalServerError, "encoding failed with error: %v", err)
-			return
-		}
-		sigresps[i] = signatureresponse{
-			Ref:       id(),
-			Type:      s.Config().Type,
-			Mode:      s.Config().Mode,
-			SignerID:  s.Config().ID,
-			PublicKey: s.Config().PublicKey,
-			Signature: encodedsig,
-			X5U:       s.Config().X5U,
 		}
 	}
+
 	respdata, err := json.Marshal(sigresps)
 	if err != nil {
 		httpError(w, r, http.StatusInternalServerError, "signing failed with error: %v", err)


### PR DESCRIPTION
Change:

* parallelize monitor signing requests per signer then aggregate the results or errors

Since we have 30+ signers in HSM prod taking ~1 minute. 

NB: I didn't get perf numbers to show a speedup.

r? @milescrabill @jvehent 