### PR TITLE
bump container versions to golang 1.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2
 jobs:
   lint-vet-fmt:
     docker:
-      - image: golang:1.11
+      - image: golang:1.12
     working_directory: /usr/local/go/src/go.mozilla.org/autograph
     steps:
       - checkout
@@ -31,7 +31,7 @@ jobs:
 
   unit-test:
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.12
       - image: circleci/postgres:11
         environment:
           POSTGRES_USER: root
@@ -77,7 +77,7 @@ jobs:
   build-integrationtest-verify:
     # based on the official golang image with more docker stuff
     docker:
-      - image: circleci/golang:1.11.4
+      - image: circleci/golang:1.12
     working_directory: /go/src/go.mozilla.org/autograph
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11
+FROM golang:1.12
 EXPOSE 8000
 
 RUN addgroup --gid 10001 app \


### PR DESCRIPTION
release notes: https://golang.org/doc/go1.12

possibly relevant or useful changes:

* https://golang.org/doc/go1.12#vet `go tool vet` unsupported, but we run `go vet`
* https://golang.org/doc/go1.12#crypto/rand "A warning will now be printed to standard error the first time Reader.Read is blocked for more than 60 seconds waiting to read entropy from the kernel."
* https://golang.org/doc/go1.12#database/sql "A query cursor can now be obtained by passing a *Rows value to the Row.Scan method."
* https://golang.org/doc/go1.12#net/http

> The HTTP server now rejects misdirected HTTP requests to HTTPS servers with a plaintext "400 Bad Request" response.

> The new Client.CloseIdleConnections method calls the Client's underlying Transport's CloseIdleConnections if it has one.

> The Transport no longer rejects HTTP responses which declare HTTP Trailers but don't use chunked encoding. Instead, the declared trailers are now just ignored.

> The Transport no longer handles MAX_CONCURRENT_STREAMS values advertised from HTTP/2 servers as strictly as it did during Go 1.10 and Go 1.11. The default behavior is now back to how it was in Go 1.9: each connection to a server can have up to MAX_CONCURRENT_STREAMS requests active and then new TCP connections are created as needed. In Go 1.10 and Go 1.11 the http2 package would block and wait for requests to finish instead of creating new connections. To get the stricter behavior back, import the golang.org/x/net/http2 package directly and set Transport.StrictMaxConcurrentStreams to true. 

* strings "The new function ReplaceAll returns a copy of a string with all non-overlapping instances of a value replaced by another."

* testing "The -benchtime flag now supports setting an explicit iteration count instead of a time when the value ends with an "x". For example, -benchtime=100x runs the benchmark 100 times."

* GC and perf improvements https://golang.org/doc/go1.12#runtime which might help with https://bugzilla.mozilla.org/show_bug.cgi?id=1547740