### PR TITLE
contentsignaturepki: don't set the signature algorithm when issuing EE

### DIFF
--- a/signer/contentsignaturepki/x509.go
+++ b/signer/contentsignaturepki/x509.go
@@ -96,12 +96,12 @@ func (s *ContentSigner) makeChain() (chain string, name string, err error) {
 			Province:           []string{"California"},
 			Locality:           []string{"Mountain View"},
 		},
-		DNSNames:           []string{cn},
-		NotBefore:          notBefore,
-		NotAfter:           notAfter,
-		IsCA:               false,
-		ExtKeyUsage:        []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
-		KeyUsage:           x509.KeyUsageDigitalSignature,
+		DNSNames:    []string{cn},
+		NotBefore:   notBefore,
+		NotAfter:    notAfter,
+		IsCA:        false,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		KeyUsage:    x509.KeyUsageDigitalSignature,
 	}
 
 	certBytes, err := x509.CreateCertificate(s.rand, crtTpl, issuer, s.eePub, s.issuerPriv)

--- a/signer/contentsignaturepki/x509.go
+++ b/signer/contentsignaturepki/x509.go
@@ -99,7 +99,6 @@ func (s *ContentSigner) makeChain() (chain string, name string, err error) {
 		DNSNames:           []string{cn},
 		NotBefore:          notBefore,
 		NotAfter:           notAfter,
-		SignatureAlgorithm: issuer.SignatureAlgorithm,
 		IsCA:               false,
 		ExtKeyUsage:        []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
 		KeyUsage:           x509.KeyUsageDigitalSignature,


### PR DESCRIPTION
The signature algorithm is automatically inferred by Go's x509 package depending on the private keys of both the issuer and the subject.