### PR TITLE
database: error instead of dying on monitor failure

### DIFF
--- a/autograph.yaml
+++ b/autograph.yaml
@@ -513,7 +513,6 @@ signers:
 
     - id: testmar
       type: mar
-      # label of the private key in the hsm, it isn't stored locally
       privatekey: |
           -----BEGIN PRIVATE KEY-----
           MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCAUrUDTS86CuqV

--- a/autograph.yaml
+++ b/autograph.yaml
@@ -29,6 +29,7 @@ statsd:
 #    sslrootcert: /etc/ssl/certs/db-root.crt
 #    maxopenconns: 100
 #    maxidleconns: 10
+#    monitorpollinterval: 10s
 
 # The keys below are testing keys that do not grant any power
 signers:

--- a/database/connect_test.go
+++ b/database/connect_test.go
@@ -1,0 +1,44 @@
+package database
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMonitor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("runs and dies on connection close", func(t *testing.T) {
+		t.Parallel()
+
+		// connects
+		db, err := Connect(Config{
+			Name:     "autograph",
+			User:     "myautographdbuser",
+			Password: "myautographdbpassword",
+			Host:     "127.0.0.1:5432",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		quit := make(chan bool)
+		go db.Monitor(5*time.Millisecond, quit)
+
+		// should not error for initial monitor run
+		err = db.CheckConnection()
+		if err != nil {
+			t.Fatalf("db.CheckConnection failed when it should not have with error: %s", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+
+		// error for failing checks
+		db.Close()
+		err = db.CheckConnection()
+		if err == nil {
+			t.Fatalf("db.CheckConnection did not fail for a closed DB")
+		}
+
+		quit <- true
+	})
+}

--- a/database/queries_test.go
+++ b/database/queries_test.go
@@ -10,10 +10,11 @@ import (
 
 func TestConcurrentEndEntityOperations(t *testing.T) {
 	db, err := Connect(Config{
-		Name:     "autograph",
-		User:     "myautographdbuser",
-		Password: "myautographdbpassword",
-		Host:     "127.0.0.1:5432",
+		Name:                "autograph",
+		User:                "myautographdbuser",
+		Password:            "myautographdbpassword",
+		Host:                "127.0.0.1:5432",
+		MonitorPollInterval: 10 * time.Second,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -61,6 +61,7 @@ Make sure to set a user with limited grants in the configuration.
 		sslrootcert: /etc/ssl/certs/db-root.crt
 		maxopenconns: 100
 		maxidleconns: 10
+		monitorpollinterval: 10s
 
 Hardware Security Module (HSM)
 ------------------------------

--- a/handlers.go
+++ b/handlers.go
@@ -238,6 +238,47 @@ func handleLBHeartbeat(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("ohai"))
 }
 
+// handleHeartbeat checks whether backing services are enabled and
+// accessible and returns 200 when they are and 502 when the
+// aren't. Currently it only checks whether the HSM is accessible.
+func (a *autographer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		httpError(w, r, http.StatusMethodNotAllowed, "%s method not allowed; endpoint accepts GET only", r.Method)
+		return
+	}
+	var (
+		// a map of backing service name to up or down/inaccessible status
+		result = map[string]bool{}
+		status = http.StatusOK
+	)
+
+	// try to fetch the private key from the HSM for the first
+	// signer conf with a non-PEM private key that we saved on
+	// server start
+	conf := a.hsmHeartbeatSignerConf
+	if conf != nil {
+		err := conf.CheckHSMConnection()
+		if err == nil {
+			result["hsmAccessible"] = true
+			status = http.StatusOK
+		} else {
+			log.Errorf("error checking HSM connection for signer %s: %s", conf.ID, err)
+			result["hsmAccessible"] = false
+			status = http.StatusInternalServerError
+		}
+	}
+
+	respdata, err := json.Marshal(result)
+	if err != nil {
+		log.Errorf("heartbeat failed to marshal JSON with error: %s", err)
+		httpError(w, r, http.StatusInternalServerError, "error marshaling response JSON")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	w.Write(respdata)
+}
+
 func handleVersion(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "GET" {
 		httpError(w, r, http.StatusMethodNotAllowed, "%s method not allowed; endpoint accepts GET only", r.Method)

--- a/handlers.go
+++ b/handlers.go
@@ -268,6 +268,19 @@ func (a *autographer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// check the database connection and return its status, but
+	// don't fail the heartbeat since we only care about DB
+	// connectivity on server start
+	if a.db != nil {
+		err := a.db.CheckConnection()
+		if err == nil {
+			result["dbAccessible"] = true
+		} else {
+			log.Errorf("error checking DB connection: %s", err)
+			result["dbAccessible"] = false
+		}
+	}
+
 	respdata, err := json.Marshal(result)
 	if err != nil {
 		log.Errorf("heartbeat failed to marshal JSON with error: %s", err)

--- a/handlers.go
+++ b/handlers.go
@@ -229,8 +229,8 @@ func (a *autographer) handleSignature(w http.ResponseWriter, r *http.Request) {
 	log.WithFields(log.Fields{"rid": rid}).Info("signing request completed successfully")
 }
 
-// handleHeartbeat returns a simple message indicating that the API is alive and well
-func handleHeartbeat(w http.ResponseWriter, r *http.Request) {
+// handleLBHeartbeat returns a simple message indicating that the API is alive and well
+func handleLBHeartbeat(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "GET" {
 		httpError(w, r, http.StatusMethodNotAllowed, "%s method not allowed; endpoint accepts GET only", r.Method)
 		return

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -360,7 +360,7 @@ func TestAuthFail(t *testing.T) {
 	}
 }
 
-func TestHeartbeat(t *testing.T) {
+func TestLBHeartbeat(t *testing.T) {
 	t.Parallel()
 
 	var TESTCASES = []struct {
@@ -373,7 +373,7 @@ func TestHeartbeat(t *testing.T) {
 		{http.StatusMethodNotAllowed, `HEAD`},
 	}
 	for i, testcase := range TESTCASES {
-		req, err := http.NewRequest(testcase.method, "http://foo.bar/__heartbeat__", nil)
+		req, err := http.NewRequest(testcase.method, "http://foo.bar/__lbheartbeat__", nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -384,6 +384,59 @@ func TestHeartbeat(t *testing.T) {
 				i, w.Code, testcase.expect)
 		}
 	}
+}
+
+func TestHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	var TESTCASES = []struct {
+		expectedHTTPStatus int
+		method             string
+	}{
+		{http.StatusOK, `GET`},
+		{http.StatusMethodNotAllowed, `POST`},
+		{http.StatusMethodNotAllowed, `PUT`},
+		{http.StatusMethodNotAllowed, `HEAD`},
+	}
+	for i, testcase := range TESTCASES {
+		req, err := http.NewRequest(testcase.method, "http://foo.bar/__heartbeat__", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		w := httptest.NewRecorder()
+		ag.handleHeartbeat(w, req)
+		if w.Code != testcase.expectedHTTPStatus {
+			t.Fatalf("test case %d failed with code %d but %d was expected",
+				i, w.Code, testcase.expectedHTTPStatus)
+		}
+		if bytes.Equal(w.Body.Bytes(), []byte("{}\n")) {
+			t.Fatalf("test case %d returned unexpected heartbeat body %s expected {}", i, w.Body.Bytes())
+		}
+	}
+}
+
+func TestHeartbeatChecksHSMStatusFails(t *testing.T) {
+	// NB: do not run in parallel with TestHeartbeat
+	ag.hsmHeartbeatSignerConf = &ag.signers[0].(*contentsignature.ContentSigner).Configuration
+
+	expectedStatus := http.StatusInternalServerError
+	expectedBody := []byte("{\"hsmAccessible\":false}")
+
+	req, err := http.NewRequest(`GET`, "http://foo.bar/__heartbeat__", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := httptest.NewRecorder()
+	ag.handleHeartbeat(w, req)
+
+	if w.Code != expectedStatus {
+		t.Fatalf("failed with code %d but %d was expected", w.Code, expectedStatus)
+	}
+	if !bytes.Equal(w.Body.Bytes(), expectedBody) {
+		t.Fatalf("got unexpected heartbeat body %s expected %s", w.Body.Bytes(), expectedBody)
+	}
+
+	ag.hsmHeartbeatSignerConf = nil
 }
 
 func TestVersion(t *testing.T) {

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -378,7 +378,7 @@ func TestHeartbeat(t *testing.T) {
 			t.Fatal(err)
 		}
 		w := httptest.NewRecorder()
-		handleHeartbeat(w, req)
+		handleLBHeartbeat(w, req)
 		if w.Code != testcase.expect {
 			t.Fatalf("test case %d failed with code %d but %d was expected",
 				i, w.Code, testcase.expect)

--- a/main.go
+++ b/main.go
@@ -304,7 +304,7 @@ func (a *autographer) initHSM(conf configuration) {
 		// if we successfully initialized the crypto11 context,
 		// tell the signers they can try using the HSM
 		for i := range conf.Signers {
-			conf.Signers[i].HsmIsAvailable(tmpCtx)
+			conf.Signers[i].InitHSM(tmpCtx)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -173,7 +173,7 @@ func run(conf configuration, listen string, authPrint, debug bool) {
 
 	router := mux.NewRouter().StrictSlash(true)
 	router.HandleFunc("/__heartbeat__", handleHeartbeat).Methods("GET")
-	router.HandleFunc("/__lbheartbeat__", handleHeartbeat).Methods("GET")
+	router.HandleFunc("/__lbheartbeat__", handleLBHeartbeat).Methods("GET")
 	router.HandleFunc("/__version__", handleVersion).Methods("GET")
 	router.HandleFunc("/__monitor__", ag.handleMonitor).Methods("GET")
 	router.HandleFunc("/sign/file", ag.handleSignature).Methods("POST")

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -143,8 +143,8 @@ type Configuration struct {
 	hsmCtx         *pkcs11.Ctx
 }
 
-// HsmIsAvailable indicates that an HSM has been initialized
-func (cfg *Configuration) HsmIsAvailable(ctx *pkcs11.Ctx) {
+// InitHSM indicates that an HSM has been initialized
+func (cfg *Configuration) InitHSM(ctx *pkcs11.Ctx) {
 	cfg.isHsmAvailable = true
 	cfg.hsmCtx = ctx
 }

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -157,9 +157,9 @@ func TestParseEmptyPrivateKey(t *testing.T) {
 	}
 }
 
-func TestEnableHSM(t *testing.T) {
+func TestInitHSM(t *testing.T) {
 	tcfg := new(Configuration)
-	tcfg.HsmIsAvailable(nil)
+	tcfg.InitHSM(nil)
 	if !tcfg.isHsmAvailable {
 		t.Fatal("expected isHsmAvailable to be set to true but still false")
 	}
@@ -190,7 +190,7 @@ func TestHSMNotAvailable(t *testing.T) {
 		}
 	}()
 	tcfg := new(Configuration)
-	tcfg.HsmIsAvailable(nil)
+	tcfg.InitHSM(nil)
 	tcfg.GetPrivateKey()
 }
 

--- a/tools/softhsm/autograph.softhsm.yaml
+++ b/tools/softhsm/autograph.softhsm.yaml
@@ -24,6 +24,7 @@ database:
   sslrootcert: /opt/db-root.crt
   maxopenconns: 100
   maxidleconns: 10
+  monitorpollinterval: 10s
 
 # The keys below are testing keys that do not grant any power
 signers:


### PR DESCRIPTION
Code changes:

* change DB monitor to log errors instead of dying (only the csigpki signer uses the DB and it sets up and loads its config at init, so it's OK to briefly lose DB connectivity and we shouldn't crash the app)
* factor out DB init to addDB in main
* factor out CheckConnection func
* add connect/monitor tests
* add MonitorPollInterval to DB config
* distinguish the heartbeat handler from LB heartbeat and teach it to check HSM connectivity (it finds the first signer config with a non-PEM private key, caches it, and uses it to check HSM connectivity returning 502 bad gateway when the connection fails to remove it from the health LBs cc @milescrabill @Micheletto re: this behavior) 

Unit tests just check DB connected and HSM disconnected, but I functional tested that running app-hsm and hitting http://localhost:8001/__heartbeat__ returns 

```json
{"hsmAccessible": true}
```

r? @jvehent 

TODO assuming this lands:

- [ ] monitor logs for HSM and DB disconnects
- [ ] add monitorpollinterval to autograph configs