### PR TITLE
Fix base deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2
 jobs:
   lint-vet-fmt:
     docker:
-      - image: golang:1.12
+      - image: golang:1.12-buster
     working_directory: /usr/local/go/src/go.mozilla.org/autograph
     steps:
       - checkout
@@ -33,7 +33,7 @@ jobs:
 
   unit-test:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.12-buster
       - image: circleci/postgres:11
         environment:
           POSTGRES_USER: root
@@ -79,7 +79,7 @@ jobs:
   build-integrationtest-verify:
     # based on the official golang image with more docker stuff
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.12-buster
     working_directory: /go/src/go.mozilla.org/autograph
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN addgroup --gid 10001 app \
       apt -y upgrade && \
       apt -y install libltdl-dev && \
       apt -y install gpg && \
+      apt -y install libncurses5 && \
       apt-get clean
 
 # import the RDS CA bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12
+FROM golang:1.12-buster
 EXPOSE 8000
 
 RUN addgroup --gid 10001 app \

--- a/bin/run_integration_tests.sh
+++ b/bin/run_integration_tests.sh
@@ -53,7 +53,7 @@ docker-compose run \
 	       --rm \
 	       --user 0 \
 	       -e TARGET=http://app:8000 \
-               -e VERIFY=0 \
+               -e VERIFY=1 \
 	       --workdir /go/src/go.mozilla.org/autograph/tools/autograph-client \
 	       --entrypoint ./build_test_apks.sh \
 	       app

--- a/tools/autograph-client/build_test_apks.sh
+++ b/tools/autograph-client/build_test_apks.sh
@@ -29,13 +29,9 @@ go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f aligned-two-files.a
 
 VERIFY=${VERIFY:-"0"}
 if [ "$VERIFY" = "1" ]; then
-    # previously from circleci/android:api-25-alpha
     # NB: need to be running as root
-    echo 'deb http://deb.debian.org/debian buster main' > /etc/apt/sources.list.d/buster.list
-    echo 'deb http://deb.debian.org/debian stretch-backports main' > /etc/apt/sources.list.d/stretch-backports.list
     apt update -qq
-    apt -t stretch-backports install -y openjdk-11-jre
-    apt -t buster install -y android-sdk-build-tools apksigner
+    apt install -y openjdk-11-jre android-sdk-build-tools apksigner
     for apk in $(ls *.resigned.apk); do
         echo "verifying ${apk}"
         java -jar /usr/bin/apksigner verify --verbose $apk


### PR DESCRIPTION
Changes:
* pin the debian version varient we want
* tidy up apksigner deps and re-enable APK verification in CI
* include libncurses5 for cloudhsm client and fixes #308 which should let us revert https://github.com/mozilla-services/cloudops-deployment/pull/3321/commits/06d98f55a1d83b69a9ab656bcb220f2524674be4 (NB: shasums don't match lib versions in stage)

@Micheletto did you want to install the cloudhsm client in the container too?