### PR TITLE
Generic rsa

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ lint:
 			go.mozilla.org/autograph/signer/mar \
 			go.mozilla.org/autograph/signer/pgp \
 			go.mozilla.org/autograph/signer/gpg2 \
+			go.mozilla.org/autograph/signer/genericrsa \
 			go.mozilla.org/autograph/signer/rsapss | tee /tmp/autograph-golint.txt | grep -v 'and that stutters' | wc -l)
 
 show-lint:
@@ -132,13 +133,19 @@ testgpg2:
 showcoveragegpg2: testgpg2
 	$(GO) tool cover -html=coverage_gpg2.out
 
+testgenericrsa:
+	$(GOTEST) -coverprofile=coverage_genericrsa.out go.mozilla.org/autograph/signer/genericrsa
+
+showcoveragegenericrsa: testgenericrsa
+	$(GO) tool cover -html=coverage_genericrsa.out
+
 testrsapss:
 	$(GOTEST) -coverprofile=coverage_rsapss.out go.mozilla.org/autograph/signer/rsapss
 
 showcoveragersapss: testrsapss
 	$(GO) tool cover -html=coverage_rsapss.out
 
-test: testautograph testautographdb testsigner testcs testcspki testxpi testapk testmar testpgp testgpg2 testrsapss testmonitor
+test: testautograph testautographdb testsigner testcs testcspki testxpi testapk testmar testpgp testgpg2 testgenericrsa testrsapss testmonitor
 	echo 'mode: count' > coverage.out
 	grep -v mode coverage_*.out | cut -d ':' -f 2,3 >> coverage.out
 

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ tag: all
 lint:
 	test 0 -eq $(shell $(GOLINT) go.mozilla.org/autograph \
 			go.mozilla.org/autograph/database \
+			go.mozilla.org/autograph/formats \
 			go.mozilla.org/autograph/signer \
 			go.mozilla.org/autograph/signer/contentsignature \
 			go.mozilla.org/autograph/signer/contentsignaturepki \
@@ -53,6 +54,7 @@ vet:
 	$(GO) vet go.mozilla.org/autograph
 	$(GO) vet go.mozilla.org/autograph/database
 	$(GO) vet go.mozilla.org/autograph/signer
+	$(GO) vet go.mozilla.org/autograph/formats
 	$(GO) vet go.mozilla.org/autograph/signer/apk
 	$(GO) vet go.mozilla.org/autograph/signer/contentsignature
 	$(GO) vet go.mozilla.org/autograph/signer/contentsignaturepki
@@ -62,6 +64,7 @@ vet:
 	$(GO) vet go.mozilla.org/autograph/signer/mar
 	$(GO) vet go.mozilla.org/autograph/signer/pgp
 	$(GO) vet go.mozilla.org/autograph/signer/gpg2
+	$(GO) vet go.mozilla.org/autograph/signer/genericrsa
 	$(GO) vet go.mozilla.org/autograph/signer/rsapss
 
 fmt-diff:
@@ -81,6 +84,12 @@ testautographdb:
 
 showcoverageautographdb: testautographdb
 	$(GO) tool cover -html=coverage_db.out
+
+testautographformats:
+	$(GOTEST) -coverprofile=coverage_formats.out go.mozilla.org/autograph/formats
+
+showcoverageautographformats: testautographformats
+	$(GO) tool cover -html=coverage_formats.out
 
 testsigner:
 	$(GOTEST) -coverprofile=coverage_signer.out go.mozilla.org/autograph/signer
@@ -145,7 +154,7 @@ testrsapss:
 showcoveragersapss: testrsapss
 	$(GO) tool cover -html=coverage_rsapss.out
 
-test: testautograph testautographdb testsigner testcs testcspki testxpi testapk testmar testpgp testgpg2 testgenericrsa testrsapss testmonitor
+test: testautograph testautographdb testautographformats testsigner testcs testcspki testxpi testapk testmar testpgp testgpg2 testgenericrsa testrsapss testmonitor
 	echo 'mode: count' > coverage.out
 	grep -v mode coverage_*.out | cut -d ':' -f 2,3 >> coverage.out
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Autograph is a cryptographic signature service that implements
 [MAR Signing](signer/mar/README.rst) for Firefox updates,
 [APK V1 Signing](signer/apk/README.rst) for Android,
 [PGP](signer/pgp/README.rst), [GPG2](signer/gpg2/README.rst)
-and [RSA PSS](signer/rsapss/README.rst).
+and [RSA](signer/genericrsa/README.rst).
 
 [![CircleCI](https://circleci.com/gh/mozilla-services/autograph/tree/master.svg?style=svg)](https://circleci.com/gh/mozilla-services/autograph/tree/master)
 [![Coverage Status](https://coveralls.io/repos/github/mozilla-services/autograph/badge.svg?branch=master)](https://coveralls.io/github/mozilla-services/autograph?branch=master)

--- a/autograph.yaml
+++ b/autograph.yaml
@@ -862,6 +862,7 @@ signers:
         gAAPg+05bWI=
         =459B
         -----END PGP PUBLIC KEY BLOCK-----
+
     - id: dummyrsapss
       # a test 2048-bit RSA key
       type: rsapss
@@ -1028,6 +1029,95 @@ signers:
           PIDNiTxNecePOmrD+1ivAEXcoL+e1w==
           -----END PRIVATE KEY-----
 
+    - id: dummyrsa
+      # a test 2048-bit RSA key
+      type: genericrsa
+      mode: pss
+      hash: sha256
+      saltlength: -1
+      privatekey: |
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEpAIBAAKCAQEAtEM/Vdfd4Vl9wmeVdCYuWYnQl0Zc9RW5hLE4hFA+c277qanE
+        8XCK+ap/c5so87XngLLfacB3zZhGxIOut/4SlEBOAUmVNCfnTO+YkRk3A8OyJ4XN
+        qdn+/ov78ZbssGf+0zws2BcwZYwhtuTvro3yi62FQ7T1TpT5VjljH7sHW/iZnS/R
+        KiY4DwqAN799gkB+Gwovtroabh2w5OX0P+PYyUbJLFQeo5uiAQ8cAXTlHqCkj11G
+        YgU4ttVDuFGotKRyaRn1F+yKxE4LQcAULx7s0KzvS35mNU+MoywLWjy9a4TcjK0n
+        q+BjspKX4UkNwVstvH18hQWun7E+dxTi59cRmwIDAQABAoIBAEKpi8aHKfqoSaWX
+        AOIPLJzYJleLId1Qx2aW0zu7IR03McIwkjBnWj2yG6f4/VADOTWS8KP/FU7mvWT2
+        /an1P5Grpi07tP2wtAzzngwqsvmlaUDMbp4di/s+cVGKasVh8A7V9g+Do9Yp2F32
+        k9yNieC1rs63IPCKjxqf5lRZqgMMcL1QYSlJI98riSVGm0m29u1v3pN6qDVNto2d
+        l6m6D8UT6vx1lfVZFV+Td3FmYHnuYyVwbgJ8dFRBQFpe2tsccK955+lapFe9MA/o
+        Xa5VfAWJ7YoLcgfssxF7atpHt2wcpvEj6NfIHfeDdExQ+Vd9T8vQGh88wd32QcTa
+        w1RiQUECgYEA7OFpsduOHqgqVSf1nIH6RPLytzzoXXd8Bs1aXWCxy45xg7lkKG+x
+        8Fa4aUFDII9RR4N7YFfUh8LwKF56BwFePbP4wwCuhz9v2E24I6/EfLD2GuRSv+B/
+        gNRG+suE5yCmeGlRC0uhASLr3ZzmGs16Mus/ytL5XPl8CJCmsVMjPHMCgYEAws/1
+        Sm2KOoYFY1+7ACMF89FyesOpTpqLvND79soNPC4Tl1PrPw4bsNA6p2BD1N2SPFiH
+        0yo7msNqh5o90wdnYA7i1uDWhcvrFnbg4e8+RhghcG/dJW33Lm5d5knST4NQxnAO
+        z/0zXgB9PSnsgFzNgm6LE++/KBZs/CbxQUPb9DkCgYEAk58eiVK0TPKr/wm6DOEL
+        oLBvBjaU8Lqntm1/ZTX/V0XcBCUi//grwgWpQx8CwGXQV2rfFnll331iwSWvknIN
+        0xI3cv8XxP2JrBkzKjo9jx+RH80urJkxnI2t9lmi5473b47ijNGC8vxaVW+UDxwC
+        jX0B8lpsQL7Rx1yuJVAUY3UCgYEAtG8gZZsnWCUhgHT+IpZNwRHQ0lu+yIrjujJl
+        7KIfuAmFI7gaPwC2LQHwEW5b5SCDfVkSFEcdha5RUN9PO9GzsYiYGSWOC8ZfKyNY
+        DmskZo+bCSTS0wQS2PJoDg95tyONAP5w+bsuhHY3iRr3bbyGq7PvJLv9dQewUatP
+        8H8FjiECgYBt93fZADyyOoqeYxMc8b38F8sf1FLTOAUfB1ik5R4yNVKDaCanYhYc
+        poTajMUVdoBcEV1g5Vds8objUIeNNlMPKyUnf/lCiPvp43wYbC3y60JqzXX3bfAS
+        TDd4Me4PP+sTZeJ3RKvArDiMzEncDeMGZZnd4dBdi3LjzCNGTANAGw==
+        -----END RSA PRIVATE KEY-----
+      publickey: |
+        -----BEGIN PUBLIC KEY-----
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtEM/Vdfd4Vl9wmeVdCYu
+        WYnQl0Zc9RW5hLE4hFA+c277qanE8XCK+ap/c5so87XngLLfacB3zZhGxIOut/4S
+        lEBOAUmVNCfnTO+YkRk3A8OyJ4XNqdn+/ov78ZbssGf+0zws2BcwZYwhtuTvro3y
+        i62FQ7T1TpT5VjljH7sHW/iZnS/RKiY4DwqAN799gkB+Gwovtroabh2w5OX0P+PY
+        yUbJLFQeo5uiAQ8cAXTlHqCkj11GYgU4ttVDuFGotKRyaRn1F+yKxE4LQcAULx7s
+        0KzvS35mNU+MoywLWjy9a4TcjK0nq+BjspKX4UkNwVstvH18hQWun7E+dxTi59cR
+        mwIDAQAB
+        -----END PUBLIC KEY-----
+
+    - id: testauthenticode
+      # a test 2048-bit RSA key
+      type: genericrsa
+      mode: pkcs15
+      hash: sha1
+      privatekey: |
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEpAIBAAKCAQEAtEM/Vdfd4Vl9wmeVdCYuWYnQl0Zc9RW5hLE4hFA+c277qanE
+        8XCK+ap/c5so87XngLLfacB3zZhGxIOut/4SlEBOAUmVNCfnTO+YkRk3A8OyJ4XN
+        qdn+/ov78ZbssGf+0zws2BcwZYwhtuTvro3yi62FQ7T1TpT5VjljH7sHW/iZnS/R
+        KiY4DwqAN799gkB+Gwovtroabh2w5OX0P+PYyUbJLFQeo5uiAQ8cAXTlHqCkj11G
+        YgU4ttVDuFGotKRyaRn1F+yKxE4LQcAULx7s0KzvS35mNU+MoywLWjy9a4TcjK0n
+        q+BjspKX4UkNwVstvH18hQWun7E+dxTi59cRmwIDAQABAoIBAEKpi8aHKfqoSaWX
+        AOIPLJzYJleLId1Qx2aW0zu7IR03McIwkjBnWj2yG6f4/VADOTWS8KP/FU7mvWT2
+        /an1P5Grpi07tP2wtAzzngwqsvmlaUDMbp4di/s+cVGKasVh8A7V9g+Do9Yp2F32
+        k9yNieC1rs63IPCKjxqf5lRZqgMMcL1QYSlJI98riSVGm0m29u1v3pN6qDVNto2d
+        l6m6D8UT6vx1lfVZFV+Td3FmYHnuYyVwbgJ8dFRBQFpe2tsccK955+lapFe9MA/o
+        Xa5VfAWJ7YoLcgfssxF7atpHt2wcpvEj6NfIHfeDdExQ+Vd9T8vQGh88wd32QcTa
+        w1RiQUECgYEA7OFpsduOHqgqVSf1nIH6RPLytzzoXXd8Bs1aXWCxy45xg7lkKG+x
+        8Fa4aUFDII9RR4N7YFfUh8LwKF56BwFePbP4wwCuhz9v2E24I6/EfLD2GuRSv+B/
+        gNRG+suE5yCmeGlRC0uhASLr3ZzmGs16Mus/ytL5XPl8CJCmsVMjPHMCgYEAws/1
+        Sm2KOoYFY1+7ACMF89FyesOpTpqLvND79soNPC4Tl1PrPw4bsNA6p2BD1N2SPFiH
+        0yo7msNqh5o90wdnYA7i1uDWhcvrFnbg4e8+RhghcG/dJW33Lm5d5knST4NQxnAO
+        z/0zXgB9PSnsgFzNgm6LE++/KBZs/CbxQUPb9DkCgYEAk58eiVK0TPKr/wm6DOEL
+        oLBvBjaU8Lqntm1/ZTX/V0XcBCUi//grwgWpQx8CwGXQV2rfFnll331iwSWvknIN
+        0xI3cv8XxP2JrBkzKjo9jx+RH80urJkxnI2t9lmi5473b47ijNGC8vxaVW+UDxwC
+        jX0B8lpsQL7Rx1yuJVAUY3UCgYEAtG8gZZsnWCUhgHT+IpZNwRHQ0lu+yIrjujJl
+        7KIfuAmFI7gaPwC2LQHwEW5b5SCDfVkSFEcdha5RUN9PO9GzsYiYGSWOC8ZfKyNY
+        DmskZo+bCSTS0wQS2PJoDg95tyONAP5w+bsuhHY3iRr3bbyGq7PvJLv9dQewUatP
+        8H8FjiECgYBt93fZADyyOoqeYxMc8b38F8sf1FLTOAUfB1ik5R4yNVKDaCanYhYc
+        poTajMUVdoBcEV1g5Vds8objUIeNNlMPKyUnf/lCiPvp43wYbC3y60JqzXX3bfAS
+        TDd4Me4PP+sTZeJ3RKvArDiMzEncDeMGZZnd4dBdi3LjzCNGTANAGw==
+        -----END RSA PRIVATE KEY-----
+      publickey: |
+        -----BEGIN PUBLIC KEY-----
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtEM/Vdfd4Vl9wmeVdCYu
+        WYnQl0Zc9RW5hLE4hFA+c277qanE8XCK+ap/c5so87XngLLfacB3zZhGxIOut/4S
+        lEBOAUmVNCfnTO+YkRk3A8OyJ4XNqdn+/ov78ZbssGf+0zws2BcwZYwhtuTvro3y
+        i62FQ7T1TpT5VjljH7sHW/iZnS/RKiY4DwqAN799gkB+Gwovtroabh2w5OX0P+PY
+        yUbJLFQeo5uiAQ8cAXTlHqCkj11GYgU4ttVDuFGotKRyaRn1F+yKxE4LQcAULx7s
+        0KzvS35mNU+MoywLWjy9a4TcjK0nq+BjspKX4UkNwVstvH18hQWun7E+dxTi59cR
+        mwIDAQAB
+        -----END PUBLIC KEY-----
+
 authorizations:
     - id: alice
       key: fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu
@@ -1047,6 +1137,8 @@ authorizations:
           - randompgp
           - pgpsubkey
           - dummyrsapss
+          - dummyrsa
+          - testauthenticode
           - webextensions-rsa-with-recommendation
 
     - id: bob

--- a/formats/rest.go
+++ b/formats/rest.go
@@ -1,0 +1,23 @@
+package formats
+
+// SignatureRequest is sent by an autograph client to request
+// a signature on input data
+type SignatureRequest struct {
+	Input   string `json:"input"`
+	KeyID   string `json:"keyid,omitempty"`
+	Options interface{}
+}
+
+// SignatureResponse is returned by autograph to a client with
+// a signature computed on input data
+type SignatureResponse struct {
+	Ref        string      `json:"ref"`
+	Type       string      `json:"type"`
+	Mode       string      `json:"mode"`
+	SignerID   string      `json:"signer_id"`
+	PublicKey  string      `json:"public_key"`
+	Signature  string      `json:"signature,omitempty"`
+	SignedFile string      `json:"signed_file,omitempty"`
+	X5U        string      `json:"x5u,omitempty"`
+	SignerOpts interface{} `json:"signer_opts,omitempty"`
+}

--- a/formats/rest.go
+++ b/formats/rest.go
@@ -1,7 +1,6 @@
 package formats
 
-// SignatureRequest is sent by an autograph client to request
-// a signature on input data
+// SignatureRequest is sent by a client to request a signature on input data
 type SignatureRequest struct {
 	Input   string `json:"input"`
 	KeyID   string `json:"keyid,omitempty"`

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"go.mozilla.org/autograph/database"
+	"go.mozilla.org/autograph/formats"
 	"go.mozilla.org/autograph/signer/apk"
 	"go.mozilla.org/autograph/signer/contentsignature"
 	"go.mozilla.org/autograph/signer/mar"
@@ -39,14 +40,14 @@ func TestSignaturePass(t *testing.T) {
 
 	var TESTCASES = []struct {
 		endpoint          string
-		signaturerequests []signaturerequest
+		signaturerequests []formats.SignatureRequest
 	}{
 		{
 			// Sign hash with Content Signature
 			"/sign/hash",
-			[]signaturerequest{
+			[]formats.SignatureRequest{
 				// request signature of a precomputed sha384 hash
-				signaturerequest{
+				formats.SignatureRequest{
 					Input: "y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d",
 					KeyID: "appkey1",
 				},
@@ -55,8 +56,8 @@ func TestSignaturePass(t *testing.T) {
 		{
 			// Sign a regular add-on
 			"/sign/data",
-			[]signaturerequest{
-				signaturerequest{
+			[]formats.SignatureRequest{
+				formats.SignatureRequest{
 					Input: "U2lnbmF0dXJlLVZlcnNpb246IDEuMApNRDUtRGlnZXN0LU1hbmlmZXN0OiA3d3RFNTF2bW00NlZQRmEvNkF0NWZ3PT0KU0hBMS1EaWdlc3QtTWFuaWZlc3Q6IEZMZEFIZHQvVjdFVHozK0JMUUtHcFFBenoyRT0KCg==",
 					KeyID: "webextensions-rsa",
 					Options: map[string]string{
@@ -68,8 +69,8 @@ func TestSignaturePass(t *testing.T) {
 		{
 			// Sign an extension
 			"/sign/data",
-			[]signaturerequest{
-				signaturerequest{
+			[]formats.SignatureRequest{
+				formats.SignatureRequest{
 					Input: "U2lnbmF0dXJlLVZlcnNpb246IDEuMApNRDUtRGlnZXN0LU1hbmlmZXN0OiA3d3RFNTF2bW00NlZQRmEvNkF0NWZ3PT0KU0hBMS1EaWdlc3QtTWFuaWZlc3Q6IEZMZEFIZHQvVjdFVHozK0JMUUtHcFFBenoyRT0KCg==",
 					KeyID: "extensions-ecdsa",
 					Options: map[string]string{
@@ -81,8 +82,8 @@ func TestSignaturePass(t *testing.T) {
 		{
 			// Sign data with Content-Signature
 			"/sign/data",
-			[]signaturerequest{
-				signaturerequest{
+			[]formats.SignatureRequest{
+				formats.SignatureRequest{
 					Input: "PCFET0NUWVBFIEhUTUw+CjxodG1sPgo8IS0tIGh0dHBzOi8vYnVnemlsbGEubW96aWxsYS5vcmcvc2hvd19idWcuY2dpP2lkPTEyMjY5MjggLS0+CjxoZWFkPgogIDxtZXRhIGNoYXJzZXQ9InV0Zi04Ij4KICA8dGl0bGU+VGVzdHBhZ2UgZm9yIGJ1ZyAxMjI2OTI4PC90aXRsZT4KPC9oZWFkPgo8Ym9keT4KICBKdXN0IGEgZnVsbHkgZ29vZCB0ZXN0cGFnZSBmb3IgQnVnIDEyMjY5Mjg8YnIvPgo8L2JvZHk+CjwvaHRtbD4K",
 					KeyID: "appkey2",
 				},
@@ -91,8 +92,8 @@ func TestSignaturePass(t *testing.T) {
 		{
 			// Sign an APK manifest
 			"/sign/data",
-			[]signaturerequest{
-				signaturerequest{
+			[]formats.SignatureRequest{
+				formats.SignatureRequest{
 					Input: "U2lnbmF0dXJlLVZlcnNpb246IDEuMApNRDUtRGlnZXN0LU1hbmlmZXN0OiA3d3RFNTF2bW00NlZQRmEvNkF0NWZ3PT0KU0hBMS1EaWdlc3QtTWFuaWZlc3Q6IEZMZEFIZHQvVjdFVHozK0JMUUtHcFFBenoyRT0KCg==",
 					KeyID: "testapp-android",
 				},
@@ -101,8 +102,8 @@ func TestSignaturePass(t *testing.T) {
 		{
 			// Sign an APK file
 			"/sign/file",
-			[]signaturerequest{
-				signaturerequest{
+			[]formats.SignatureRequest{
+				formats.SignatureRequest{
 					Input: "UEsDBBQAAAAIAAAAfgEMqbyCAwIAALoDAAAVABwAYnVpbGQtZGF0YS5wcm9wZXJ0aWVzVVQJAANQQYcU5bmyWnV4CwABBOgDAAAE6AMAAJ1Sy27UMBTd8xVeFgnHcTLpJIMsleeKh9SyoNJI0Y1zk7g4sbGdoAHx77jzKmWBEAtb9n3onHPPbWal2ySA6zGIRsN3pGYOrJeSrpLPyS2VzngfjNF04SUddo1TLe1dwGVFv5TU2MAaNbE7WIBJM7LemF4jg6l1RrWsH700DlmLC7NGK7mrPQbPcluPZoqBMChZO/hWW4f1OE891i1abXbJHbgnzZ5ebzWEzrhR/CuvY6M2EoIyk/BGKtB0H0VH7X1fQB+uzNe+53y7OfH2TrJOafSMF0WZlZfpKnK3Jqp0MMkhJo6S6sU45WuHGsFjfUgznldpwVdVlhTs+s2L1x8/vLs9kpFa4RTqUcXLBwizF/yYWtCpTkGj8Ry6lyZe3hvyjBwxyMGfLOWXCU+TnNOcXIygJq0mJFc8X695ydfZ00eAYv+hHuXskKqpM9vNxY2Tb29OdRoa1OKxrKVK8rO261c8PdbuZ5FYCINg/z2Yw6zzk1I1ovg0zOQ97AjnJEu3G15tN0Uan3xNLmLXqigqXqVnZSrIxE9g/WCCoKeZ7e9ataLI06bNOk7TIivpiudIocwayuO/zZqigbb7DT26MdoEfBKtEQ9oJ7AB4lZq5cO55LQaD/b5uGUjWBEPOUslLXYw60B+EMbIT6JGa1wghy2cFsbTtLp8/ieRvzH4DfoXUEsDBAoAAAAAAHV/dUwAAAAAAAAAAAAAAAAMABwAZXJyb3JfcHJvbmUvVVQJAAOuubJao9eyWnV4CwABBOgDAAAE6AMAAFBLAwQUAAAACAAAAH4B0laLyWIAAAB3AAAAHwAcAGVycm9yX3Byb25lL0Fubm90YXRpb25zLmd3dC54bWxVVAkAA1BBhxTlubJadXgLAAEE6AMAAAToAwAANcxBCsJADAXQvaeI+w7ZS3HrMUpw0jpFk+H3V/H2CuLurd54LEUuL8oj6353qb5d0ToTg9jOXDwcRq8yJ4SGxSmqvDXUqRv41tWepg4kpo4MP1lE0tgyNinlfBh/9xf61wdQSwMECgAAAAAAdX91TAAAAAAAAAAAAAAAABMAHABqc3IzMDVfYW5ub3RhdGlvbnMvVVQJAAOuubJao9eyWnV4CwABBOgDAAAE6AMAAFBLAwQUAAAACAAAAH4BW1Ms2mgAAACFAAAALQAcAGpzcjMwNV9hbm5vdGF0aW9ucy9Kc3IzMDVfYW5ub3RhdGlvbnMuZ3d0LnhtbFVUCQADUEGHFOW5slp1eAsAAQToAwAABOgDAABlzTEKg0AQRuE+p5j0LiMEG5G0OYYM2VFXzI7M/hpyewPBKt3Ha153DYEeb9DL4rYoRS1PTyvMK5INNmpWF2ikwZwgPiqIGVPy2K/i+PAsu/Bc/FY3veRsECTLpf1PFML90v1OX/CpA1BLAwQKAAAAAAB1f3VMAAAAAAAAAAAAAAAABwAcAGtvdGxpbi9VVAkAA665slqj17JadXgLAAEE6AMAAAToAwAAUEsDBAoAAAAAAHV/dUwAAAAAAAAAAAAAAAAQABwAa290bGluL2ludGVybmFsL1VUCQADrrmyWqPXslp1eAsAAQToAwAABOgDAABQSwMEFAAAAAgAAAB+AaMkSDi2AQAA1gIAACgAHABrb3RsaW4vaW50ZXJuYWwvaW50ZXJuYWwua290bGluX2J1aWx0aW5zVVQJAANQQYcU5bmyWnV4CwABBOgDAAAE6AMAAH1PwW7UMBC14yR1pruLm5aSLpx66rHiwl7Tsoit2iWKlkNPyN04S1SvXSVeEEd+hE/g0BPf1S/AccIuEhKWPM/z3ryZMUKIIIQw6g6Gnx6E99rISkF0KbUS/E4KIKn6BsGyzYFWyohacQkHmeSm1PX6rXgQqhDKAKRKacNNpRUA373DBa9XwsCIS6m/iqJLG2C7+r6Cvvs4v1zMPswhyoWxPVt78IXLjYDDXfVOCy9m8zS/hWG2qUUuqrJyK48Wt9n0U5bm6c10Mc2BFVVZilqopbjRxUZqIDO7MOaA7wAvwb/WagUndoWs1qtaNI1tfs0bM5Vi3X4taAyvDRD7U/AbIx6ArHURfwaPIQgpYjjp0LPoW/RtRljQs2HP7tksZNSxIYMeBz2OHBLGetdhjy8SNP6BxwmLX/vs6AzZ+NzF4zM0Qe+9rYKdgp2CJ9gpic1OXPXYxZfOg7YKdgp2SutB45i9+nuOm/CH6ye0vZ8wBe98YO/wV0ROj2kZY5Tgq5ARazl6wr6VvNM39LvXCv4F6qjgMYrpXjyiUQx0cBVSOKeT/ceoI4ZxS8Dk2da4/1/jwT/G31BLAwQKAAAAAAB1f3VMAAAAAAAAAAAAAAAAEgAcAGtvdGxpbi9hbm5vdGF0aW9uL1VUCQADrrmyWqPXslp1eAsAAQToAwAABOgDAABQSwMEFAAAAAgAAAB+Ad2BpysvAgAAngMAACwAHABrb3RsaW4vYW5ub3RhdGlvbi9hbm5vdGF0aW9uLmtvdGxpbl9idWlsdGluc1VUCQADUEGHFOW5slp1eAsAAQToAwAABOgDAACFkM1O20AQx3f9lfUkBGModelXGqo2pyrcuK6NQ0wdO1o7qJwiF5aKNDhVcKh4gfYt+hCc+lx5gq7xNukBqZZ+mp2P/4xnEEIqQgij6sPwSwXj66yYXuUAWZ7Piqy4muWwTVdvxguePwQ1P19cg5HEI+b5YLhBRNkZ1NgoSoOBD9Zak2bzL7wA3QtpkohEFMUpTYM4GleRZno29MdDyujAT30GZMjioc/SM9B7gR8eQTOMPRqOTykLqBv6sHlKw9G/iroXR0nKRl4aC3lvFHlle9j822h87Kdl3TqQVAGtHA3gfxoyP0lKjdYLxASzjNMwoAnUk6v8nH+srlK75fObcnv14MMBmN50lvPs85SDSvM70M9LH6zB4qZw+dHsfHEtjsUvANbHAEOeo5lNp7Pv/KJybwAY/8az4qGbuT6zfptNFxx0Op9nd/YEFAuBRpCFwSDYUhwkLLLUB4utmvSfSrsn7XOZfyn9V9J/Le0badsy/9ZBe+pvE7ffkx/YxthRXIUoE4VoAl1gLHEDlK4Chi3+oau2L2WhJguJwBSAoC5oCDYETcGmwBJsCWzBtmBH8GSyRXbvzQbRbUIcWyOk86yao63m7JJLGyPHODGsF4eov7PEmsjX2u/IT6VMEBdVIfPetAnYTdKygTRODAJd7dBc1dX/U3co6xousQ2iWPsdzDRrv4+XmJSqcvnHlcdSCaXSanWUbqls9ZUltqVSAyK2ww7ubjza494UB/wDUEsDBAoAAAAAAAmAdUwAAAAAAAAAAAAAAAAJABwATUVUQS1JTkYvVVQJAAPRubJao9eyWnV4CwABBOgDAAAE6AMAAFBLAwQUAAAACAAAAH4BEyaSx4YBAAAJAwAALgAcAE1FVEEtSU5GL2tvdGxpbngtY29yb3V0aW5lcy1jb3JlLmtvdGxpbl9tb2R1bGVVVAkAA1BBhxTlubJadXgLAAEE6AMAAAToAwAAjVLLSgMxFB0VqUZbdFBBXLgRFBf1B9z0oYiOUGxFXGaSqw1Nc4c8ZCr+r7/hzbTV6qYuhpx77uvkZJIkWUuSZGX21djnKjseodfKlE2BFoNXBlwTygKsGoPxXKcHrdx5y4XvoKF04F6hufMpawelJVhH+LDDjQCtea7hT1l9IUXhfgfHhQYfwy68gLUgiU478+2xHUo/LZ1xXeUK7sUQLNFH3/RVKaCIa264kbpK1rqQh9eobmE4kZpPCGxdvdGdMsSiCkoQwWN1gfVbzOloZPx9stC5/QAujOEeZdS+1ScJMugqdTAYWuCyh6h/ydsekHF9DFbEltqzAk3l7IOdLTG6KYbcGNAu3f12fMrEOS1BSqNRbYtcCu4Wkps/kM1gvNNmz6IMUQa7Xb5dke3W0HtvtDyOlaABexmK0bUFyJQZgcyUo2dhl+z8H7OsMk4JlzYejZzbE30YsNNl3Q40CO/SjX4FSMjOFD2aXHFXuV9/GioN8wJ2wU6WTp0YkdbuA/1cd/4LUEsDBBQAAAAIAAAAfgG0Oma0SAAAAE0AAAAxABwATUVUQS1JTkYva290bGlueC1jb3JvdXRpbmVzLWFuZHJvaWQua290bGluX21vZHVsZVVUCQADUEGHFOW5slp1eAsAAQToAwAABOgDAABjYGBgZmBgYIRidi5rLvXs/JKczLwKveT8ovzSksy81GK91IqC1KLM3NS8ksQcvcS8lKL8zBQhAQ8gKye1yDk/ryS1osS7BABQSwMEFAAAAAgAAAB+AZ7sVwQnAAAAKwAAACkAHABNRVRBLUlORi9rb3RsaW4tc3RkbGliLWpyZTcua290bGluX21vZHVsZVVUCQADUEGHFOW5slp1eAsAAQToAwAABOgDAABjYGBgZmBgYIRiTi5JLrbs/JKczDwhfsfSknznnPzi1MSknFTvEgBQSwMEFAAAAAgAAAB+AfGhyDynAAAA9gAAACUAHABNRVRBLUlORi9rb3RsaW4tcnVudGltZS5rb3RsaW5fbW9kdWxlVVQJAANQQYcU5bmyWnV4CwABBOgDAAAE6AMAAF2OywrCMBBFI4JgRGrjShDcuHLhPxRXvkB87ccyltE0KZNQ7N8bbaHoYhZ3ONx7hBBdIUSnub5cyN7Tek1GxQkzVGvjmYyj1G29Gp6rAhNN4DBEOZdRzS7JeGQDWsUHthmjc2TNxZMO1EzKhnqUuYo3Zb7S4NweioJMFoCTHLdAWxXV+yGBtxzWRz+Pj89kZ1PQV2CCm8Yj3pHRpF+3qRw0pR5f/+ZvUEsDBAoAAAAAAAAAfgGr+1PWBgAAAAYAAAAvABwATUVUQS1JTkYvYW5kcm9pZC5hcmNoLmxpZmVjeWNsZV9ydW50aW1lLnZlcnNpb25VVAkAA1BBhxTlubJadXgLAAEE6AMAAAToAwAAMS4wLjMKUEsDBAoAAAAAAAAAfgFoqH79BgAAAAYAAAAyABwATUVUQS1JTkYvYW5kcm9pZC5hcmNoLmxpZmVjeWNsZV9leHRlbnNpb25zLnZlcnNpb25VVAkAA1BBhxTlubJadXgLAAEE6AMAAAToAwAAMS4wLjAKUEsDBAoAAAAAAAAAfgFoqH79BgAAAAYAAAAqABwATUVUQS1JTkYvYW5kcm9pZC5hcmNoLmNvcmVfcnVudGltZS52ZXJzaW9uVVQJAANQQYcU5bmyWnV4CwABBOgDAAAE6AMAADEuMC4wClBLAwQUAAAACAAAAH4BYKTfM1MAAABXAAAAFAAcAE1FVEEtSU5GL01BTklGRVNULk1GVVQJAANQQYcU5bmyWnV4CwABBOgDAAAE6AMAAPNNzMtMSy0u0Q1LLSrOzM+zUjDUM+DlcirNzCnRdaq0UnBPzUstSixJTdFNqtR1dAnh5XIuSgXzQbKOeSlF+ZkpCu5FiSk5qQpGesZ6xrxcvFwAUEsDBAoAAAAAAHV/dUwAAAAAAAAAAAAAAAAMABwAdGhpcmRfcGFydHkvVVQJAAOuubJao9eyWnV4CwABBOgDAAAE6AMAAFBLAwQKAAAAAAB1f3VMAAAAAAAAAAAAAAAAFQAcAHRoaXJkX3BhcnR5L2phdmFfc3JjL1VUCQADrrmyWqPXslp1eAsAAQToAwAABOgDAABQSwMECgAAAAAAdX91TAAAAAAAAAAAAAAAACEAHAB0aGlyZF9wYXJ0eS9qYXZhX3NyYy9lcnJvcl9wcm9uZS9VVAkAA665slqj17JadXgLAAEE6AMAAAToAwAAUEsDBAoAAAAAAHV/dUwAAAAAAAAAAAAAAAApABwAdGhpcmRfcGFydHkvamF2YV9zcmMvZXJyb3JfcHJvbmUvcHJvamVjdC9VVAkAA665slqj17JadXgLAAEE6AMAAAToAwAAUEsDBAoAAAAAAHV/dUwAAAAAAAAAAAAAAAA1ABwAdGhpcmRfcGFydHkvamF2YV9zcmMvZXJyb3JfcHJvbmUvcHJvamVjdC9hbm5vdGF0aW9ucy9VVAkAA665slqj17JadXgLAAEE6AMAAAToAwAAUEsDBBQAAAAIAAAAfgEKaCexkgAAANUAAABMABwAdGhpcmRfcGFydHkvamF2YV9zcmMvZXJyb3JfcHJvbmUvcHJvamVjdC9hbm5vdGF0aW9ucy9Hb29nbGVfaW50ZXJuYWwuZ3d0LnhtbFVUCQADUEGHFOW5slp1eAsAAQToAwAABOgDAABNzTEOwjAMheG9pzCdibyj0pVjRFZi0lRtHLkuiNtTiJBY3va+fzg5B7enwSpxXxgib0FzNdEz0G6SuLCScYS7KBhpYgNEm7JGX0nthTM9yG8akFVFfVUpjMfOHAypFDGyLGW7JJG0sM/FWAst4NzYDa07djBssmtgqGTTtf94K+Xy1THIiu3dIq3xZ/d4UPiz3lBLAwQUAAAACAAAAH4BwKrePbkAAAB3AQAASAAcAHRoaXJkX3BhcnR5L2phdmFfc3JjL2Vycm9yX3Byb25lL3Byb2plY3QvYW5ub3RhdGlvbnMvQW5ub3RhdGlvbnMuZ3d0LnhtbFVUCQADUEGHFOW5slp1eAsAAQToAwAABOgDAAClzzEOwjAMheGdU5jONN5RYeUYlZWaNqi1K8cFcXsKBSk7S+Qh+p7+Zl/XcHk4TNotI0PHOVqaXe0AtLj2LGzk3MFVDZysZwdEH5J17UzmT7zRndpsEdlMrZ1NhXF9bxwdSUSdPKnkY3FDXZ93zbZ53kGTdbHIMJMPp+ptTZTkI2PUCXvVfuRtYPMLq8J/hfWHxMWMxTcsycCWPIPQxKeqqA2/2lDUhm9tKMxw+Sy2SZxNaHzDDf6KX1BLAQIeAxQAAAAIAAAAfgEMqbyCAwIAALoDAAAVABgAAAAAAAEAAACkgQAAAABidWlsZC1kYXRhLnByb3BlcnRpZXNVVAUAA1BBhxR1eAsAAQToAwAABOgDAABQSwECHgMKAAAAAAB1f3VMAAAAAAAAAAAAAAAADAAYAAAAAAAAABAA7UFSAgAAZXJyb3JfcHJvbmUvVVQFAAOuubJadXgLAAEE6AMAAAToAwAAUEsBAh4DFAAAAAgAAAB+AdJWi8liAAAAdwAAAB8AGAAAAAAAAQAAAKSBmAIAAGVycm9yX3Byb25lL0Fubm90YXRpb25zLmd3dC54bWxVVAUAA1BBhxR1eAsAAQToAwAABOgDAABQSwECHgMKAAAAAAB1f3VMAAAAAAAAAAAAAAAAEwAYAAAAAAAAABAA7UFTAwAAanNyMzA1X2Fubm90YXRpb25zL1VUBQADrrmyWnV4CwABBOgDAAAE6AMAAFBLAQIeAxQAAAAIAAAAfgFbUyzaaAAAAIUAAAAtABgAAAAAAAEAAACkgaADAABqc3IzMDVfYW5ub3RhdGlvbnMvSnNyMzA1X2Fubm90YXRpb25zLmd3dC54bWxVVAUAA1BBhxR1eAsAAQToAwAABOgDAABQSwECHgMKAAAAAAB1f3VMAAAAAAAAAAAAAAAABwAYAAAAAAAAABAA7UFvBAAAa290bGluL1VUBQADrrmyWnV4CwABBOgDAAAE6AMAAFBLAQIeAwoAAAAAAHV/dUwAAAAAAAAAAAAAAAAQABgAAAAAAAAAEADtQbAEAABrb3RsaW4vaW50ZXJuYWwvVVQFAAOuubJadXgLAAEE6AMAAAToAwAAUEsBAh4DFAAAAAgAAAB+AaMkSDi2AQAA1gIAACgAGAAAAAAAAAAAAKSB+gQAAGtvdGxpbi9pbnRlcm5hbC9pbnRlcm5hbC5rb3RsaW5fYnVpbHRpbnNVVAUAA1BBhxR1eAsAAQToAwAABOgDAABQSwECHgMKAAAAAAB1f3VMAAAAAAAAAAAAAAAAEgAYAAAAAAAAABAA7UESBwAAa290bGluL2Fubm90YXRpb24vVVQFAAOuubJadXgLAAEE6AMAAAToAwAAUEsBAh4DFAAAAAgAAAB+Ad2BpysvAgAAngMAACwAGAAAAAAAAAAAAKSBXgcAAGtvdGxpbi9hbm5vdGF0aW9uL2Fubm90YXRpb24ua290bGluX2J1aWx0aW5zVVQFAANQQYcUdXgLAAEE6AMAAAToAwAAUEsBAh4DCgAAAAAACYB1TAAAAAAAAAAAAAAAAAkAGAAAAAAAAAAQAO1B8wkAAE1FVEEtSU5GL1VUBQAD0bmyWnV4CwABBOgDAAAE6AMAAFBLAQIeAxQAAAAIAAAAfgETJpLHhgEAAAkDAAAuABgAAAAAAAAAAACkgTYKAABNRVRBLUlORi9rb3RsaW54LWNvcm91dGluZXMtY29yZS5rb3RsaW5fbW9kdWxlVVQFAANQQYcUdXgLAAEE6AMAAAToAwAAUEsBAh4DFAAAAAgAAAB+AbQ6ZrRIAAAATQAAADEAGAAAAAAAAAAAAKSBJAwAAE1FVEEtSU5GL2tvdGxpbngtY29yb3V0aW5lcy1hbmRyb2lkLmtvdGxpbl9tb2R1bGVVVAUAA1BBhxR1eAsAAQToAwAABOgDAABQSwECHgMUAAAACAAAAH4BnuxXBCcAAAArAAAAKQAYAAAAAAAAAAAApIHXDAAATUVUQS1JTkYva290bGluLXN0ZGxpYi1qcmU3LmtvdGxpbl9tb2R1bGVVVAUAA1BBhxR1eAsAAQToAwAABOgDAABQSwECHgMUAAAACAAAAH4B8aHIPKcAAAD2AAAAJQAYAAAAAAAAAAAApIFhDQAATUVUQS1JTkYva290bGluLXJ1bnRpbWUua290bGluX21vZHVsZVVUBQADUEGHFHV4CwABBOgDAAAE6AMAAFBLAQIeAwoAAAAAAAAAfgGr+1PWBgAAAAYAAAAvABgAAAAAAAEAAACkgWcOAABNRVRBLUlORi9hbmRyb2lkLmFyY2gubGlmZWN5Y2xlX3J1bnRpbWUudmVyc2lvblVUBQADUEGHFHV4CwABBOgDAAAE6AMAAFBLAQIeAwoAAAAAAAAAfgFoqH79BgAAAAYAAAAyABgAAAAAAAEAAACkgdYOAABNRVRBLUlORi9hbmRyb2lkLmFyY2gubGlmZWN5Y2xlX2V4dGVuc2lvbnMudmVyc2lvblVUBQADUEGHFHV4CwABBOgDAAAE6AMAAFBLAQIeAwoAAAAAAAAAfgFoqH79BgAAAAYAAAAqABgAAAAAAAEAAACkgUgPAABNRVRBLUlORi9hbmRyb2lkLmFyY2guY29yZV9ydW50aW1lLnZlcnNpb25VVAUAA1BBhxR1eAsAAQToAwAABOgDAABQSwECHgMUAAAACAAAAH4BYKTfM1MAAABXAAAAFAAYAAAAAAABAAAApIGyDwAATUVUQS1JTkYvTUFOSUZFU1QuTUZVVAUAA1BBhxR1eAsAAQToAwAABOgDAABQSwECHgMKAAAAAAB1f3VMAAAAAAAAAAAAAAAADAAYAAAAAAAAABAA7UFTEAAAdGhpcmRfcGFydHkvVVQFAAOuubJadXgLAAEE6AMAAAToAwAAUEsBAh4DCgAAAAAAdX91TAAAAAAAAAAAAAAAABUAGAAAAAAAAAAQAO1BmRAAAHRoaXJkX3BhcnR5L2phdmFfc3JjL1VUBQADrrmyWnV4CwABBOgDAAAE6AMAAFBLAQIeAwoAAAAAAHV/dUwAAAAAAAAAAAAAAAAhABgAAAAAAAAAEADtQegQAAB0aGlyZF9wYXJ0eS9qYXZhX3NyYy9lcnJvcl9wcm9uZS9VVAUAA665slp1eAsAAQToAwAABOgDAABQSwECHgMKAAAAAAB1f3VMAAAAAAAAAAAAAAAAKQAYAAAAAAAAABAA7UFDEQAAdGhpcmRfcGFydHkvamF2YV9zcmMvZXJyb3JfcHJvbmUvcHJvamVjdC9VVAUAA665slp1eAsAAQToAwAABOgDAABQSwECHgMKAAAAAAB1f3VMAAAAAAAAAAAAAAAANQAYAAAAAAAAABAA7UGmEQAAdGhpcmRfcGFydHkvamF2YV9zcmMvZXJyb3JfcHJvbmUvcHJvamVjdC9hbm5vdGF0aW9ucy9VVAUAA665slp1eAsAAQToAwAABOgDAABQSwECHgMUAAAACAAAAH4BCmgnsZIAAADVAAAATAAYAAAAAAABAAAApIEVEgAAdGhpcmRfcGFydHkvamF2YV9zcmMvZXJyb3JfcHJvbmUvcHJvamVjdC9hbm5vdGF0aW9ucy9Hb29nbGVfaW50ZXJuYWwuZ3d0LnhtbFVUBQADUEGHFHV4CwABBOgDAAAE6AMAAFBLAQIeAxQAAAAIAAAAfgHAqt49uQAAAHcBAABIABgAAAAAAAEAAACkgS0TAAB0aGlyZF9wYXJ0eS9qYXZhX3NyYy9lcnJvcl9wcm9uZS9wcm9qZWN0L2Fubm90YXRpb25zL0Fubm90YXRpb25zLmd3dC54bWxVVAUAA1BBhxR1eAsAAQToAwAABOgDAABQSwUGAAAAABoAGgCiCgAAaBQAAAAA",
 					KeyID: "testapp-android",
 				},
@@ -111,8 +112,8 @@ func TestSignaturePass(t *testing.T) {
 		{
 			// Sign MAR data
 			"/sign/data",
-			[]signaturerequest{
-				signaturerequest{
+			[]formats.SignatureRequest{
+				formats.SignatureRequest{
 					Input: "Y2FyaWJvdW1hdXJpY2U=",
 					KeyID: "testmar",
 				},
@@ -121,8 +122,8 @@ func TestSignaturePass(t *testing.T) {
 		{
 			// Sign a MAR file
 			"/sign/file",
-			[]signaturerequest{
-				signaturerequest{
+			[]formats.SignatureRequest{
+				formats.SignatureRequest{
 					// Input is the base64 of miniMarB from the mar signer unit tests
 					Input: "TUFSMQAAAX0AAAAAAAABlgAAAAIAAAACAAABACDExrLgT1Lc1TbLUiKbIVxQl60L6ATvYe6L6JwewAbVSjhEUCGMQ0OK1TmKi18GGijNxaf/uU7Lm/RTyvm0VL7gcODm/pogDmRttf+rc2UfX7nthPxCgB/oOj7fXqDwYpiBPNSSHMIATUb7fnRRHqVTdqhkQZ2RqQsyKL7O6D/bN62EHmVTnn5LbYqYnDLhp+bEVGPo9ETsUpSk7XlFq3v96blLi4Iazm4LyPUXtQmixNwe6OOGpS+ZqobGAtooe7nPPC0Q/kqqKKQmcwCyTP/+lD1Vk7JXbDyGzYj9f9Cloq8PH7gyxOmNvwfHxMU95Jw/ExdFUDdK6QW7UPRTx7AAAAADAAAAQMSHgnYz95K8msSv6YA6IWRfT99ig0W74KDl0QvM0Ti+BRvI7FSmjjt4QOfVHRDko31NuVa2sUCo/PibauLI7GwAAAAAYWFhYWFhYWFhYWFhYWFhYWFhYWFhAAAAFQAAAWgAAAAVAAACWC9mb28vYmFyAA==",
 					KeyID: "testmar",
@@ -163,7 +164,7 @@ func TestSignaturePass(t *testing.T) {
 		}
 
 		// parse the response
-		var responses []signatureresponse
+		var responses []formats.SignatureResponse
 		err = json.Unmarshal(w.Body.Bytes(), &responses)
 		if err != nil {
 			t.Fatal(err)
@@ -528,20 +529,20 @@ func TestSignerAuthorized(t *testing.T) {
 
 	var TESTCASES = []struct {
 		userid string
-		sgs    []signaturerequest
+		sgs    []formats.SignatureRequest
 	}{
 		{
 			userid: conf.Authorizations[0].ID,
-			sgs: []signaturerequest{
-				signaturerequest{
+			sgs: []formats.SignatureRequest{
+				formats.SignatureRequest{
 					Input: "PCFET0NUWVBFIEhUTUw+CjxodG1sPgo8IS0tIGh0dHBzOi8vYnVnemlsbGEubW96aWxsYS5vcmcvc2hvd19idWcuY2dpP2lkPTEyMjY5MjggLS0+CjxoZWFkPgogIDxtZXRhIGNoYXJzZXQ9InV0Zi04Ij4KICA8dGl0bGU+VGVzdHBhZ2UgZm9yIGJ1ZyAxMjI2OTI4PC90aXRsZT4KPC9oZWFkPgo8Ym9keT4KICBKdXN0IGEgZnVsbHkgZ29vZCB0ZXN0cGFnZSBmb3IgQnVnIDEyMjY5Mjg8YnIvPgo8L2JvZHk+CjwvaHRtbD4K",
 					KeyID: conf.Authorizations[0].Signers[0],
 				},
-				signaturerequest{
+				formats.SignatureRequest{
 					Input: "y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d",
 					KeyID: conf.Authorizations[0].Signers[0],
 				},
-				signaturerequest{
+				formats.SignatureRequest{
 					Input: "Q29udGVudC1TaWduYXR1cmU6ADwhRE9DVFlQRSBIVE1MPgo8aHRtbD4KPCEtLSBodHRwczovL2J1Z3ppbGxhLm1vemlsbGEub3JnL3Nob3dfYnVnLmNnaT9pZD0xMjI2OTI4IC0tPgo8aGVhZD4KICA8bWV0YSBjaGFyc2V0PSJ1dGYtOCI+CiAgPHRpdGxlPlRlc3RwYWdlIGZvciBidWcgMTIyNjkyODwvdGl0bGU+CjwvaGVhZD4KPGJvZHk+CiAgSnVzdCBhIGZ1bGx5IGdvb2QgdGVzdHBhZ2UgZm9yIEJ1ZyAxMjI2OTI4PGJyLz4KPC9ib2R5Pgo8L2h0bWw+Cg==",
 					KeyID: conf.Authorizations[0].Signers[1],
 				},
@@ -549,12 +550,12 @@ func TestSignerAuthorized(t *testing.T) {
 		},
 		{
 			userid: conf.Authorizations[1].ID,
-			sgs: []signaturerequest{
-				signaturerequest{
+			sgs: []formats.SignatureRequest{
+				formats.SignatureRequest{
 					Input: "PCFET0NUWVBFIEhUTUw+CjxodG1sPgo8IS0tIGh0dHBzOi8vYnVnemlsbGEubW96aWxsYS5vcmcvc2hvd19idWcuY2dpP2lkPTEyMjY5MjggLS0+CjxoZWFkPgogIDxtZXRhIGNoYXJzZXQ9InV0Zi04Ij4KICA8dGl0bGU+VGVzdHBhZ2UgZm9yIGJ1ZyAxMjI2OTI4PC90aXRsZT4KPC9oZWFkPgo8Ym9keT4KICBKdXN0IGEgZnVsbHkgZ29vZCB0ZXN0cGFnZSBmb3IgQnVnIDEyMjY5Mjg8YnIvPgo8L2JvZHk+CjwvaHRtbD4K",
 					KeyID: conf.Authorizations[1].Signers[0],
 				},
-				signaturerequest{
+				formats.SignatureRequest{
 					Input: "y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d",
 					KeyID: conf.Authorizations[1].Signers[0],
 				},
@@ -584,7 +585,7 @@ func TestSignerAuthorized(t *testing.T) {
 				tid, w.Code, w.Body.String(), req)
 		}
 		// verify that we got a proper signature response, with a valid signature
-		var responses []signatureresponse
+		var responses []formats.SignatureResponse
 		err = json.Unmarshal(w.Body.Bytes(), &responses)
 		if err != nil {
 			t.Fatal(err)
@@ -611,13 +612,13 @@ func TestSignerAuthorized(t *testing.T) {
 func TestSignerUnauthorized(t *testing.T) {
 	t.Parallel()
 
-	var TESTCASES = []signaturerequest{
+	var TESTCASES = []formats.SignatureRequest{
 		// request signature that need to prepend the content-signature:\x00 header
-		signaturerequest{
+		formats.SignatureRequest{
 			Input: "PCFET0NUWVBFIEhUTUw+CjxodG1sPgo8IS0tIGh0dHBzOi8vYnVnemlsbGEubW96aWxsYS5vcmcvc2hvd19idWcuY2dpP2lkPTEyMjY5MjggLS0+CjxoZWFkPgogIDxtZXRhIGNoYXJzZXQ9InV0Zi04Ij4KICA8dGl0bGU+VGVzdHBhZ2UgZm9yIGJ1ZyAxMjI2OTI4PC90aXRsZT4KPC9oZWFkPgo8Ym9keT4KICBKdXN0IGEgZnVsbHkgZ29vZCB0ZXN0cGFnZSBmb3IgQnVnIDEyMjY5Mjg8YnIvPgo8L2JvZHk+CjwvaHRtbD4K",
 			KeyID: conf.Authorizations[0].Signers[0],
 		},
-		signaturerequest{
+		formats.SignatureRequest{
 			Input: "y0hdfsN8tHlCG82JLywb4d2U+VGWWry8dzwIC3Hk6j32mryUHxUel9SWM5TWkk0d",
 			KeyID: conf.Authorizations[0].Signers[0],
 		},
@@ -646,8 +647,8 @@ func TestSignerUnauthorized(t *testing.T) {
 func TestContentType(t *testing.T) {
 	t.Parallel()
 
-	var TESTCASES = []signaturerequest{
-		signaturerequest{
+	var TESTCASES = []formats.SignatureRequest{
+		formats.SignatureRequest{
 			Input: "Y2FyaWJvdXZpbmRpZXV4Cg==",
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ import (
 	"go.mozilla.org/autograph/signer/contentsignature"
 
 	"go.mozilla.org/autograph/signer/contentsignaturepki"
+	"go.mozilla.org/autograph/signer/genericrsa"
 	"go.mozilla.org/autograph/signer/gpg2"
 	"go.mozilla.org/autograph/signer/mar"
 	"go.mozilla.org/autograph/signer/pgp"
@@ -399,6 +400,11 @@ func (a *autographer) addSigners(signerConfs []signer.Configuration) error {
 			}
 		case gpg2.Type:
 			s, err = gpg2.New(signerConf)
+			if err != nil {
+				return errors.Wrapf(err, "failed to add signer %q", signerConf.ID)
+			}
+		case genericrsa.Type:
+			s, err = genericrsa.New(signerConf)
 			if err != nil {
 				return errors.Wrapf(err, "failed to add signer %q", signerConf.ID)
 			}

--- a/monitor.go
+++ b/monitor.go
@@ -70,13 +70,14 @@ func (a *autographer) handleMonitor(w http.ResponseWriter, r *http.Request) {
 
 			sigerrstrs[i] = ""
 			sigresps[i] = formats.SignatureResponse{
-				Ref:       id(),
-				Type:      s.Config().Type,
-				Mode:      s.Config().Mode,
-				SignerID:  s.Config().ID,
-				PublicKey: s.Config().PublicKey,
-				Signature: encodedsig,
-				X5U:       s.Config().X5U,
+				Ref:        id(),
+				Type:       s.Config().Type,
+				Mode:       s.Config().Mode,
+				SignerID:   s.Config().ID,
+				PublicKey:  s.Config().PublicKey,
+				Signature:  encodedsig,
+				X5U:        s.Config().X5U,
+				SignerOpts: s.Config().SignerOpts,
 			}
 		}(i, s)
 	}

--- a/monitor.go
+++ b/monitor.go
@@ -9,6 +9,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"go.mozilla.org/autograph/formats"
 	"go.mozilla.org/autograph/signer"
 )
 
@@ -41,7 +42,7 @@ func (a *autographer) handleMonitor(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sigerrstrs := make([]string, len(a.signers))
-	sigresps := make([]signatureresponse, len(a.signers))
+	sigresps := make([]formats.SignatureResponse, len(a.signers))
 	var wg sync.WaitGroup
 	for i, s := range a.signers {
 		wg.Add(1)
@@ -68,7 +69,7 @@ func (a *autographer) handleMonitor(w http.ResponseWriter, r *http.Request) {
 			}
 
 			sigerrstrs[i] = ""
-			sigresps[i] = signatureresponse{
+			sigresps[i] = formats.SignatureResponse{
 				Ref:       id(),
 				Type:      s.Config().Type,
 				Mode:      s.Config().Mode,

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -11,9 +11,11 @@ import (
 	"strings"
 	"testing"
 
+	"go.mozilla.org/autograph/formats"
 	"go.mozilla.org/autograph/signer/apk"
 	"go.mozilla.org/autograph/signer/contentsignature"
 	"go.mozilla.org/autograph/signer/contentsignaturepki"
+	"go.mozilla.org/autograph/signer/genericrsa"
 	"go.mozilla.org/autograph/signer/gpg2"
 	"go.mozilla.org/autograph/signer/mar"
 	"go.mozilla.org/autograph/signer/pgp"
@@ -40,7 +42,7 @@ func TestMonitorPass(t *testing.T) {
 		t.Fatalf("failed with %d: %s; request was: %+v", w.Code, w.Body.String(), req)
 	}
 	// verify that we got a proper signature response, with a valid signature
-	var responses []signatureresponse
+	var responses []formats.SignatureResponse
 	err = json.Unmarshal(w.Body.Bytes(), &responses)
 	if err != nil {
 		t.Fatal(err)
@@ -68,6 +70,8 @@ func TestMonitorPass(t *testing.T) {
 				response.Signature, response.PublicKey, margo.SigAlgRsaPkcs1Sha384)
 		case rsapss.Type:
 			err = verifyRsapssSignature(response.Signature, response.PublicKey)
+		case genericrsa.Type:
+			err = genericrsa.VerifyGenericRsaSignatureResponse(MonitoringInputData, response)
 		case pgp.Type, gpg2.Type:
 			// we don't verify pgp signatures. I don't feel good about this, but the openpgp
 			// package is very much a pain to deal with and requires putting the public key
@@ -107,7 +111,7 @@ func TestMonitorHasSignerParameters(t *testing.T) {
 		t.Fatalf("failed with %d: %s; request was: %+v", w.Code, w.Body.String(), req)
 	}
 	// verify that we got a proper signature response, with a valid signature
-	var responses []signatureresponse
+	var responses []formats.SignatureResponse
 	err = json.Unmarshal(w.Body.Bytes(), &responses)
 	if err != nil {
 		t.Fatal(err)

--- a/signer/genericrsa/README.rst
+++ b/signer/genericrsa/README.rst
@@ -1,0 +1,106 @@
+RSA Signing
+===============
+
+.. sectnum::
+.. contents:: Table of Contents
+
+This signer implements RSA PSS and PKCS1.5 signing. It accepts SHA1
+and SHA256 hashes on `/sign/hash` and data to be hashed on `/sign/data`.
+
+Example Usage:
+
+.. code:: bash
+
+    # hash your input data
+    $ echo foo | sha256sum -b | cut -d ' ' -f 1 | xxd -r -p | base64
+    tbudgBSg+bHWHiHnlteNzN8TUvI80ygS9IULh4rklEw=
+
+    # request a signature using the autograph client
+    $ go run client.go -D -a "tbudgBSg+bHWHiHnlteNzN8TUvI80ygS9IULh4rklEw=" \
+      -k dummyrsa -o /tmp/sig.bin -ko /tmp/pub.key
+
+    # format /tmp/pub.key to PEM (fold lines to 64 and add header and footer)
+    $ (echo '-----BEGIN PUBLIC KEY-----'; cat /tmp/pub.key |fold -w 64; echo;echo '-----END PUBLIC KEY-----') > /tmp/pub.pem
+
+    -----BEGIN PUBLIC KEY-----
+    MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtEM/Vdfd4Vl9wmeVdCYu
+    WYnQl0Zc9RW5hLE4hFA+c277qanE8XCK+ap/c5so87XngLLfacB3zZhGxIOut/4S
+    lEBOAUmVNCfnTO+YkRk3A8OyJ4XNqdn+/ov78ZbssGf+0zws2BcwZYwhtuTvro3y
+    i62FQ7T1TpT5VjljH7sHW/iZnS/RKiY4DwqAN799gkB+Gwovtroabh2w5OX0P+PY
+    yUbJLFQeo5uiAQ8cAXTlHqCkj11GYgU4ttVDuFGotKRyaRn1F+yKxE4LQcAULx7s
+    0KzvS35mNU+MoywLWjy9a4TcjK0nq+BjspKX4UkNwVstvH18hQWun7E+dxTi59cR
+    mwIDAQAB
+    -----END PUBLIC KEY-----
+
+    # verify the signature with openssl
+    $ openssl pkeyutl -verify \
+    -in /tmp/inputhash.bin \
+    -sigfile /tmp/sig.bin \
+    -inkey /tmp/pub.pem -pubin -keyform PEM \
+    -pkeyopt rsa_padding_mode:pss -pkeyopt rsa_pss_saltlen:-1 -pkeyopt digest:sha1
+
+    Signature Verified Successfully
+
+Configuration
+-------------
+
+Requires PEM encoded public and private RSA keys.
+
+NB: if the publickey does not match the private key the monitor will
+break.
+
+For example:
+
+.. code:: yaml
+
+    signers:
+    - id: some-rsa-key
+      type: rsa
+      mode: pss
+      hash: sha256
+      saltlength: -1
+      privatekey: |
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEpAIBAAKCAQEAtEM/Vdfd4Vl9wmeVdCYuWYnQl0Zc9RW5hLE4hFA+c277qanE
+        ...
+        TDd4Me4PP+sTZeJ3RKvArDiMzEncDeMGZZnd4dBdi3LjzCNGTANAGw==
+        -----END RSA PRIVATE KEY-----
+      publickey: |
+        -----BEGIN PUBLIC KEY-----
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtEM/Vdfd4Vl9wmeVdCYu
+        ...
+        mwIDAQAB
+        -----END PUBLIC KEY-----
+
+Where:
+
+* hash is either sha1 or sha256
+* saltlength is only used in pss mode and is an integer
+  that correspond to https://golang.org/pkg/crypto/rsa/#pkg-constants
+
+Both Hash and SaltLength are returned in the signature response so
+clients know how signing was performed and can pass those options
+to their verification logic.
+
+Signature response
+------------------
+
+Returns base64-encoded public key (DER) and signature (hex). The
+public key is from the config.
+
+.. code:: json
+
+    [
+      {
+        "ref": "29cfra8jxug9r3mzjapmlbjlp5",
+        "type": "rsa",
+        "mode": "pss",
+        "signer_id": "dummy-rsa",
+        "public_key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtEM/Vdfd4Vl9wmeVdCYuWYnQl0Zc9RW5hLE4hFA+c277qanE8XCK+ap/c5so87XngLLfacB3zZhGxIOut/4SlEBOAUmVNCfnTO+YkRk3A8OyJ4XNqdn+/ov78ZbssGf+0zws2BcwZYwhtuTvro3yi62FQ7T1TpT5VjljH7sHW/iZnS/RKiY4DwqAN799gkB+Gwovtroabh2w5OX0P+PYyUbJLFQeo5uiAQ8cAXTlHqCkj11GYgU4ttVDuFGotKRyaRn1F+yKxE4LQcAULx7s0KzvS35mNU+MoywLWjy9a4TcjK0nq+BjspKX4UkNwVstvH18hQWun7E+dxTi59cRmwIDAQAB",
+        "signature": "S81qc/poBLToOIXVd8eOS6/CxXdhdsM/0Uz0q4cJWdmSKf9Iv8Eboz94xfuMgl81ybtPrEWDuZRLgY1qr4GxhShwa1Yb7rBtGxyJlseYfstnf24T7B6s4aeW3Zo5lfF2SCONbI0hLSHHyFzPPsnCHxvA2Ji5F+vDeBLpSrXhFn+mn14AGhz6smtU4k/iLPrfhocvBGscZv+7h7PI0vPs3MEckVZeSP8i0CkK4ev1QV88wrIa8estHCbiT4STu5zBHYb0LkkowEyCMW0KrQu5M2HO8yL4SSK9LHNR4WOS8BxBvKIXjmG5bjcH+g0gEK0RFSuJ3sLCNoRETGhRykufJA==",
+        "signer_opts": {
+          "SaltLength": -1,
+          "Hash": 5
+        }
+      }
+    ]

--- a/signer/genericrsa/rsa.go
+++ b/signer/genericrsa/rsa.go
@@ -5,10 +5,13 @@ import (
 	"crypto/rsa"
 	"crypto/sha1"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"hash"
 	"io"
+
+	"go.mozilla.org/autograph/formats"
 
 	"github.com/pkg/errors"
 	"go.mozilla.org/autograph/signer"
@@ -70,12 +73,12 @@ func New(conf signer.Configuration) (s *RSASigner, err error) {
 	s = new(RSASigner)
 
 	if conf.Type != Type {
-		return nil, errors.Errorf("rsa: invalid type %q, must be %q", conf.Type, Type)
+		return nil, errors.Errorf("genericrsa: invalid type %q, must be %q", conf.Type, Type)
 	}
 	s.Type = conf.Type
 
 	if conf.ID == "" {
-		return nil, errors.New("rsa: missing signer ID in signer configuration")
+		return nil, errors.New("genericrsa: missing signer ID in signer configuration")
 	}
 	s.ID = conf.ID
 
@@ -83,26 +86,26 @@ func New(conf signer.Configuration) (s *RSASigner, err error) {
 	case ModePSS, ModePKCS15:
 		s.Mode = conf.Mode
 	case "":
-		return nil, errors.Errorf("rsa: missing signer mode for signer %q, must be 'pkcs15' or 'pss'", s.ID)
+		return nil, errors.Errorf("genericrsa: missing signer mode for signer %q, must be 'pkcs15' or 'pss'", s.ID)
 	default:
-		return nil, errors.Errorf("rsa: invalid signer mode %q for signer %q, must be 'pkcs15' or 'pss'", conf.Mode, s.ID)
+		return nil, errors.Errorf("genericrsa: invalid signer mode %q for signer %q, must be 'pkcs15' or 'pss'", conf.Mode, s.ID)
 	}
 
 	if conf.PrivateKey == "" {
-		return nil, errors.Errorf("rsa: missing private key for signer %q", s.ID)
+		return nil, errors.Errorf("genericrsa: missing private key for signer %q", s.ID)
 	}
 	s.PrivateKey = conf.PrivateKey
 
 	if conf.PublicKey == "" {
-		return nil, errors.Errorf("rsa: missing public key for signer %q", s.ID)
+		return nil, errors.Errorf("genericrsa: missing public key for signer %q", s.ID)
 	}
 	s.key, s.pubKey, s.rng, s.PublicKey, err = conf.GetKeysAndRand()
 	if err != nil {
-		return nil, errors.Wrapf(err, "rsa: error fetching key and rand for signer %q", s.ID)
+		return nil, errors.Wrapf(err, "genericrsa: error fetching key and rand for signer %q", s.ID)
 	}
 	_, ok := s.pubKey.(*rsa.PublicKey)
 	if !ok {
-		return nil, errors.Errorf("rsa: unsupported public key type %T for signer %q, use RSA keys", s.pubKey, s.ID)
+		return nil, errors.Errorf("genericrsa: unsupported public key type %T for signer %q, use RSA keys", s.pubKey, s.ID)
 	}
 
 	s.Hash = conf.Hash
@@ -115,7 +118,7 @@ func New(conf signer.Configuration) (s *RSASigner, err error) {
 		hRef = crypto.SHA256
 		s.hashSize = sha256.Size
 	default:
-		return nil, errors.Errorf("rsa: unsupported hash %q for signer %q, must be 'sha1' or 'sha256'", s.Hash, s.ID)
+		return nil, errors.Errorf("genericrsa: unsupported hash %q for signer %q, must be 'sha1' or 'sha256'", s.Hash, s.ID)
 	}
 
 	s.SaltLength = conf.SaltLength
@@ -127,7 +130,7 @@ func New(conf signer.Configuration) (s *RSASigner, err error) {
 		}
 	case ModePKCS15:
 		if s.SaltLength != 0 {
-			return nil, errors.Errorf("rsa: signer %q uses mode %q and sets salt length to %d, which is only valid in 'pss' mode", s.ID, s.Mode, s.SaltLength)
+			return nil, errors.Errorf("genericrsa: signer %q uses mode %q and sets salt length to %d, which is only valid in 'pss' mode", s.ID, s.Mode, s.SaltLength)
 		}
 		s.sigOpts = &Options{
 			Hash: hRef,
@@ -164,11 +167,11 @@ func (s *RSASigner) SignData(data []byte, options interface{}) (signer.Signature
 // SignHash takes an input hash and returns a signed base64 encoded hash
 func (s *RSASigner) SignHash(digest []byte, options interface{}) (signer.Signature, error) {
 	if len(digest) != s.hashSize {
-		return nil, errors.Errorf("rsa: refusing to sign input hash. Got length %d, expected %d", len(digest), s.hashSize)
+		return nil, errors.Errorf("genericrsa: refusing to sign input hash. Got length %d, expected %d", len(digest), s.hashSize)
 	}
 	sigBytes, err := s.key.(crypto.Signer).Sign(s.rng, digest, s.sigOpts)
 	if err != nil {
-		return nil, errors.Wrap(err, "rsa: error signing hash")
+		return nil, errors.Wrap(err, "genericrsa: error signing hash")
 	}
 	sig := new(Signature)
 	sig.Data = sigBytes
@@ -239,7 +242,33 @@ func VerifySignature(input, sigBytes []byte, pubKey *rsa.PublicKey, sigopt inter
 		hashed := h.Sum(nil)
 		return rsa.VerifyPKCS1v15(pubKey, opt.Hash, hashed, sigBytes)
 	default:
-		return errors.Errorf("rsa: invalid mode %q", mode)
+		return errors.Errorf("genericrsa: invalid mode %q", mode)
 	}
-	return errors.Wrapf(err, "rsa: failed to verify signature")
+	return errors.Wrapf(err, "genericrsa: failed to verify signature")
+}
+
+// VerifyGenericRsaSignatureResponse is a helper that takes
+// an input and autograph signature response and verify its signature.
+func VerifyGenericRsaSignatureResponse(input []byte, sr formats.SignatureResponse) error {
+	if sr.Type != Type {
+		return errors.Errorf("genericrsa: signature response of type %q cannot be verified by %q", sr.Type, Type)
+	}
+	sig, err := Unmarshal(sr.Signature)
+	if err != nil {
+		return errors.Wrap(err, "genericrsa: failed to unmarshal rsa signature")
+	}
+	keyBytes, err := base64.StdEncoding.DecodeString(sr.PublicKey)
+	if err != nil {
+		return errors.Wrap(err, "genericrsa: failed to decode public key")
+	}
+	keyInterface, err := x509.ParsePKIXPublicKey(keyBytes)
+	if err != nil {
+		return errors.Wrap(err, "genericrsa: failed to parse pkix public key")
+	}
+	pubKey := keyInterface.(*rsa.PublicKey)
+	err = VerifySignature(input, sig.(*Signature).Data, pubKey, sr.SignerOpts, sr.Mode)
+	if err != nil {
+		return errors.Wrap(err, "genericrsa: failed to verify signature")
+	}
+	return nil
 }

--- a/signer/genericrsa/rsa.go
+++ b/signer/genericrsa/rsa.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	// Type of this signer is "rsa"
+	// Type of this signer is "genericrsa"
 	Type = "genericrsa"
 )
 
@@ -109,13 +109,13 @@ func New(conf signer.Configuration) (s *RSASigner, err error) {
 	}
 
 	s.Hash = conf.Hash
-	var hRef crypto.Hash
+	var hashID crypto.Hash
 	switch s.Hash {
 	case "sha1":
-		hRef = crypto.SHA1
+		hashID = crypto.SHA1
 		s.hashSize = sha1.Size
 	case "sha256":
-		hRef = crypto.SHA256
+		hashID = crypto.SHA256
 		s.hashSize = sha256.Size
 	default:
 		return nil, errors.Errorf("genericrsa: unsupported hash %q for signer %q, must be 'sha1' or 'sha256'", s.Hash, s.ID)
@@ -126,14 +126,14 @@ func New(conf signer.Configuration) (s *RSASigner, err error) {
 	case ModePSS:
 		s.sigOpts = &rsa.PSSOptions{
 			SaltLength: s.SaltLength,
-			Hash:       hRef,
+			Hash:       hashID,
 		}
 	case ModePKCS15:
 		if s.SaltLength != 0 {
 			return nil, errors.Errorf("genericrsa: signer %q uses mode %q and sets salt length to %d, which is only valid in 'pss' mode", s.ID, s.Mode, s.SaltLength)
 		}
 		s.sigOpts = &Options{
-			Hash: hRef,
+			Hash: hashID,
 		}
 	}
 	return s, nil

--- a/signer/genericrsa/rsa.go
+++ b/signer/genericrsa/rsa.go
@@ -1,0 +1,245 @@
+package genericrsa
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"hash"
+	"io"
+
+	"github.com/pkg/errors"
+	"go.mozilla.org/autograph/signer"
+)
+
+const (
+	// Type of this signer is "rsa"
+	Type = "genericrsa"
+)
+
+// RSASigner holds the configuration of the signer
+type RSASigner struct {
+	signer.Configuration
+
+	// key is the RSA private key to sign hashes.
+	// we use the `crypto.PrivateKey` interface to support
+	// keys in HSM.
+	key crypto.PrivateKey
+
+	// pubkey is an RSA Public Key
+	pubKey crypto.PublicKey
+
+	// rng is our random number generator
+	rng io.Reader
+
+	// sigOpts stores options for PSS signing and is nil
+	// in pkcs15 mode
+	sigOpts crypto.SignerOpts
+
+	// hashSize is the byte size of the configured hash checksum
+	hashSize int
+}
+
+const (
+	// ModePSS enables PSS padding mode
+	ModePSS = "pss"
+
+	// ModePKCS15 enables PKCS15 padding mode
+	ModePKCS15 = "pkcs15"
+)
+
+// Options contains options for creating and verifying PKCS15 signatures.
+type Options struct {
+	// Hash, if not zero, overrides the hash function passed to SignPSS.
+	// This is the only way to specify the hash function when using the
+	// crypto.Signer interface.
+	Hash crypto.Hash
+}
+
+// HashFunc returns the Hash used by the signer so that Options implements
+// crypto.SignerOpts
+func (opts *Options) HashFunc() crypto.Hash {
+	return opts.Hash
+
+}
+
+// New initializes a rsa signer using a configuration
+func New(conf signer.Configuration) (s *RSASigner, err error) {
+	s = new(RSASigner)
+
+	if conf.Type != Type {
+		return nil, errors.Errorf("rsa: invalid type %q, must be %q", conf.Type, Type)
+	}
+	s.Type = conf.Type
+
+	if conf.ID == "" {
+		return nil, errors.New("rsa: missing signer ID in signer configuration")
+	}
+	s.ID = conf.ID
+
+	switch conf.Mode {
+	case ModePSS, ModePKCS15:
+		s.Mode = conf.Mode
+	case "":
+		return nil, errors.Errorf("rsa: missing signer mode for signer %q, must be 'pkcs15' or 'pss'", s.ID)
+	default:
+		return nil, errors.Errorf("rsa: invalid signer mode %q for signer %q, must be 'pkcs15' or 'pss'", conf.Mode, s.ID)
+	}
+
+	if conf.PrivateKey == "" {
+		return nil, errors.Errorf("rsa: missing private key for signer %q", s.ID)
+	}
+	s.PrivateKey = conf.PrivateKey
+
+	if conf.PublicKey == "" {
+		return nil, errors.Errorf("rsa: missing public key for signer %q", s.ID)
+	}
+	s.key, s.pubKey, s.rng, s.PublicKey, err = conf.GetKeysAndRand()
+	if err != nil {
+		return nil, errors.Wrapf(err, "rsa: error fetching key and rand for signer %q", s.ID)
+	}
+	_, ok := s.pubKey.(*rsa.PublicKey)
+	if !ok {
+		return nil, errors.Errorf("rsa: unsupported public key type %T for signer %q, use RSA keys", s.pubKey, s.ID)
+	}
+
+	s.Hash = conf.Hash
+	var hRef crypto.Hash
+	switch s.Hash {
+	case "sha1":
+		hRef = crypto.SHA1
+		s.hashSize = sha1.Size
+	case "sha256":
+		hRef = crypto.SHA256
+		s.hashSize = sha256.Size
+	default:
+		return nil, errors.Errorf("rsa: unsupported hash %q for signer %q, must be 'sha1' or 'sha256'", s.Hash, s.ID)
+	}
+
+	s.SaltLength = conf.SaltLength
+	switch s.Mode {
+	case ModePSS:
+		s.sigOpts = &rsa.PSSOptions{
+			SaltLength: s.SaltLength,
+			Hash:       hRef,
+		}
+	case ModePKCS15:
+		if s.SaltLength != 0 {
+			return nil, errors.Errorf("rsa: signer %q uses mode %q and sets salt length to %d, which is only valid in 'pss' mode", s.ID, s.Mode, s.SaltLength)
+		}
+		s.sigOpts = &Options{
+			Hash: hRef,
+		}
+	}
+	return s, nil
+}
+
+// Config returns the configuration of the current signer
+func (s *RSASigner) Config() signer.Configuration {
+	return signer.Configuration{
+		ID:         s.ID,
+		Type:       s.Type,
+		Mode:       s.Mode,
+		PrivateKey: s.PrivateKey,
+		PublicKey:  s.PublicKey,
+		SignerOpts: s.sigOpts,
+	}
+}
+
+// SignData takes data, hashes it and returns a signed base64 encoded hash
+func (s *RSASigner) SignData(data []byte, options interface{}) (signer.Signature, error) {
+	var h hash.Hash
+	switch s.Hash {
+	case "sha1":
+		h = sha1.New()
+	case "sha256":
+		h = sha256.New()
+	}
+	h.Write(data)
+	return s.SignHash(h.Sum(nil), options)
+}
+
+// SignHash takes an input hash and returns a signed base64 encoded hash
+func (s *RSASigner) SignHash(digest []byte, options interface{}) (signer.Signature, error) {
+	if len(digest) != s.hashSize {
+		return nil, errors.Errorf("rsa: refusing to sign input hash. Got length %d, expected %d", len(digest), s.hashSize)
+	}
+	sigBytes, err := s.key.(crypto.Signer).Sign(s.rng, digest, s.sigOpts)
+	if err != nil {
+		return nil, errors.Wrap(err, "rsa: error signing hash")
+	}
+	sig := new(Signature)
+	sig.Data = sigBytes
+	return sig, nil
+}
+
+// Signature is a rsa signature
+type Signature struct {
+	Data []byte
+}
+
+// Marshal returns the base64 representation of a signature
+func (sig *Signature) Marshal() (string, error) {
+	return base64.StdEncoding.EncodeToString(sig.Data), nil
+}
+
+// Unmarshal decodes a base64 signature string into a Signature
+func Unmarshal(sigstr string) (signer.Signature, error) {
+	sig := new(Signature)
+	sigBytes, err := base64.StdEncoding.DecodeString(sigstr)
+	if err != nil {
+		return nil, err
+	}
+	sig.Data = sigBytes
+	return sig, nil
+}
+
+// GetDefaultOptions returns default options of the signer
+func (s *RSASigner) GetDefaultOptions() interface{} {
+	return Options{}
+}
+
+// VerifySignature verifies a rsa signature for the given SHA1
+// digest for the given RSA public and signature bytes
+func VerifySignature(input, sigBytes []byte, pubKey *rsa.PublicKey, sigopt interface{}, mode string) (err error) {
+	switch mode {
+	case ModePSS:
+		// in PSS mode, the signer options are unmarshalled into
+		// a rsa.PSSOptions struct that contains the salt length
+		// and the hash algorithm used for signing
+		var opt rsa.PSSOptions
+		marshalledOpt, err := json.Marshal(sigopt)
+		if err != nil {
+			return err
+		}
+		err = json.Unmarshal(marshalledOpt, &opt)
+		if err != nil {
+			return err
+		}
+		h := opt.Hash.New()
+		h.Write(input)
+		hashed := h.Sum(nil)
+		return rsa.VerifyPSS(pubKey, opt.Hash, hashed, sigBytes, &opt)
+	case ModePKCS15:
+		// in PKCS15 mode, the signer options are unmarshalled into
+		// an option struct that only contains the hash used for signing
+		marshalledOpt, err := json.Marshal(sigopt)
+		if err != nil {
+			return err
+		}
+		var opt Options
+		err = json.Unmarshal(marshalledOpt, &opt)
+		if err != nil {
+			return err
+		}
+		h := opt.Hash.New()
+		h.Write(input)
+		hashed := h.Sum(nil)
+		return rsa.VerifyPKCS1v15(pubKey, opt.Hash, hashed, sigBytes)
+	default:
+		return errors.Errorf("rsa: invalid mode %q", mode)
+	}
+	return errors.Wrapf(err, "rsa: failed to verify signature")
+}

--- a/signer/genericrsa/rsa.go
+++ b/signer/genericrsa/rsa.go
@@ -244,7 +244,6 @@ func VerifySignature(input, sigBytes []byte, pubKey *rsa.PublicKey, sigopt inter
 	default:
 		return errors.Errorf("genericrsa: invalid mode %q", mode)
 	}
-	return errors.Wrapf(err, "genericrsa: failed to verify signature")
 }
 
 // VerifyGenericRsaSignatureResponse is a helper that takes

--- a/signer/genericrsa/rsa_test.go
+++ b/signer/genericrsa/rsa_test.go
@@ -1,0 +1,445 @@
+package genericrsa
+
+import (
+	"bytes"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/x509"
+	"hash"
+
+	"go.mozilla.org/autograph/formats"
+
+	"encoding/base64"
+	"testing"
+
+	"go.mozilla.org/autograph/signer"
+)
+
+func assertNewSignerWithConfOK(t *testing.T, conf signer.Configuration) *RSASigner {
+	s, err := New(conf)
+	if s == nil {
+		t.Fatal("expected non-nil signer for valid conf, but got nil signer")
+	}
+	if err != nil {
+		t.Fatalf("signer initialization failed with: %v", err)
+	}
+	return s
+}
+
+func assertNewSignerWithConfErrs(t *testing.T, invalidConf signer.Configuration) {
+	s, err := New(invalidConf)
+	if s != nil {
+		t.Fatalf("expected nil signer for invalid conf, but got non-nil signer %v", s)
+	}
+	if err == nil {
+		t.Fatal("signer initialization did not fail")
+	}
+}
+
+func TestNewSigner(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+
+		_ = assertNewSignerWithConfOK(t, rsaSignerConfs[0])
+	})
+
+	t.Run("invalid type", func(t *testing.T) {
+		t.Parallel()
+
+		invalidConf := rsaSignerConfs[0]
+		invalidConf.Type = "badType"
+		assertNewSignerWithConfErrs(t, invalidConf)
+	})
+
+	t.Run("invalid ID", func(t *testing.T) {
+		t.Parallel()
+
+		invalidConf := rsaSignerConfs[0]
+		invalidConf.ID = ""
+		assertNewSignerWithConfErrs(t, invalidConf)
+	})
+
+	t.Run("invalid PrivateKey", func(t *testing.T) {
+		t.Parallel()
+
+		invalidConf := rsaSignerConfs[0]
+		invalidConf.PrivateKey = ""
+		assertNewSignerWithConfErrs(t, invalidConf)
+	})
+
+	t.Run("invalid PublicKey", func(t *testing.T) {
+		t.Parallel()
+
+		invalidConf := rsaSignerConfs[0]
+		invalidConf.PublicKey = ""
+		assertNewSignerWithConfErrs(t, invalidConf)
+	})
+
+	t.Run("invalid PEM PrivateKey", func(t *testing.T) {
+		t.Parallel()
+
+		invalidConf := rsaSignerConfs[0]
+		invalidConf.PrivateKey = "NOT VALID PEM"
+		assertNewSignerWithConfErrs(t, invalidConf)
+	})
+
+	t.Run("non-RSA PrivateKey", func(t *testing.T) {
+		t.Parallel()
+
+		invalidConf := rsaSignerConfs[0]
+		invalidConf.PrivateKey = nonRSAPrivateKey
+		assertNewSignerWithConfErrs(t, invalidConf)
+	})
+}
+
+func TestConfig(t *testing.T) {
+	t.Parallel()
+
+	for i, conf := range rsaSignerConfs {
+		s := assertNewSignerWithConfOK(t, conf)
+
+		if s.Config().Type != conf.Type {
+			t.Fatalf("in config %d %q, signer type %q does not match configuration %q", i, conf.ID, s.Config().Type, conf.Type)
+		}
+		if s.Config().ID != conf.ID {
+			t.Fatalf("in config %d %q, signer id %q does not match configuration %q", i, conf.ID, s.Config().ID, conf.ID)
+		}
+		if s.Config().PrivateKey != conf.PrivateKey {
+			t.Fatalf("in config %d %q, signer private key %q does not match configuration %q", i, conf.ID, s.Config().PrivateKey, conf.PrivateKey)
+		}
+
+		// decode public key
+		keyBytes, err := base64.StdEncoding.DecodeString(s.Config().PublicKey)
+		if err != nil {
+			t.Fatalf("in config %d %q, failed to parse public key: %v", i, conf.ID, err)
+		}
+		keyInterface, err := x509.ParsePKIXPublicKey(keyBytes)
+		if err != nil {
+			t.Fatalf("in config %d %q, failed to parse public key DER: %v", i, conf.ID, err)
+		}
+		_, ok := keyInterface.(*rsa.PublicKey)
+		if !ok {
+			t.Fatalf("in config %d %q, parsed public key was not rsa", i, conf.ID)
+		}
+	}
+}
+
+func TestOptionsAreEmpty(t *testing.T) {
+	t.Parallel()
+
+	s := assertNewSignerWithConfOK(t, rsaSignerConfs[0])
+	defaultOpts := s.GetDefaultOptions()
+	expectedOpts := Options{}
+	if defaultOpts != expectedOpts {
+		t.Fatalf("signer returned unexpected default options: %v", defaultOpts)
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	_, err := Unmarshal("invalid!base64")
+	if err == nil {
+		t.Fatalf("Signature Unmarshal did not faile for invalid base64 bytes")
+	}
+}
+
+func TestSignHash(t *testing.T) {
+	input := []byte("this is the hash input")
+	for i, conf := range rsaSignerConfs {
+		// initialize a signer
+		s := assertNewSignerWithConfOK(t, conf)
+
+		var h hash.Hash
+		switch s.Hash {
+		case "sha1":
+			h = sha1.New()
+		case "sha256":
+			h = sha256.New()
+		}
+		h.Write(input)
+		digest := h.Sum(nil)
+
+		// sign input data
+		sig, err := s.SignHash(digest, s.GetDefaultOptions())
+		if err != nil {
+			t.Fatalf("in config %d %q, failed to sign data: %v", i, conf.ID, err)
+		}
+
+		// convert signature to string format
+		sigstr, err := sig.Marshal()
+		if err != nil {
+			t.Fatalf("in config %d %q, failed to marshal signature: %v", i, conf.ID, err)
+		}
+
+		t.Run("Rejects invalid input length", func(t *testing.T) {
+			t.Parallel()
+
+			_, err := s.SignHash([]byte("too short"), s.GetDefaultOptions())
+			if err == nil {
+				t.Fatalf("in config %d %q, failed to throw error for invalid data length", i, conf.ID)
+			}
+		})
+
+		t.Run("MarshalRoundTrip", func(t *testing.T) {
+			t.Parallel()
+
+			// convert string format back to signature
+			sig2, err := Unmarshal(sigstr)
+			if err != nil {
+				t.Fatalf("in config %d %q, failed to unmarshal signature: %v", i, conf.ID, err)
+			}
+
+			if !bytes.Equal(sig.(*Signature).Data, sig2.(*Signature).Data) {
+				t.Fatalf("in config %d %q, marshalling signature changed its format.\nexpected\t%q\nreceived\t%q",
+					i, conf.ID, sig.(*Signature).Data, sig2.(*Signature).Data)
+			}
+		})
+
+		t.Run("Verifies", func(t *testing.T) {
+			t.Parallel()
+
+			rsaKey := s.key.(*rsa.PrivateKey)
+			pubKey := rsaKey.Public()
+			err := VerifySignature(input, sig.(*Signature).Data, pubKey.(*rsa.PublicKey), s.sigOpts, s.Mode)
+			if err != nil {
+				t.Fatalf("in config %d %q, failed to verify signature: %v", i, conf.ID, err)
+			}
+		})
+	}
+}
+
+func TestSignData(t *testing.T) {
+	input := []byte("this is the input")
+
+	for i, conf := range rsaSignerConfs {
+
+		// initialize a signer
+		s := assertNewSignerWithConfOK(t, conf)
+
+		// sign input data
+		sig, err := s.SignData(input, s.GetDefaultOptions())
+		if err != nil {
+			t.Fatalf("in config %d %q, failed to sign data: %v", i, conf.ID, err)
+		}
+
+		// convert signature to string format
+		_, err = sig.Marshal()
+		if err != nil {
+			t.Fatalf("in config %d %q, failed to marshal signature: %v", i, conf.ID, err)
+		}
+
+		t.Run("Verifies", func(t *testing.T) {
+			t.Parallel()
+
+			rsaKey := s.key.(*rsa.PrivateKey)
+			pubKey := rsaKey.Public()
+			err := VerifySignature(input, sig.(*Signature).Data, pubKey.(*rsa.PublicKey), s.sigOpts, s.Mode)
+			if err != nil {
+				t.Fatalf("in config %d %q, failed to verify signature: %v", i, conf.ID, err)
+			}
+		})
+	}
+}
+
+func TestVerifySignatureFromB64(t *testing.T) {
+	t.Parallel()
+
+	for i, conf := range rsaSignerConfs {
+
+		// initialize a signer and compute base64 args
+		var (
+			_input  = []byte("this is the input")
+			_s      = assertNewSignerWithConfOK(t, conf)
+			_b64Sig string
+		)
+
+		_sig, err := _s.SignData(_input, _s.GetDefaultOptions())
+		if err != nil {
+			t.Fatalf("failed to sign data: %v", err)
+		}
+
+		// convert signature to base64 string
+		_b64Sig, err = _sig.Marshal()
+		if err != nil {
+			t.Fatalf("in config %d %q, failed to marshal signature: %v", i, conf.ID, err)
+		}
+
+		sr := formats.SignatureResponse{
+			Type:       _s.Config().Type,
+			Mode:       _s.Config().Mode,
+			SignerID:   _s.Config().ID,
+			PublicKey:  _s.Config().PublicKey,
+			Signature:  _b64Sig,
+			SignerOpts: _s.Config().SignerOpts,
+		}
+
+		t.Run("verifies valid input", func(t *testing.T) {
+			t.Parallel()
+
+			// unencoded verification should pass
+			rsaKey := _s.key.(*rsa.PrivateKey)
+			pubKey := rsaKey.Public()
+			err := VerifySignature(_input, _sig.(*Signature).Data, pubKey.(*rsa.PublicKey), _s.sigOpts, _s.Mode)
+			if err != nil {
+				t.Fatalf("in config %d %q, failed to verify signature: %v", i, conf.ID, err)
+			}
+
+			err = VerifyGenericRsaSignatureResponse(_input, sr)
+			if err != nil {
+				t.Fatalf("in config %d %q, failed to verify valid input: %s", i, conf.ID, err)
+			}
+		})
+
+		t.Run("fails for invalid b64 input", func(t *testing.T) {
+			t.Parallel()
+			err = VerifyGenericRsaSignatureResponse([]byte("aieeee"), sr)
+			if err == nil {
+				t.Fatalf("in config %d %q, did not to fail for invalid input", i, conf.ID)
+			}
+		})
+
+		t.Run("fails for invalid b64 sig", func(t *testing.T) {
+			t.Parallel()
+			_sr := sr
+			_sr.Signature = "aieeee"
+			err = VerifyGenericRsaSignatureResponse(_input, _sr)
+			if err == nil {
+				t.Fatalf("in config %d %q, did not to fail for invalid sig", i, conf.ID)
+			}
+		})
+
+		t.Run("fails for invalid b64 pubkey", func(t *testing.T) {
+			t.Parallel()
+			_sr := sr
+			_sr.PublicKey = "aieeee"
+			err = VerifyGenericRsaSignatureResponse(_input, _sr)
+			if err == nil {
+				t.Fatalf("in config %d %q, did not to fail for invalid pubkey", i, conf.ID)
+			}
+		})
+
+		t.Run("fails for invalid pubkey pem", func(t *testing.T) {
+			t.Parallel()
+			_sr := sr
+			_sr.PublicKey = ""
+			err = VerifyGenericRsaSignatureResponse(_input, _sr)
+			if err == nil {
+				t.Fatalf("in config %d %q, did not to fail for invalid pub key PEM block", i, conf.ID)
+			}
+		})
+
+		t.Run("fails for invalid pubkey type", func(t *testing.T) {
+			t.Parallel()
+			_sr := sr
+			_sr.PublicKey = base64.StdEncoding.EncodeToString([]byte(nonRSAPrivateKey))
+			err = VerifyGenericRsaSignatureResponse(_input, _sr)
+			if err == nil {
+				t.Fatalf("in config %d %q, did not to fail for bad pem key type", i, conf.ID)
+			}
+		})
+	}
+}
+
+const nonRSAPrivateKey = `-----BEGIN EC PRIVATE KEY-----
+MIGkAgEBBDART/nn3fKlhyENdc2u3klbvRJ5+odP0kWzt9p+v5hDyggbtVA4M1Mb
+fL9KoaiAAv2gBwYFK4EEACKhZANiAATugz97A6HPqq0fJCGom9PdKJ58Y9aobARQ
+BkZWS5IjC+15Uqt3yOcCMdjIJpikiD1WjXRaeFe+b3ovcoBs4ToLK7d8y0qFlkgx
+/5Cp6z37rpp781N4haUOIauM14P4KUw=
+-----END EC PRIVATE KEY-----`
+
+var rsaSignerConfs = []signer.Configuration{
+	signer.Configuration{
+		ID:         "rsa-pss-sha1-length-equal-hash",
+		Type:       Type,
+		Mode:       ModePSS,
+		Hash:       "sha1",
+		SaltLength: -1,
+		PrivateKey: standardPrivateKey,
+		PublicKey:  standardPublicKey,
+	},
+	signer.Configuration{
+		ID:         "rsa-pss-sha256-length-equal-hash",
+		Type:       Type,
+		Mode:       ModePSS,
+		Hash:       "sha256",
+		SaltLength: -1,
+		PrivateKey: standardPrivateKey,
+		PublicKey:  standardPublicKey,
+	},
+	signer.Configuration{
+		ID:         "rsa-pss-sha1-length-auto",
+		Type:       Type,
+		Mode:       ModePSS,
+		Hash:       "sha1",
+		SaltLength: 0,
+		PrivateKey: standardPrivateKey,
+		PublicKey:  standardPublicKey,
+	},
+	signer.Configuration{
+		ID:         "rsa-pss-sha256-length-auto",
+		Type:       Type,
+		Mode:       ModePSS,
+		Hash:       "sha256",
+		SaltLength: 0,
+		PrivateKey: standardPrivateKey,
+		PublicKey:  standardPublicKey,
+	},
+	signer.Configuration{
+		ID:         "rsa-pkcs15-sha1",
+		Type:       Type,
+		Mode:       ModePKCS15,
+		Hash:       "sha1",
+		PrivateKey: standardPrivateKey,
+		PublicKey:  standardPublicKey,
+	},
+	signer.Configuration{
+		ID:         "rsa-pkcs15-sha256",
+		Type:       Type,
+		Mode:       ModePKCS15,
+		Hash:       "sha256",
+		PrivateKey: standardPrivateKey,
+		PublicKey:  standardPublicKey,
+	},
+}
+
+var standardPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAtEM/Vdfd4Vl9wmeVdCYuWYnQl0Zc9RW5hLE4hFA+c277qanE
+8XCK+ap/c5so87XngLLfacB3zZhGxIOut/4SlEBOAUmVNCfnTO+YkRk3A8OyJ4XN
+qdn+/ov78ZbssGf+0zws2BcwZYwhtuTvro3yi62FQ7T1TpT5VjljH7sHW/iZnS/R
+KiY4DwqAN799gkB+Gwovtroabh2w5OX0P+PYyUbJLFQeo5uiAQ8cAXTlHqCkj11G
+YgU4ttVDuFGotKRyaRn1F+yKxE4LQcAULx7s0KzvS35mNU+MoywLWjy9a4TcjK0n
+q+BjspKX4UkNwVstvH18hQWun7E+dxTi59cRmwIDAQABAoIBAEKpi8aHKfqoSaWX
+AOIPLJzYJleLId1Qx2aW0zu7IR03McIwkjBnWj2yG6f4/VADOTWS8KP/FU7mvWT2
+/an1P5Grpi07tP2wtAzzngwqsvmlaUDMbp4di/s+cVGKasVh8A7V9g+Do9Yp2F32
+k9yNieC1rs63IPCKjxqf5lRZqgMMcL1QYSlJI98riSVGm0m29u1v3pN6qDVNto2d
+l6m6D8UT6vx1lfVZFV+Td3FmYHnuYyVwbgJ8dFRBQFpe2tsccK955+lapFe9MA/o
+Xa5VfAWJ7YoLcgfssxF7atpHt2wcpvEj6NfIHfeDdExQ+Vd9T8vQGh88wd32QcTa
+w1RiQUECgYEA7OFpsduOHqgqVSf1nIH6RPLytzzoXXd8Bs1aXWCxy45xg7lkKG+x
+8Fa4aUFDII9RR4N7YFfUh8LwKF56BwFePbP4wwCuhz9v2E24I6/EfLD2GuRSv+B/
+gNRG+suE5yCmeGlRC0uhASLr3ZzmGs16Mus/ytL5XPl8CJCmsVMjPHMCgYEAws/1
+Sm2KOoYFY1+7ACMF89FyesOpTpqLvND79soNPC4Tl1PrPw4bsNA6p2BD1N2SPFiH
+0yo7msNqh5o90wdnYA7i1uDWhcvrFnbg4e8+RhghcG/dJW33Lm5d5knST4NQxnAO
+z/0zXgB9PSnsgFzNgm6LE++/KBZs/CbxQUPb9DkCgYEAk58eiVK0TPKr/wm6DOEL
+oLBvBjaU8Lqntm1/ZTX/V0XcBCUi//grwgWpQx8CwGXQV2rfFnll331iwSWvknIN
+0xI3cv8XxP2JrBkzKjo9jx+RH80urJkxnI2t9lmi5473b47ijNGC8vxaVW+UDxwC
+jX0B8lpsQL7Rx1yuJVAUY3UCgYEAtG8gZZsnWCUhgHT+IpZNwRHQ0lu+yIrjujJl
+7KIfuAmFI7gaPwC2LQHwEW5b5SCDfVkSFEcdha5RUN9PO9GzsYiYGSWOC8ZfKyNY
+DmskZo+bCSTS0wQS2PJoDg95tyONAP5w+bsuhHY3iRr3bbyGq7PvJLv9dQewUatP
+8H8FjiECgYBt93fZADyyOoqeYxMc8b38F8sf1FLTOAUfB1ik5R4yNVKDaCanYhYc
+poTajMUVdoBcEV1g5Vds8objUIeNNlMPKyUnf/lCiPvp43wYbC3y60JqzXX3bfAS
+TDd4Me4PP+sTZeJ3RKvArDiMzEncDeMGZZnd4dBdi3LjzCNGTANAGw==
+-----END RSA PRIVATE KEY-----`
+
+var standardPublicKey = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtEM/Vdfd4Vl9wmeVdCYu
+WYnQl0Zc9RW5hLE4hFA+c277qanE8XCK+ap/c5so87XngLLfacB3zZhGxIOut/4S
+lEBOAUmVNCfnTO+YkRk3A8OyJ4XNqdn+/ov78ZbssGf+0zws2BcwZYwhtuTvro3y
+i62FQ7T1TpT5VjljH7sHW/iZnS/RKiY4DwqAN799gkB+Gwovtroabh2w5OX0P+PY
+yUbJLFQeo5uiAQ8cAXTlHqCkj11GYgU4ttVDuFGotKRyaRn1F+yKxE4LQcAULx7s
+0KzvS35mNU+MoywLWjy9a4TcjK0nq+BjspKX4UkNwVstvH18hQWun7E+dxTi59cR
+mwIDAQAB
+-----END PUBLIC KEY-----`

--- a/signer/rsapss/README.rst
+++ b/signer/rsapss/README.rst
@@ -1,6 +1,8 @@
 RSA-PSS Signing
 ===============
 
+**THIS SIGNER IS DEPRECATED, USE THE `genericrsa` SIGNER INSTEAD**
+
 .. sectnum::
 .. contents:: Table of Contents
 
@@ -56,7 +58,7 @@ For example:
 .. code:: yaml
 
     signers:
-    - id: some-rsapss-rsa-key
+    - id: some-rsa-key
       type: rsapss
       privatekey: |
         -----BEGIN RSA PRIVATE KEY-----

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -139,6 +139,17 @@ type Configuration struct {
 	// CaCert is the certificate of the root of the pki, when used
 	CaCert string `json:"cacert,omitempty"`
 
+	// Hash is a hash algorithm like 'sha1' or 'sha256'
+	Hash string `json:"hash,omitempty"`
+
+	// SaltLength controls the length of the salt used in a RSA PSS
+	// signature. It can either be a number of bytes, or one of the special
+	// PSSSaltLength constants from the rsa package.
+	SaltLength int `json:"saltlength,omitempty"`
+
+	// SignerOpts contains options for signing with a Signer
+	SignerOpts crypto.SignerOpts `json:"signer_opts,omitempty"`
+
 	isHsmAvailable bool
 	hsmCtx         *pkcs11.Ctx
 }

--- a/tools/autograph-client/client.go
+++ b/tools/autograph-client/client.go
@@ -65,12 +65,12 @@ func urlToRequestType(url string) requestType {
 
 func main() {
 	var (
-		userid, pass, data, hash, url, infile, outfile, outkeyfile, keyid, cn, pk7digest, rootPath, rsapssHash, zipMethodOption string
-		iter, maxworkers, sa                                                                                                    int
-		debug                                                                                                                   bool
-		err                                                                                                                     error
-		requests                                                                                                                []formats.SignatureRequest
-		algs                                                                                                                    coseAlgs
+		userid, pass, data, hash, url, infile, outfile, outkeyfile, keyid, cn, pk7digest, rootPath, zipMethodOption string
+		iter, maxworkers, sa                                                                                        int
+		debug                                                                                                       bool
+		err                                                                                                         error
+		requests                                                                                                    []formats.SignatureRequest
+		algs                                                                                                        coseAlgs
 	)
 	flag.Usage = func() {
 		fmt.Print("autograph-client - simple command line client to the autograph service\n\n")
@@ -328,7 +328,7 @@ examples:
 						log.Fatal(err)
 					}
 				case rsapss.Type:
-					err = rsapss.VerifySignatureFromB64(rsapssHash, response.Signature, response.PublicKey)
+					err = rsapss.VerifySignatureFromB64(requests[i].Input, response.Signature, response.PublicKey)
 					if err != nil {
 						log.Fatalf("got error verifying RSA-PSS response: %s", err)
 					}

--- a/tools/autograph-monitor/contentsignaturepki.go
+++ b/tools/autograph-monitor/contentsignaturepki.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"go.mozilla.org/autograph/formats"
 	"go.mozilla.org/autograph/signer/contentsignaturepki"
 )
 
@@ -29,7 +30,7 @@ var ignoredCerts = map[string]bool{
 // to verify the sig. Otherwise, use the PublicKey contained in the response.
 //
 // If the signature passes, verify the chain of trust maps.
-func verifyContentSignature(response signatureresponse) error {
+func verifyContentSignature(response formats.SignatureResponse) error {
 	var (
 		key   *ecdsa.PublicKey
 		err   error

--- a/tools/autograph-monitor/contentsignaturepki_test.go
+++ b/tools/autograph-monitor/contentsignaturepki_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"go.mozilla.org/autograph/formats"
 	"go.mozilla.org/autograph/signer/contentsignaturepki"
 )
 
@@ -131,7 +132,7 @@ func TestVerifyFirefoxStagingRoot(t *testing.T) {
 
 // fixtures -----------------------------------------------------------------
 
-var ValidMonitoringContentSignature = signatureresponse{
+var ValidMonitoringContentSignature = formats.SignatureResponse{
 	Ref:       "1881ks1du39bi26cfmfczu6pf3",
 	Type:      "contentsignature",
 	Mode:      "p384ecdsa",


### PR DESCRIPTION
This PR adds a new signer called `genericrsa` that is configurable to support both PSS and PKCS15, with various hashes and salt length.

It also moves the http signaturerequest and signatureresponse to its own `formats` package so we don't have to copy those structs over to other go clients.

The code is fairly straightforward, to perhaps the exception of one trick: the hash and salt length are sent back to client in a new field of signature response called `SignerOpts`. This is needed so clients know how signing happened and how verification needs to be handled.

One thing I'd like to add is openssl unit tests. I'll try to get them in before we merge this if time allows.