### PR TITLE
signer: use HSM RNG when available

### DIFF
--- a/signer/contentsignature/contentsignature.go
+++ b/signer/contentsignature/contentsignature.go
@@ -65,7 +65,8 @@ func New(conf signer.Configuration) (s *ContentSigner, err error) {
 	if conf.PrivateKey == "" {
 		return nil, errors.New("contentsignature: missing private key in signer configuration")
 	}
-	s.priv, s.pub, s.rand, s.PublicKey, err = conf.GetKeysAndRand()
+	s.rand = conf.GetRand()
+	s.priv, s.pub, s.PublicKey, err = conf.GetKeys()
 	if err != nil {
 		return nil, errors.Wrap(err, "contentsignature: failed to retrieve signer")
 	}

--- a/signer/contentsignaturepki/contentsignature.go
+++ b/signer/contentsignaturepki/contentsignature.go
@@ -88,13 +88,14 @@ func New(conf signer.Configuration) (s *ContentSigner, err error) {
 	if conf.IssuerPrivKey == "" {
 		return nil, fmt.Errorf("contentsignaturepki %q: missing issuer private key in signer configuration", s.ID)
 	}
-	// we need to parse or retrieve from the hsm the issuer private key,
-	// so make a temporary config to call getkeysandrand
+	s.rand = conf.GetRand()
+	// make a temporary config since we need to retrieve the
+	// issuer private key from the hsm
 	tmpconf := conf
 	tmpconf.PrivateKey = conf.IssuerPrivKey
-	s.issuerPriv, s.issuerPub, s.rand, _, err = tmpconf.GetKeysAndRand()
+	s.issuerPriv, s.issuerPub, _, err = tmpconf.GetKeys()
 	if err != nil {
-		return nil, errors.Wrapf(err, "contentsignaturepki %q: failed to get keys and rand", s.ID)
+		return nil, errors.Wrapf(err, "contentsignaturepki %q: failed to get keys", s.ID)
 	}
 	// if validity is undef, default to 30 days
 	if s.validity == 0 {

--- a/signer/contentsignaturepki/contentsignature_test.go
+++ b/signer/contentsignaturepki/contentsignature_test.go
@@ -182,7 +182,7 @@ func TestNewFailure(t *testing.T) {
 		{err: `contentsignaturepki "": invalid type`, cfg: signer.Configuration{Type: ""}},
 		{err: `contentsignaturepki "": missing signer ID in signer configuration`, cfg: signer.Configuration{Type: Type, ID: ""}},
 		{err: `contentsignaturepki "bob": missing issuer private key in signer configuration`, cfg: signer.Configuration{Type: Type, ID: "bob"}},
-		{err: `contentsignaturepki "bob": failed to get keys and rand`, cfg: signer.Configuration{Type: Type, ID: "bob", IssuerPrivKey: "Ym9iCg=="}},
+		{err: `contentsignaturepki "bob": failed to get keys`, cfg: signer.Configuration{Type: Type, ID: "bob", IssuerPrivKey: "Ym9iCg=="}},
 		{err: `contentsignaturepki "abcd": invalid public key type for issuer, must be ecdsa`, cfg: signer.Configuration{
 			Type: Type,
 			ID:   "abcd",

--- a/signer/contentsignaturepki/x509.go
+++ b/signer/contentsignaturepki/x509.go
@@ -31,7 +31,8 @@ func (s *ContentSigner) findAndSetEE(conf signer.Configuration) (err error) {
 		s.X5U = tmpX5U
 	}
 	conf.PrivateKey = s.eeLabel
-	s.eePriv, s.eePub, s.rand, s.PublicKey, err = conf.GetKeysAndRand()
+	s.rand = conf.GetRand()
+	s.eePriv, s.eePub, s.PublicKey, err = conf.GetKeys()
 	if err != nil {
 		err = errors.Wrapf(err, "found suitable end-entity labeled %q in database but not in hsm", s.eeLabel)
 		return

--- a/signer/entropy_test.go
+++ b/signer/entropy_test.go
@@ -24,12 +24,9 @@ func shannonEntropy(data []byte) (entropy float64) {
 
 func TestRng(t *testing.T) {
 	for i, testcase := range PASSINGTESTCASES {
-		_, _, rng, _, err := testcase.cfg.GetKeysAndRand()
-		if err != nil {
-			t.Fatalf("testcase %d failed to load signer configuration: %v", i, err)
-		}
+		rng := testcase.cfg.GetRand()
 		randomData := make([]byte, 512)
-		_, err = rng.Read(randomData)
+		_, err := rng.Read(randomData)
 		if err != nil {
 			t.Fatalf("testcase %d failed to read from rng: %v", i, err)
 		}

--- a/signer/genericrsa/rsa.go
+++ b/signer/genericrsa/rsa.go
@@ -99,9 +99,10 @@ func New(conf signer.Configuration) (s *RSASigner, err error) {
 	if conf.PublicKey == "" {
 		return nil, errors.Errorf("genericrsa: missing public key for signer %q", s.ID)
 	}
-	s.key, s.pubKey, s.rng, s.PublicKey, err = conf.GetKeysAndRand()
+	s.rng = conf.GetRand()
+	s.key, s.pubKey, s.PublicKey, err = conf.GetKeys()
 	if err != nil {
-		return nil, errors.Wrapf(err, "genericrsa: error fetching key and rand for signer %q", s.ID)
+		return nil, errors.Wrapf(err, "genericrsa: error fetching key for signer %q", s.ID)
 	}
 	_, ok := s.pubKey.(*rsa.PublicKey)
 	if !ok {

--- a/signer/mar/mar.go
+++ b/signer/mar/mar.go
@@ -49,9 +49,10 @@ func New(conf signer.Configuration) (s *MARSigner, err error) {
 		return nil, errors.New("mar: missing private key in signer configuration")
 	}
 	s.PrivateKey = conf.PrivateKey
-	s.signingKey, s.publicKey, s.rand, s.PublicKey, err = conf.GetKeysAndRand()
+	s.rand = conf.GetRand()
+	s.signingKey, s.publicKey, s.PublicKey, err = conf.GetKeys()
 	if err != nil {
-		return nil, errors.Wrap(err, "mar: failed to get keys and random io reader")
+		return nil, errors.Wrap(err, "mar: failed to get keys")
 	}
 
 	// select the default signature algorithm depending on the private key type

--- a/signer/rsapss/rsapss.go
+++ b/signer/rsapss/rsapss.go
@@ -56,9 +56,10 @@ func New(conf signer.Configuration) (s *RSAPSSSigner, err error) {
 	if conf.PublicKey == "" {
 		return nil, errors.New("rsapss: missing public key in signer configuration")
 	}
-	s.key, s.pubKey, s.rng, s.PublicKey, err = conf.GetKeysAndRand()
+	s.rng = conf.GetRand()
+	s.key, s.pubKey, s.PublicKey, err = conf.GetKeys()
 	if err != nil {
-		return nil, errors.Wrapf(err, "rsapss: error fetching key and rand from signer configuration")
+		return nil, errors.Wrapf(err, "rsapss: error fetching key from signer configuration")
 	}
 	_, ok := s.pubKey.(*rsa.PublicKey)
 	if !ok {

--- a/signer/rsapss/rsapss_test.go
+++ b/signer/rsapss/rsapss_test.go
@@ -255,7 +255,7 @@ func TestVerifySignatureFromB64(t *testing.T) {
 	// args to VerifySignatureFromB64
 	var (
 		b64Digest = base64.StdEncoding.EncodeToString(_digest)
-		b64PubKey = _s.PublicKey // base64 encoded in signer GetKeysAndRand
+		b64PubKey = _s.PublicKey // base64 encoded in signer GetKeys
 		b64Sig    = _b64Sig
 	)
 

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -207,10 +207,10 @@ func (cfg *Configuration) GetRand() io.Reader {
 	return rand.Reader
 }
 
-// GetKeysAndRand parses a configuration to retrieve the private and public key
-// of a signer, as well as a RNG and a marshalled public key. It knows to handle
-// HSMs as needed, and thus removes that complexity from individual signers.
-func (cfg *Configuration) GetKeysAndRand() (priv crypto.PrivateKey, pub crypto.PublicKey, rng io.Reader, publicKey string, err error) {
+// GetKeys parses a configuration to retrieve the private and public
+// key of a signer, and a marshalled public key. It fetches keys from
+// the HSM when possible.
+func (cfg *Configuration) GetKeys() (priv crypto.PrivateKey, pub crypto.PublicKey, publicKey string, err error) {
 	priv, err = cfg.GetPrivateKey()
 	if err != nil {
 		return
@@ -220,7 +220,6 @@ func (cfg *Configuration) GetKeysAndRand() (priv crypto.PrivateKey, pub crypto.P
 		publicKeyBytes []byte
 		unmarshaledPub crypto.PublicKey
 	)
-	rng = cfg.GetRand()
 
 	switch privateKey := priv.(type) {
 	case *rsa.PrivateKey:

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -207,7 +207,7 @@ func TestNoSuitableKeyFound(t *testing.T) {
 
 func TestMakeKey(t *testing.T) {
 	for i, testcase := range PASSINGTESTCASES {
-		_, keyTpl, _, _, err := testcase.cfg.GetKeysAndRand()
+		_, keyTpl, _, err := testcase.cfg.GetKeys()
 		if err != nil {
 			t.Fatalf("testcase %d failed to load signer configuration: %v", i, err)
 		}

--- a/signer/xpi/xpi.go
+++ b/signer/xpi/xpi.go
@@ -135,9 +135,10 @@ func New(conf signer.Configuration, stats *signer.StatsClient) (s *XPISigner, er
 	}
 	s.PrivateKey = conf.PrivateKey
 
-	s.issuerKey, s.issuerPublicKey, s.rand, s.PublicKey, err = conf.GetKeysAndRand()
+	s.rand = conf.GetRand()
+	s.issuerKey, s.issuerPublicKey, s.PublicKey, err = conf.GetKeys()
 	if err != nil {
-		return nil, errors.Wrap(err, "xpi: GetKeysAndRand failed to retrieve signer")
+		return nil, errors.Wrap(err, "xpi: GetKeys failed to retrieve signer")
 	}
 
 	block, _ := pem.Decode([]byte(conf.Certificate))

--- a/signer/xpi/xpi_test.go
+++ b/signer/xpi/xpi_test.go
@@ -1107,7 +1107,7 @@ var FAILINGTESTCASES = []struct {
 	{err: "xpi: invalid type", cfg: signer.Configuration{Type: ""}},
 	{err: "xpi: missing signer ID in signer configuration", cfg: signer.Configuration{Type: Type, ID: ""}},
 	{err: "xpi: missing private key in signer configuration", cfg: signer.Configuration{Type: Type, ID: "bob"}},
-	{err: "xpi: GetKeysAndRand failed to retrieve signer: no suitable key found", cfg: signer.Configuration{Type: Type, ID: "bob", PrivateKey: "Ym9iCg=="}},
+	{err: "xpi: GetKeys failed to retrieve signer: no suitable key found", cfg: signer.Configuration{Type: Type, ID: "bob", PrivateKey: "Ym9iCg=="}},
 	{err: "xpi: failed to parse certificate PEM", cfg: signer.Configuration{
 		Type:        Type,
 		ID:          "abcd",


### PR DESCRIPTION
refs: https://bugzilla.mozilla.org/show_bug.cgi?id=1569471

i.e. not based on private key type

The HSM should produce more and higher quality random numbers and app servers should not block on boot waiting for RNG init (particularly for XPI key gen). Also, it reduces the risk of app server compromise allowing someone to bias the RNG (since an attacker would have to compromise the HSM RNG now).

This also gives us more breathing room for migrating all XPI signers to the HSM, since it depends on getting new certs for stage (for dep) and prod intermediate CAs, which might not happen in time for train-4.

One possible risk is exhausting the HSM RNG somehow, but however it's unlikely we'll hit CloudHSM's limit.

> Q: What is the ‘entropy source’ (source of randomness) for CloudHSM?

> Each HSM has a FIPS-validated Deterministic Random Bit Generator (DRBG) that is seeded by a True Random Number Generator (TRNG) within the HSM hardware module that conforms to SP800-90B. This is a high-quality entropy source capable of producing 20Mb/sec of entropy per HSM.

https://aws.amazon.com/cloudhsm/faqs/