### PR TITLE
Test profiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ test%: PACKAGE_TEST_OUTPUT_DIR = $(subst test,testprofiles/,$@)
 test%:
 	mkdir -p $(PACKAGE_TEST_OUTPUT_DIR)
 	$(GOTEST) -outputdir "testprofiles/$(PACKAGE_NAME)" $(PACKAGE_PATH)
+	$(GO) test -v -race $(PACKAGE_PATH)
 
 showcoverageautograph:
 showcoveragedatabase:

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,9 @@ test%: PACKAGE_TEST_OUTPUT_DIR = $(subst test,testprofiles/,$@)
 test%:
 	mkdir -p $(PACKAGE_TEST_OUTPUT_DIR)
 	$(GOTEST) -outputdir "testprofiles/$(PACKAGE_NAME)" $(PACKAGE_PATH)
+ifeq ($(RACE_TEST),1)
 	$(GO) test -v -race $(PACKAGE_PATH)
+endif
 
 showcoverageautograph:
 showcoveragedatabase:

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 GO := go
 GOLINT := golint -set_exit_status
-GOTEST := $(GO) test -v -covermode=count -count=1
-PACKAGE_NAMES := $(shell git grep -E -n --no-color -h '^package [a-z]+$$' -- '*.go' ':!vendor/' ':!tools/' | cut -d ':' -f 2 | sed 's/package\s+//g' | sed 's/main/autograph/g' | sort | uniq)
+GOTEST := $(GO) test -v -coverprofile coverage.out -covermode=count -count=1
+PACKAGE_NAMES := $(shell git grep -E -n --no-color -h '^package [a-z0-9]+$$' -- '*.go' ':!vendor/' ':!tools/' | cut -d ':' -f 2 | sed 's/package //g' | sed 's/main/autograph/g' | sort | uniq) monitor
 PACKAGES := $(addprefix go.mozilla.org/,$(PACKAGE_NAMES))
+TEST_TARGETS := $(addprefix test,$(PACKAGE_NAMES))
 
 all: generate test vet lint install
 
@@ -46,96 +47,58 @@ fmt-fix:
 	go fmt $(PACKAGES)
 	gofmt -w tools/autograph-client/ $(shell ls tools/autograph-monitor/*.go) tools/softhsm/ tools/hawk-token-maker/ tools/make-hsm-ee/ tools/makecsr/ tools/genpki/
 
-testautograph:
-	$(GOTEST) -coverprofile=coverage_autograph.out go.mozilla.org/autograph
+# for test* and showcoverage* targets include known package names for
+# autocompletion but fall through to generic implementation
 
-showcoverageautograph: testautograph
-	$(GO) tool cover -html=coverage_autograph.out
-
-testautographdb:
-	$(GOTEST) -coverprofile=coverage_db.out go.mozilla.org/autograph/database
-
-showcoverageautographdb: testautographdb
-	$(GO) tool cover -html=coverage_db.out
-
-testautographformats:
-	$(GOTEST) -coverprofile=coverage_formats.out go.mozilla.org/autograph/formats
-
-showcoverageautographformats: testautographformats
-	$(GO) tool cover -html=coverage_formats.out
-
-testsigner:
-	$(GOTEST) -coverprofile=coverage_signer.out go.mozilla.org/autograph/signer
-
-showcoveragesigner: testsigner
-	$(GO) tool cover -html=coverage_signer.out
-
-testmonitor:
-	$(GOTEST) -coverprofile=coverage_monitor.out go.mozilla.org/autograph/tools/autograph-monitor
-
-testcs:
-	$(GOTEST) -coverprofile=coverage_cs.out go.mozilla.org/autograph/signer/contentsignature
-
-showcoveragecs: testcs
-	$(GO) tool cover -html=coverage_cs.out
-
-testcspki:
-	$(GOTEST) -coverprofile=coverage_cspki.out go.mozilla.org/autograph/signer/contentsignaturepki
-
-showcoveragecspki: testcspki
-	$(GO) tool cover -html=coverage_cspki.out
-
-testxpi:
-	$(GOTEST) -coverprofile=coverage_xpi.out go.mozilla.org/autograph/signer/xpi
-
-showcoveragexpi: testxpi
-	$(GO) tool cover -html=coverage_xpi.out
+# non-signer package paths
+testautograph: PACKAGE_PATH = go.mozilla.org/autograph
+testdatabase: PACKAGE_PATH = go.mozilla.org/autograph/database
+testformats:  PACKAGE_PATH = go.mozilla.org/autograph/formats
+testmonitor: PACKAGE_PATH = go.mozilla.org/autograph/tools/autograph-monitor
+testsigner: PACKAGE_PATH = go.mozilla.org/autograph/signer
 
 testapk:
-	$(GOTEST) -coverprofile=coverage_apk.out go.mozilla.org/autograph/signer/apk
-
-showcoverageapk: testapk
-	$(GO) tool cover -html=coverage_apk.out
-
-testapk2:
-	$(GOTEST) -coverprofile=coverage_apk2.out go.mozilla.org/autograph/signer/apk2
-
-showcoverageapk2: testapk2
-	$(GO) tool cover -html=coverage_apk2.out
-
-testmar:
-	$(GOTEST) -coverprofile=coverage_mar.out go.mozilla.org/autograph/signer/mar
-
-showcoveragemar: testmar
-	$(GO) tool cover -html=coverage_mar.out
-
-testpgp:
-	$(GOTEST) -coverprofile=coverage_pgp.out go.mozilla.org/autograph/signer/pgp
-
-showcoveragepgp: testpgp
-	$(GO) tool cover -html=coverage_pgp.out
-
-testgpg2:
-	$(GOTEST) -coverprofile=coverage_gpg2.out go.mozilla.org/autograph/signer/gpg2
-
-showcoveragegpg2: testgpg2
-	$(GO) tool cover -html=coverage_gpg2.out
-
+testcontentsignature:
+testcontentsignaturepki:
 testgenericrsa:
-	$(GOTEST) -coverprofile=coverage_genericrsa.out go.mozilla.org/autograph/signer/genericrsa
-
-showcoveragegenericrsa: testgenericrsa
-	$(GO) tool cover -html=coverage_genericrsa.out
-
+testgpg2:
+testmar:
+testpgp:
 testrsapss:
-	$(GOTEST) -coverprofile=coverage_rsapss.out go.mozilla.org/autograph/signer/rsapss
+testxpi:
+# default vars for test* targets https://www.gnu.org/software/make/manual/html_node/Pattern_002dspecific.html#Pattern_002dspecific
+test%: PACKAGE_NAME = $(subst test,,$@)
+test%: PACKAGE_PATH = $(addprefix go.mozilla.org/autograph/signer/,$(subst test,,$@))
+test%: PACKAGE_TEST_OUTPUT_DIR = $(subst test,testprofiles/,$@)
+test%:
+	mkdir -p $(PACKAGE_TEST_OUTPUT_DIR)
+	$(GOTEST) -outputdir "testprofiles/$(PACKAGE_NAME)" $(PACKAGE_PATH)
 
-showcoveragersapss: testrsapss
-	$(GO) tool cover -html=coverage_rsapss.out
+showcoverageautograph:
+showcoveragedatabase:
+showcoverageformats:
+showcoveragemonitor:
+showcoveragesigner:
 
-test: testautograph testautographdb testautographformats testsigner testcs testcspki testxpi testapk testapk2 testmar testpgp testgpg2 testgenericrsa testrsapss testmonitor
+showcoverageapk:
+showcoveragecontentsignature:
+showcoveragecontentsignaturepki:
+showcoveragegenericrsa:
+showcoveragegpg2:
+showcoveragemar:
+showcoveragepgp:
+showcoveragersapss:
+showcoveragexpi:
+
+showcoverage%: PACKAGE_NAME = $(subst showcoverage,,$@)
+showcoverage%: PACKAGE_TEST_OUTPUT_DIR = $(subst showcoverage,testprofiles/,$@)
+showcoverage%:
+	make $(subst showcoverage,test,$@)
+	$(GO) tool cover -html=$(PACKAGE_TEST_OUTPUT_DIR)/coverage.out
+
+test: $(TEST_TARGETS)
 	echo 'mode: count' > coverage.out
-	grep -v mode coverage_*.out | cut -d ':' -f 2,3 >> coverage.out
+	grep -v mode $(shell find testprofiles/ -name coverage.out) | cut -d ':' -f 2,3 >> coverage.out
 
 showcoverage: test
 	$(GO) tool cover -html=coverage.out
@@ -152,4 +115,5 @@ integration-test:
 dummy-statsd:
 	nc -kluvw 0 localhost 8125
 
+.SUFFIXES:            # Delete the default suffixes
 .PHONY: all dummy-statsd test generate vendor integration-test

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GO := go
 GOLINT := golint -set_exit_status
 GOTEST := $(GO) test -v -coverprofile coverage.out -covermode=count -count=1
 PACKAGE_NAMES := $(shell git grep -E -n --no-color -h '^package [a-z0-9]+$$' -- '*.go' ':!vendor/' ':!tools/' | cut -d ':' -f 2 | sed 's/package //g' | sed 's/main/autograph/g' | sort | uniq) monitor
-PACKAGES := $(addprefix go.mozilla.org/,$(PACKAGE_NAMES))
+PACKAGE_PATHS := $(subst go.mozilla.org/autograph/signer/autograph,go.mozilla.org/autograph,$(subst go.mozilla.org/autograph/signer/monitor,go.mozilla.org/autograph/tools/autograph-monitor,$(subst go.mozilla.org/autograph/signer/signer,go.mozilla.org/autograph/signer,$(subst go.mozilla.org/autograph/signer/formats,go.mozilla.org/autograph/formats,$(subst go.mozilla.org/autograph/signer/database,go.mozilla.org/autograph/database,$(addprefix go.mozilla.org/autograph/signer/,$(PACKAGE_NAMES)))))))
 TEST_TARGETS := $(addprefix test,$(PACKAGE_NAMES))
 
 all: generate test vet lint install
@@ -31,20 +31,20 @@ tag: all
 	git tag -s $(TAGVER) -a -m "$(TAGMSG)"
 
 lint:
-	test 0 -eq $(shell $(GOLINT) $(PACKAGES) | tee /tmp/autograph-golint.txt | grep -v 'and that stutters' | wc -l)
+	test 0 -eq $(shell $(GOLINT) $(PACKAGE_PATHS) | tee /tmp/autograph-golint.txt | grep -v 'and that stutters' | wc -l)
 
 show-lint:
 	cat /tmp/autograph-golint.txt
 	rm -f /tmp/autograph-golint.txt
 
 vet:
-	go vet $(PACKAGES)
+	go vet $(PACKAGE_PATHS)
 
 fmt-diff:
 	gofmt -d *.go database/ signer/ tools/autograph-client/ $(shell ls tools/autograph-monitor/*.go) tools/softhsm/ tools/hawk-token-maker/ tools/make-hsm-ee/ tools/makecsr/ tools/genpki/
 
 fmt-fix:
-	go fmt $(PACKAGES)
+	go fmt $(PACKAGE_PATHS)
 	gofmt -w tools/autograph-client/ $(shell ls tools/autograph-monitor/*.go) tools/softhsm/ tools/hawk-token-maker/ tools/make-hsm-ee/ tools/makecsr/ tools/genpki/
 
 # for test* and showcoverage* targets include known package names for

--- a/Makefile
+++ b/Makefile
@@ -4,22 +4,8 @@
 GO := go
 GOLINT := golint -set_exit_status
 GOTEST := $(GO) test -v -covermode=count -count=1
-
-PACKAGES := go.mozilla.org/autograph \
-go.mozilla.org/autograph/database \
-go.mozilla.org/autograph/signer \
-go.mozilla.org/autograph/formats \
-go.mozilla.org/autograph/signer/apk \
-go.mozilla.org/autograph/signer/apk2 \
-go.mozilla.org/autograph/signer/contentsignature \
-go.mozilla.org/autograph/signer/contentsignaturepki \
-go.mozilla.org/autograph/signer/mar \
-go.mozilla.org/autograph/signer/xpi \
-go.mozilla.org/autograph/signer/mar \
-go.mozilla.org/autograph/signer/pgp \
-go.mozilla.org/autograph/signer/gpg2 \
-go.mozilla.org/autograph/signer/genericrsa \
-go.mozilla.org/autograph/signer/rsapss
+PACKAGE_NAMES := $(shell git grep -E -n --no-color -h '^package [a-z]+$$' -- '*.go' ':!vendor/' ':!tools/' | cut -d ':' -f 2 | sed 's/package\s+//g' | sed 's/main/autograph/g' | sort | uniq)
+PACKAGES := $(addprefix go.mozilla.org/,$(PACKAGE_NAMES))
 
 all: generate test vet lint install
 

--- a/database/queries_test.go
+++ b/database/queries_test.go
@@ -1,3 +1,5 @@
+// +build !race
+
 package database
 
 import (

--- a/handlers.go
+++ b/handlers.go
@@ -23,7 +23,7 @@ import (
 	"go.mozilla.org/autograph/signer"
 )
 
-// HeartbeatConfig configures the heartbeat handler. It sets timeouts
+// heartbeatConfig configures the heartbeat handler. It sets timeouts
 // for each backing service to check.
 //
 // `hsmHeartbeatSignerConf` is determined added on boot in initHSM

--- a/main.go
+++ b/main.go
@@ -186,6 +186,14 @@ func run(conf configuration, listen string, authPrint, debug bool) {
 	router.HandleFunc("/sign/file", ag.handleSignature).Methods("POST")
 	router.HandleFunc("/sign/data", ag.handleSignature).Methods("POST")
 	router.HandleFunc("/sign/hash", ag.handleSignature).Methods("POST")
+	if os.Getenv("AUTOGRAPH_PROFILE") == "1" {
+		err = setRuntimeConfig()
+		if err != nil {
+			log.Fatal(err)
+		}
+		addProfilerHandlers(router)
+		log.Infof("enabled HTTP perf profiler")
+	}
 
 	server := &http.Server{
 		IdleTimeout:  conf.Server.IdleTimeout,

--- a/profiler.go
+++ b/profiler.go
@@ -1,0 +1,74 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"net/http/pprof"
+	"os"
+	"runtime"
+	"strconv"
+
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// setRuntimeConfig sets runtime config options from env vars
+func setRuntimeConfig() (err error) {
+	var (
+		// BlockProfileRate is the fraction of goroutine blocking
+		// events that are reported in the blocking profile. The
+		// profiler aims to sample an average of one blocking event
+		// per rate nanoseconds spent blocked.
+		//
+		// To include every blocking event in the profile, pass rate = 1. To turn off profiling entirely, pass rate <= 0.
+		//
+		// https://golang.org/pkg/runtime/#SetBlockProfileRate
+		blockProfileRate int = 0
+
+		// mutexProfileFraction is the rate of mutex contention events
+		// that are reported in the mutex profile. On average 1/rate
+		// events are reported. The previous rate is returned.
+		//
+		// To turn off profiling entirely, pass rate 0. To just read
+		// the current rate, pass rate < 0. (For n>1 the details of
+		// sampling may change.)
+		//
+		// https://golang.org/pkg/runtime/#SetMutexProfileFraction
+		mutexProfileFraction int = 0
+	)
+	val, ok := os.LookupEnv("BLOCK_PROFILE_RATE")
+	if ok {
+		blockProfileRate, err = strconv.Atoi(val)
+		if err != nil {
+			return errors.Wrap(err, "failed to parse BLOCK_PROFILE_RATE as int")
+		}
+		runtime.SetBlockProfileRate(blockProfileRate)
+		log.Infof("SetBlockProfileRate to %d", blockProfileRate)
+	} else {
+		log.Infof("Did not SetBlockProfileRate. BLOCK_PROFILE_RATE is not set.")
+	}
+	val, ok = os.LookupEnv("MUTEX_PROFILE_FRACTION")
+	if ok {
+		mutexProfileFraction, err = strconv.Atoi(val)
+		if err != nil {
+			return errors.Wrap(err, "failed to parse MUTEX_PROFILE_FRACTION as int")
+		}
+		runtime.SetMutexProfileFraction(mutexProfileFraction)
+		log.Infof("SetMutexProfileFraction to %d", mutexProfileFraction)
+	} else {
+		log.Infof("Did not SetMutexProfileFraction. MUTEX_PROFILE_FRACTION is not set.")
+	}
+	return nil
+}
+
+// addProfilerHandlers adds debug pprof handlers
+func addProfilerHandlers(router *mux.Router) {
+	router.HandleFunc("/debug/pprof/", pprof.Index)
+	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	router.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	router.HandleFunc("/debug/pprof/trace", pprof.Trace)
+}


### PR DESCRIPTION
Changes:
* update make to detect new unvendored golang packages and add test* and showcoverage* targets for it (without autocomplete)
* refactor makefile to use golang package names and save them to `testprofiles/$PKG_NAME` (renames the following targets (from on the left result on the right)

testautographdb testdatabase
testautographformats testformats
testcs contentsignature
testcspki contentsignaturepki

and similarly for showcoverage* of the same package names). This should make it easier to add other types of test profile.
* env vars to enable the http pprof endpoints and configure a golang runtime variables (fixes #385)
* add data race detector for tests ~~and enable it in CI~~ (todo later once test failures are fixed)