### PR TITLE
main: Add arg for configurable logging level

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,17 +95,41 @@ func main() {
 
 func parseArgsAndLoadConfig(args []string) (conf configuration, listen string, authPrint, debug bool) {
 	var (
-		cfgFile string
-		port    string
-		err     error
-		fset    = flag.NewFlagSet("parseArgsAndLoadConfig", flag.ContinueOnError)
+		cfgFile  string
+		port     string
+		err      error
+		logLevel string
+		fset     = flag.NewFlagSet("parseArgsAndLoadConfig", flag.ContinueOnError)
 	)
 
 	fset.StringVar(&cfgFile, "c", "autograph.yaml", "Path to configuration file")
 	fset.StringVar(&port, "p", "", "Port to listen on. Overrides the listen var from the config file")
 	fset.BoolVar(&authPrint, "A", false, "Print authorizations matrix and exit")
-	fset.BoolVar(&debug, "D", false, "Print debug logs")
+	// https://github.com/sirupsen/logrus#level-logging
+	fset.StringVar(&logLevel, "l", "", "Set the logging level. Optional defaulting to info. Options: trace, debug, info, warning, error, fatal and panic")
+	fset.BoolVar(&debug, "D", false, "Sets the log level to debug to print debug logs.")
 	fset.Parse(args)
+
+	switch logLevel {
+	case "debug":
+		debug = true
+	case "":
+		if debug {
+			logLevel = "debug"
+		}
+	default:
+		if debug {
+			log.Fatalf("Got debug true, but conflicting log level: %s", logLevel)
+		}
+	}
+	if logLevel != "" {
+		level, err := log.ParseLevel(logLevel)
+		if err != nil {
+			log.Fatalf("Error parsing log level: %s", err)
+		}
+		log.SetLevel(level)
+		log.Infof("Set logging level to %s", level)
+	}
 
 	err = conf.loadFromFile(cfgFile)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -10,10 +10,11 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"testing"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -451,4 +452,38 @@ func TestPortOverride(t *testing.T) {
 	if listen != expected {
 		t.Errorf("expected listen %s got %s", expected, listen)
 	}
+}
+
+func TestLogLevelParsing(t *testing.T) {
+	t.Parallel()
+
+	var (
+		debug bool
+		fatal bool = false
+	)
+	_, _, _, debug = parseArgsAndLoadConfig([]string{"-l", "debug"})
+	if !(debug == true && log.GetLevel() == log.DebugLevel) {
+		t.Errorf("failed to set debug flag for debug log level")
+	}
+	_, _, _, debug = parseArgsAndLoadConfig([]string{"-D"})
+	if !(debug == true && log.GetLevel() == log.DebugLevel) {
+		t.Errorf("failed to set debug log level for debug flag")
+	}
+	_, _, _, debug = parseArgsAndLoadConfig([]string{"-l", "error"})
+	if !(debug == false && log.GetLevel() == log.ErrorLevel) {
+		t.Errorf("failed to set error log level")
+	}
+
+	log.StandardLogger().ExitFunc = func(int) { fatal = true }
+	_, _, _, _ = parseArgsAndLoadConfig([]string{"-l", "error", "-D"})
+	if fatal != true {
+		t.Errorf("did not fail for mismatched log level and debug flag")
+	}
+
+	fatal = false
+	_, _, _, _ = parseArgsAndLoadConfig([]string{"-l", "foo"})
+	if fatal != true {
+		t.Errorf("did not fail for invalid log level")
+	}
+	log.StandardLogger().ExitFunc = nil
 }


### PR DESCRIPTION
fixes: #352

Some functional tests:

```
$ ~/go/bin/autograph -l warn ./autograph.yaml
{"Timestamp":1572629643491818379,"Time":"2019-11-01T17:34:03Z","Type":"app.log","Logger":"autograph","Hostname":"gguthe-ThinkPad-X1-Carbon-6th","EnvVersion":"2.0","Pid":24181,"Severity":4,"Fields":{"msg":"Error sending gauge xpi.rsa_cache.chan_cap: write udp 127.0.0.1:48118-\u003e127.0.0.1:8125: write: connection refused"}}
{"Timestamp":1572629643526409580,"Time":"2019-11-01T17:34:03Z","Type":"app.log","Logger":"autograph","Hostname":"gguthe-ThinkPad-X1-Carbon-6th","EnvVersion":"2.0","Pid":24181,"Severity":4,"Fields":{"msg":"Error sending gauge xpi.rsa_cache.chan_cap: write udp 127.0.0.1:48118-\u003e127.0.0.1:8125: write: connection refused"}}
{"Timestamp":1572629644359552037,"Time":"2019-11-01T17:34:04Z","Type":"app.log","Logger":"autograph","Hostname":"gguthe-ThinkPad-X1-Carbon-6th","EnvVersion":"2.0","Pid":24181,"Severity":4,"Fields":{"msg":"Error sending histogram xpi.rsa_cache.gen_key_dur: write udp 127.0.0.1:48118-\u003e127.0.0.1:8125: write: connection refused"}}
{"Timestamp":1572629645086288971,"Time":"2019-11-01T17:34:05Z","Type":"app.log","Logger":"autograph","Hostname":"gguthe-ThinkPad-X1-Carbon-6th","EnvVersion":"2.0","Pid":24181,"Severity":4,"Fields":{"msg":"Error sending histogram xpi.rsa_cache.gen_key_dur: write udp 127.0.0.1:48118-\u003e127.0.0.1:8125: write: connection refused"}}
~/go/bin/autograph -D -l warn ./autograph.yaml
{"Timestamp":1572629650763733498,"Time":"2019-11-01T17:34:10Z","Type":"app.log","Logger":"autograph","Hostname":"gguthe-ThinkPad-X1-Carbon-6th","EnvVersion":"2.0","Pid":24285,"Severity":2,"Fields":{"msg":"Got debug true, but conflicting log level: warn"}}
```