### PR TITLE
docker: update AWS RDS CA cert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN addgroup --gid 10001 app \
 
 # import the RDS CA bundle
 # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.SSL
-RUN curl -o /tmp/rds-combined-ca-bundle.pem https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem && \
+RUN curl -o /tmp/rds-combined-ca-bundle.pem https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && \
     openssl x509 -in /tmp/rds-combined-ca-bundle.pem -inform PEM -out /usr/local/share/ca-certificates/rds-combined-ca-bundle.crt && \
     rm -f /tmp/rds-combined-ca-bundle.pem && \
     update-ca-certificates


### PR DESCRIPTION
Our current RDS cert expires March 6th and we want to update it in RDS and autograph app before then.

Per discussion w/ @Micheletto last night, we're planning to:

* land this and tag a point release
* upgrade the cert in RDS
* do an off-train deploy next week (so we can keep a working live stack around and limit the change set size)
 
Alternatives:

* land these changes in train-8
* lower the sslmode to not verify the cert
* mount the new cert into the image and add it as part of the deploy

r? @Micheletto @jvehent 


Follow up item:

- [ ] fix the cert filename in the docker image and config files