### PR TITLE
Convert to using the 2019 Root CA for RDS. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN addgroup --gid 10001 app \
       apt-get clean
 
 # import the RDS CA Cert, and fail if it expires in < 90 days.
-# https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.SSL
+# https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.SSL && \
 RUN curl -o /tmp/rds-combined-ca-2019-root.pem curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && \
     cat /tmp/rds-ca-2019-root.pem | openssl x509 -noout -checkend 7776000 && \
     openssl x509 -in /tmp/rds-ca-2019-root.pem -inform PEM -out /usr/local/share/ca-certificates/rds-ca-2019-root.crt && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,12 @@ RUN addgroup --gid 10001 app \
       apt -y install libltdl-dev gpg libncurses5 apksigner && \
       apt-get clean
 
-# import the RDS CA bundle
+# import the RDS CA Cert, and fail if it expires in < 90 days.
 # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.SSL
-RUN curl -o /tmp/rds-combined-ca-bundle.pem https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem && \
-    openssl x509 -in /tmp/rds-combined-ca-bundle.pem -inform PEM -out /usr/local/share/ca-certificates/rds-combined-ca-bundle.crt && \
-    rm -f /tmp/rds-combined-ca-bundle.pem && \
+RUN curl -o /tmp/rds-combined-ca-2019-root.pem curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && \
+    cat /tmp/rds-ca-2019-root.pem | openssl x509 -noout -checkend 7776000 && \
+    openssl x509 -in /tmp/rds-ca-2019-root.pem -inform PEM -out /usr/local/share/ca-certificates/rds-ca-2019-root.crt && \
+    rm -f /tmp/rds-ca-2019-root.pem && \
     update-ca-certificates
 
 ADD . /go/src/go.mozilla.org/autograph

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN addgroup --gid 10001 app \
 
 # import the RDS CA Cert, and fail if it expires in < 90 days.
 # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.SSL && \
-RUN curl -o /tmp/rds-ca-2019-root.pem curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && \
+RUN curl -o /tmp/rds-ca-2019-root.pem https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && \
     cat /tmp/rds-ca-2019-root.pem | openssl x509 -noout -checkend 7776000 && \
     openssl x509 -in /tmp/rds-ca-2019-root.pem -inform PEM -out /usr/local/share/ca-certificates/rds-ca-2019-root.crt && \
     rm -f /tmp/rds-ca-2019-root.pem && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN addgroup --gid 10001 app \
 
 # import the RDS CA Cert, and fail if it expires in < 90 days.
 # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.SSL && \
-RUN curl -o /tmp/rds-combined-ca-2019-root.pem curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && \
+RUN curl -o /tmp/rds-ca-2019-root.pem curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && \
     cat /tmp/rds-ca-2019-root.pem | openssl x509 -noout -checkend 7776000 && \
     openssl x509 -in /tmp/rds-ca-2019-root.pem -inform PEM -out /usr/local/share/ca-certificates/rds-ca-2019-root.crt && \
     rm -f /tmp/rds-ca-2019-root.pem && \


### PR DESCRIPTION
This change converts to using the 2019 Root CA for RDS (expires Aug 22, 2024) and fails if it expires in less than 90 days.