### PR TITLE
more monitor refactoring

### DIFF
--- a/tools/autograph-monitor/constants.go
+++ b/tools/autograph-monitor/constants.go
@@ -1,5 +1,11 @@
 package main
 
+// autographDevRootHash is the SHA2 hash of the cacert in the
+// autograph dev config:
+// https://github.com/mozilla-services/autograph/blob/b3081068f4a9c0c1de02150432f2d02887dd6722/autograph.yaml#L113-L126
+// used on the normandy and remote settings development servers
+const autographDevRootHash = `5E:36:F2:14:DE:82:3F:8B:29:96:89:23:5F:03:41:AC:AF:A0:75:AF:82:CB:4C:D4:30:7C:3D:B3:43:39:2A:FE`
+
 // firefoxPkiStageRootHash is the SHA2 hash of the firefoxPkiStageRoot
 // cert raw bytes
 const firefoxPkiStageRootHash = `DB:74:CE:58:E4:F9:D0:9E:E0:42:36:BE:6C:C5:C4:F6:6A:E7:74:7D:C0:21:42:7A:03:BC:2F:57:0C:8B:9B:90`

--- a/tools/autograph-monitor/contentsignaturepki_test.go
+++ b/tools/autograph-monitor/contentsignaturepki_test.go
@@ -74,7 +74,7 @@ func TestVerifyWronglyOrderedChain(t *testing.T) {
 }
 
 func TestVerifyFirefoxRoot(t *testing.T) {
-	rootHash := "97:E8:BA:9C:F1:2F:B3:DE:53:CC:42:A4:E6:57:7E:D6:4D:F4:93:C2:47:B4:14:FE:A0:36:81:8D:38:23:56:0E"
+	rootHash := firefoxPkiProdRootHash
 	block, _ := pem.Decode([]byte(firefoxPkiProdRoot))
 	if block == nil {
 		t.Fatalf("Failed to parse certificate PEM")
@@ -109,7 +109,7 @@ func TestVerifyFirefoxRootWithBadHash(t *testing.T) {
 }
 
 func TestVerifyFirefoxStagingRoot(t *testing.T) {
-	rootHash := "DB:74:CE:58:E4:F9:D0:9E:E0:42:36:BE:6C:C5:C4:F6:6A:E7:74:7D:C0:21:42:7A:03:BC:2F:57:0C:8B:9B:90"
+	rootHash := firefoxPkiStageRootHash
 	block, _ := pem.Decode([]byte(firefoxPkiStageRoot))
 	if block == nil {
 		t.Fatalf("Failed to parse certificate PEM")

--- a/tools/autograph-monitor/contentsignaturepki_test.go
+++ b/tools/autograph-monitor/contentsignaturepki_test.go
@@ -75,7 +75,7 @@ func TestVerifyWronglyOrderedChain(t *testing.T) {
 
 func TestVerifyFirefoxRoot(t *testing.T) {
 	rootHash := "97:E8:BA:9C:F1:2F:B3:DE:53:CC:42:A4:E6:57:7E:D6:4D:F4:93:C2:47:B4:14:FE:A0:36:81:8D:38:23:56:0E"
-	block, _ := pem.Decode(FirefoxPKIRootPEM)
+	block, _ := pem.Decode([]byte(firefoxPkiProdRoot))
 	if block == nil {
 		t.Fatalf("Failed to parse certificate PEM")
 	}
@@ -91,7 +91,7 @@ func TestVerifyFirefoxRoot(t *testing.T) {
 
 func TestVerifyFirefoxRootWithBadHash(t *testing.T) {
 	rootHash := "foo"
-	block, _ := pem.Decode(FirefoxPKIRootPEM)
+	block, _ := pem.Decode([]byte(firefoxPkiProdRoot))
 	if block == nil {
 		t.Fatalf("Failed to parse certificate PEM")
 	}
@@ -110,7 +110,7 @@ func TestVerifyFirefoxRootWithBadHash(t *testing.T) {
 
 func TestVerifyFirefoxStagingRoot(t *testing.T) {
 	rootHash := "DB:74:CE:58:E4:F9:D0:9E:E0:42:36:BE:6C:C5:C4:F6:6A:E7:74:7D:C0:21:42:7A:03:BC:2F:57:0C:8B:9B:90"
-	block, _ := pem.Decode(FirefoxPKIStagingRootPEM)
+	block, _ := pem.Decode([]byte(firefoxPkiStageRoot))
 	if block == nil {
 		t.Fatalf("Failed to parse certificate PEM")
 	}
@@ -135,12 +135,6 @@ var ValidMonitoringContentSignature = formats.SignatureResponse{
 	Signature: "9M26T-1RCEzTAlCzDZk6CkEZxkVZkt-wUJfA4s4altKx3Vw-MfuE08bXy1TenbR0I87PzuuA9c1CNOZ8hzRbVuYvKnOH0z4kIbGzAMWzyOxwRgufaODHpcnSAKv2q3JM",
 	X5U:       "http://127.0.0.1:64320/normandychain",
 }
-
-// this is the trusted root ca for the firefox pki
-var FirefoxPKIRootPEM = []byte(firefoxPkiProdRoot)
-
-// this is the trusted root ca for the staging firefox pki
-var FirefoxPKIStagingRootPEM = []byte(firefoxPkiStageRoot)
 
 // This chain has an expired end-entity certificate
 var ExpiredEndEntityChain = `-----BEGIN CERTIFICATE-----

--- a/tools/autograph-monitor/monitor.go
+++ b/tools/autograph-monitor/monitor.go
@@ -77,7 +77,7 @@ func main() {
 		conf.depTruststore = x509.NewCertPool()
 		conf.depTruststore.AppendCertsFromPEM([]byte(firefoxPkiStageRoot))
 	default:
-		conf.rootHash = "5E36F214DE823F8B299689235F0341ACAFA075AF82CB4CD4307C3DB343392AFE"
+		conf.rootHash = autographDevRootHash
 		conf.truststore = nil
 		conf.depRootHash = ""
 		conf.depTruststore = nil


### PR DESCRIPTION
All changes in `tools/autograph-monitor`

Changes:
* refactor csig test fixtures
* extract autograph CS dev root to `constants.go` 
* document csigpki `verifyCertChain`