### PR TITLE
ci: bump cci version to 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 # DOCKER_USER
 # DOCKER_PASS
 #
-version: 2
+version: 2.1
 jobs:
   lint-vet-fmt:
     docker:


### PR DESCRIPTION
enables more CCI config keys https://circleci.com/docs/2.0/configuration-reference/ config reuse