### PR TITLE
Fix monitor notifications

### DIFF
--- a/tools/autograph-monitor/Makefile
+++ b/tools/autograph-monitor/Makefile
@@ -11,6 +11,8 @@ test-cover-report:
 	go tool cover -func=monitor-coverage.out
 test-cover-report-html:
 	go tool cover -html=monitor-coverage.out
+race:
+	go test -v -race -covermode=atomic -count=1 .
 lint:
 	golint *.go
 vet:

--- a/tools/autograph-monitor/contentsignaturepki.go
+++ b/tools/autograph-monitor/contentsignaturepki.go
@@ -131,6 +131,10 @@ func verifyCertChain(notifier Notifier, rootHash string, certs []*x509.Certifica
 			err = fmt.Errorf("Certificate %d %q expires in less than 15 days: notAfter=%s",
 				i, cert.Subject.CommonName, cert.NotAfter)
 		}
+		if timeToExpiration < -time.Nanosecond {
+			err = fmt.Errorf("Certificate %d %q expired: notAfter=%s",
+				i, cert.Subject.CommonName, cert.NotAfter)
+		}
 		if timeToValid > time.Nanosecond {
 			err = fmt.Errorf("Certificate %d %q is not yet valid: notBefore=%s",
 				i, cert.Subject.CommonName, cert.NotBefore)

--- a/tools/autograph-monitor/contentsignaturepki.go
+++ b/tools/autograph-monitor/contentsignaturepki.go
@@ -115,30 +115,37 @@ func verifyCertChain(notifier Notifier, rootHash string, certs []*x509.Certifica
 			log.Printf("Certificate %d %q has a valid signature from parent certificate %d %q",
 				i, cert.Subject.CommonName, i+1, certs[i+1].Subject.CommonName)
 		}
-		if notifier != nil && time.Now().Add(30*24*time.Hour).After(cert.NotAfter) {
+		var (
+			notificationSeverity, notificationMessage string
+			err                                       error
+		)
+		if time.Now().Add(30 * 24 * time.Hour).After(cert.NotAfter) {
+			notificationSeverity = "warning"
 			// cert expires in less than 30 days, this is a soft error. send an email.
-			message := fmt.Sprintf("Certificate %d for %q expires in less than 30 days: notAfter=%s", i, cert.Subject.CommonName, cert.NotAfter)
-			err := notifier.Send(cert.Subject.CommonName, "warning", message)
-			if err != nil {
-				log.Printf("failed to send soft notification: %v", err)
-			}
+			notificationMessage = fmt.Sprintf("Certificate %d for %q expires in less than 30 days: notAfter=%s", i, cert.Subject.CommonName, cert.NotAfter)
 		}
 		if time.Now().Add(15 * 24 * time.Hour).After(cert.NotAfter) {
-			return fmt.Errorf("Certificate %d %q expires in less than 15 days: notAfter=%s",
+			err = fmt.Errorf("Certificate %d %q expires in less than 15 days: notAfter=%s",
 				i, cert.Subject.CommonName, cert.NotAfter)
 		}
 		if time.Now().Before(cert.NotBefore) {
-			return fmt.Errorf("Certificate %d %q is not yet valid: notBefore=%s",
+			err = fmt.Errorf("Certificate %d %q is not yet valid: notBefore=%s",
 				i, cert.Subject.CommonName, cert.NotBefore)
 		}
-		message := fmt.Sprintf(fmt.Sprintf("Certificate %d %q is valid from %s to %s",
-			i, cert.Subject.CommonName, cert.NotBefore, cert.NotAfter))
-		log.Printf(message)
+		if err == nil {
+			notificationSeverity = "info"
+			notificationMessage = fmt.Sprintf(fmt.Sprintf("Certificate %d %q is valid from %s to %s",
+				i, cert.Subject.CommonName, cert.NotBefore, cert.NotAfter))
+			log.Printf(notificationMessage)
+		}
 		if notifier != nil {
-			err := notifier.Send(cert.Subject.CommonName, "info", message)
-			if err != nil {
-				log.Printf("failed to send soft notification: %v", err)
+			notifyErr := notifier.Send(cert.Subject.CommonName, notificationSeverity, notificationMessage)
+			if notifyErr != nil {
+				log.Printf("failed to send soft notification: %v", notifyErr)
 			}
+		}
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/tools/autograph-monitor/contentsignaturepki_test.go
+++ b/tools/autograph-monitor/contentsignaturepki_test.go
@@ -134,7 +134,7 @@ func TestVerifyExpiredCertChain(t *testing.T) {
 		t.Fatal("Expected to fail chain verification with expired end-entity, but succeeded")
 	}
 	log.Printf("Chain verification failed with: %v", err)
-	if !strings.Contains(err.Error(), "expires in less than 15 days") {
+	if !strings.Contains(err.Error(), "expired") {
 		t.Fatalf("Expected to failed with expired end-entity but failed with: %v", err)
 	}
 }
@@ -160,7 +160,7 @@ func TestVerifyExpiredCertChainNotifySendsWarning(t *testing.T) {
 		t.Fatal("Expected to fail chain verification with expired end-entity, but succeeded")
 	}
 	log.Printf("Chain verification failed with: %v", err)
-	if !strings.Contains(err.Error(), "expires in less than 15 days") {
+	if !strings.Contains(err.Error(), "expired") {
 		t.Fatalf("Expected to failed with expired end-entity but failed with: %v", err)
 	}
 }
@@ -186,7 +186,7 @@ func TestVerifyExpiredCertChainWhenNotifySendWarningErrs(t *testing.T) {
 		t.Fatal("Expected to fail chain verification with expired end-entity, but succeeded")
 	}
 	log.Printf("Chain verification failed with: %v", err)
-	if !strings.Contains(err.Error(), "expires in less than 15 days") {
+	if !strings.Contains(err.Error(), "expired") {
 		t.Fatalf("Expected to failed with expired end-entity but failed with: %v", err)
 	}
 }

--- a/tools/autograph-monitor/notifier.go
+++ b/tools/autograph-monitor/notifier.go
@@ -67,7 +67,7 @@ func (n *PDEventNotifier) prepareEvent(dedupeKey, severity, message string) (*pa
 		action = "resolve"
 	}
 	if !(len(dedupeKey) < 256) {
-		return nil, fmt.Errorf("notifier: received invalid dedupeKey %s (%d long). Must be less than 256 chars.", dedupeKey, len(dedupeKey))
+		return nil, fmt.Errorf("notifier: received invalid dedupeKey %s (%d long). Must be less than 256 chars", dedupeKey, len(dedupeKey))
 	}
 
 	return &pagerduty.V2Event{


### PR DESCRIPTION
Changes:
* fix resolving soft notification alerts right after triggering them (i.e. make one call to `notifier.Send` per cert)
* refactor cert validity checks to use durations
* add a cert expired error message, which should be less confusing than expires in less than 15 days
* add a golang race condition test target


