### PR TITLE
Fix 403 apk v3 signatures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,11 @@ RUN addgroup --gid 10001 app \
       --home /app --shell /sbin/nologin \
       --disabled-password app \
       && \
+      echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/buster-backports.list && \
       apt update && \
       apt -y upgrade && \
-      apt -y install libltdl-dev gpg libncurses5 apksigner && \
+      apt -y install libltdl-dev gpg libncurses5 && \
+      apt -y install -t buster-backports apksigner && \
       apt-get clean
 
 # fetch the RDS CA bundle

--- a/autograph.yaml
+++ b/autograph.yaml
@@ -505,8 +505,106 @@ signers:
           1KDtwVd+U8cK/z6UQxo8YQ==
           -----END PRIVATE KEY-----
 
+    - id: testapp-android-v3
+      type: apk2
+      mode: v3enabled
+      certificate: |
+          -----BEGIN CERTIFICATE-----
+          MIIDyTCCArGgAwIBAgIEVxuKpDANBgkqhkiG9w0BAQsFADCBlDELMAkGA1UEBhMC
+          VVMxEzARBgNVBAgTCkNhbGlmb3JuaWExFjAUBgNVBAcTDU1vdW50YWluIFZpZXcx
+          HDAaBgNVBAoTE01vemlsbGEgQ29ycG9yYXRpb24xHDAaBgNVBAsTE1JlbGVhc2Ug
+          RW5naW5lZXJpbmcxHDAaBgNVBAMTE1JlbGVhc2UgRW5naW5lZXJpbmcwHhcNMTgw
+          MTE5MTgwNzMyWhcNNDUwNjA2MTgwNzMyWjCBlDELMAkGA1UEBhMCVVMxEzARBgNV
+          BAgTCkNhbGlmb3JuaWExFjAUBgNVBAcTDU1vdW50YWluIFZpZXcxHDAaBgNVBAoT
+          E01vemlsbGEgQ29ycG9yYXRpb24xHDAaBgNVBAsTE1JlbGVhc2UgRW5naW5lZXJp
+          bmcxHDAaBgNVBAMTE1JlbGVhc2UgRW5naW5lZXJpbmcwggEiMA0GCSqGSIb3DQEB
+          AQUAA4IBDwAwggEKAoIBAQCAUrUDTS86CuqVctCo8jG8SSd4W/m/A4UF0J8T+la/
+          pnJsZt2HhQ+Ma/+HmXF8QSeVax0LfrOaRmLyOnfwOakP7QIGYtFsBQoLV5TWJzOr
+          2ieonQS3h9xF865lNv+i9YPRGQT+ijjtKc49mnb1vek+6/o8vfCMe7/5CE+fq2c/
+          +yRjCJIstimDPfCTo5YHqXr2GaebQ006Vak2sXhmp1sScGC/HYOuyris/AgmYHXG
+          pNR4PLNWftoljp8m+PKwe8fy4zN83RqEEYnjLzR0zOPad9Z4gD+89E/3tOsvxsRS
+          jR2v6UTD+fVNeHs03fNsw8TeMcJfeMlKbO9a72ZCZcdNAgMBAAGjITAfMB0GA1Ud
+          DgQWBBTpkU1g44JTIoVS0ARI3och7+50DzANBgkqhkiG9w0BAQsFAAOCAQEAUGDm
+          suWrrN6ireyvv+SoVYZHP6YxfcNlOos41wPG2548gL0OirAjdc7+3FRl2WAuseY5
+          79RknrC1yTUUxRtoiNBAMp9NQ7jHiQLheaiZuMhf2IVXfgJf9qxfHy+6Z/tPfOt9
+          4pkbJiIlZWJbFM6FgnhEBgwJygtO0mAa5FT7UckF0TnRJfjpZKJ7YETflITyiZ7f
+          i+UaOY4AHXEAn1t3FuRW4J2W4tku4XmAZys9ATX0/LVbm/R3pqGYmTAqv0SDnStM
+          Gg/He+3S+8Rq0zqXAbOVJDVSTCRV5C9ZOmTWedBzaqmykScsCxLSpmEffy2RrtBU
+          dNKAPtSx4o34NaTpxg==
+          -----END CERTIFICATE-----
+      privatekey: |
+          -----BEGIN PRIVATE KEY-----
+          MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCAUrUDTS86CuqV
+          ctCo8jG8SSd4W/m/A4UF0J8T+la/pnJsZt2HhQ+Ma/+HmXF8QSeVax0LfrOaRmLy
+          OnfwOakP7QIGYtFsBQoLV5TWJzOr2ieonQS3h9xF865lNv+i9YPRGQT+ijjtKc49
+          mnb1vek+6/o8vfCMe7/5CE+fq2c/+yRjCJIstimDPfCTo5YHqXr2GaebQ006Vak2
+          sXhmp1sScGC/HYOuyris/AgmYHXGpNR4PLNWftoljp8m+PKwe8fy4zN83RqEEYnj
+          LzR0zOPad9Z4gD+89E/3tOsvxsRSjR2v6UTD+fVNeHs03fNsw8TeMcJfeMlKbO9a
+          72ZCZcdNAgMBAAECggEAN3iJOxYgdizF3zi0rnOTwFq3LzZDLakt1aerPI2Y9lvT
+          VrzYwn5ojEEbQti30AiyPcsB0ThCF0yZ9TAFLNkgFfxURcJt2Q4Mm36Onkxv77fs
+          MN0/br7SH4MJPkOaGi2bf8Ya/JVvqkXKG6MsDWq86zBDCgLpezD7eYF4OgN0LJmc
+          5aCmqipDWpmQ+EFRiQBrKIAalZLMPvdEFzD6U5jMch+gNiA09tUuJnI60sYvrbul
+          eJOwr8yv+CPSo8FA40Hwooy5Ab4kkkXxb3ypzVDas5QU7QVoaSrQYaQ6oKaCeKaH
+          YCKsPD3RIUilMHDhOOn4S/R5DlkYJNoXNHFq0hE3wQKBgQC+7KZVoalALOiZ5vNa
+          EUrWAUIGug2xIxtHIhGBz1oHjIOqowYaZSpa9jbFe0LbWiEveGn2j54MWUsQVtPy
+          MhHuI/1zsbFs29d44s1xP7tuggqcBGUwMMf5w36MavmnbTdxv5T29DNALz3xg/ax
+          IaiZiI4fswciDMXpFXfsL8SO+QKBgQCsD7LbMjbz9Mleia3QeyZ9sbV2EYFaps1X
+          RNntQqOow4itBXqMYBuKcoGoMR2eAMVT9ZDCtZaU00KJ608NI9yYb0xxPtNaqdlF
+          hqSn9C5khAwQmvDiV63QUTIMYqf2m3sCdwZaXSiYUXwjNXvyO63opZqgR9TwuZfO
+          h8B2DBZL9QKBgHAvhAl7JYWFHeQY9dNtp8iaEp77QkJcu5GPrjPVkDQxV8izZEms
+          OjgaxtJBfGaBzlAjdDgh6Z+d9GKUcpO04h5JXYtW1Ud+4lyxAEDUTyE/HlbQqlin
+          wUm8mqaN0UaVAWhAR5rYoSjM2ZwJi7JHcddNix2LR9y1HrG4ILBS3S+ZAoGAfVme
+          gsRtdoNSJNaG04i0fQP3YEHWjDVTCY32ejx/QJbbPrnsEtJ9nfpX7TGDEzYajFUt
+          ljx2rIvQQOw2FiuXLVKATUxo6/cre9Rgpp9lIQN2Sq6maS9ZSJeur4k8NpQFJMGT
+          1kdiKL3Mg1YWq13BD+l94eETCCEdsHADzbx2jfUCgYAjJk016W+hugkU7rtAHIaP
+          Q9+gIrgtjJrWCw6SHF3pIB749A1J4NMlQ+0XjPhcwSMrxxkMTwmLhgSEHZcVl3C6
+          zw097oFSo1ZF/8Qpe3cb3252I9MOWKSXWTJ1BP2iVlCp0jRteFCJj8SB2CAnay9F
+          1KDtwVd+U8cK/z6UQxo8YQ==
+          -----END PRIVATE KEY-----
+
     - id: apk_cert_with_ecdsa_sha256
       type: apk2
+      certificate: |
+          -----BEGIN CERTIFICATE-----
+          MIIEaDCCA+6gAwIBAgIBATAKBggqhkjOPQQDAjCBvDELMAkGA1UEBhMCVVMxCzAJ
+          BgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRwwGgYDVQQKExNBbGxp
+          em9tIENvcnBvcmF0aW9uMSAwHgYDVQQLExdBbGxpem9tIEFNTyBEZXZlbG9wbWVu
+          dDEYMBYGA1UEAxMPZGV2LmFtby5yb290LmNhMS4wLAYJKoZIhvcNAQkBFh9mb3hz
+          ZWMrZGV2YW1vcm9vdGNhQG1vemlsbGEuY29tMB4XDTE3MDMyMjExNDg0MFoXDTI3
+          MDMyMDExNDg0MFowgbwxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UE
+          BxMNTW91bnRhaW4gVmlldzEcMBoGA1UEChMTQWxsaXpvbSBDb3Jwb3JhdGlvbjEg
+          MB4GA1UECxMXQWxsaXpvbSBBTU8gRGV2ZWxvcG1lbnQxGDAWBgNVBAMTD2Rldi5h
+          bW8ucm9vdC5jYTEuMCwGCSqGSIb3DQEJARYfZm94c2VjK2RldmFtb3Jvb3RjYUBt
+          b3ppbGxhLmNvbTB2MBAGByqGSM49AgEGBSuBBAAiA2IABD0rcBU0tirO38TeyZXU
+          4jz+2v2ngib0I7ABJ4dQg5ZEfC7nW1HvgbKowwjxqPJnpB+W+RUcnsdspj91uwv9
+          RW22eGPLY8Oot7cgULitIXpBJ1ChHTCMWkzQ/C3jBYAoe6OCAcAwggG8MA8GA1Ud
+          EwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgGGMBYGA1UdJQEB/wQMMAoGCCsGAQUF
+          BwMDMB0GA1UdDgQWBBQoV8bn7ADMjKLF9XAIwDeEdqn8bDCB6QYDVR0jBIHhMIHe
+          gBQoV8bn7ADMjKLF9XAIwDeEdqn8bKGBwqSBvzCBvDELMAkGA1UEBhMCVVMxCzAJ
+          BgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRwwGgYDVQQKExNBbGxp
+          em9tIENvcnBvcmF0aW9uMSAwHgYDVQQLExdBbGxpem9tIEFNTyBEZXZlbG9wbWVu
+          dDEYMBYGA1UEAxMPZGV2LmFtby5yb290LmNhMS4wLAYJKoZIhvcNAQkBFh9mb3hz
+          ZWMrZGV2YW1vcm9vdGNhQG1vemlsbGEuY29tggEBMDQGCWCGSAGG+EIBBAQnFiVo
+          dHRwczovL2Ftby5kZXYubW96YXdzLm5ldC9jYS9jcmwucGVtMEAGCCsGAQUFBwEB
+          BDQwMjAwBggrBgEFBQcwAoYkaHR0cHM6Ly9hbW8uZGV2Lm1vemF3cy5uZXQvY2Ev
+          Y2EucGVtMAoGCCqGSM49BAMCA2gAMGUCMH/W3TjLf0giza8y83S0f4i21b1hSxEv
+          DZ0QKXuha63GeB4qNOcqqE0Zh7ttWhZ2lQIxANlADi6ZTdDtByJL/QKbk9hKGJCE
+          wMlTLnlLg0nhVXAEq2SRaF7Tx/v4Ny9kuR7p5A==
+          -----END CERTIFICATE-----
+      privatekey: |
+          -----BEGIN EC PARAMETERS-----
+          BgUrgQQAIg==
+          -----END EC PARAMETERS-----
+          -----BEGIN EC PRIVATE KEY-----
+          MIGkAgEBBDCRB9WEMGnGieJ+Vpy0s4Lg/nfONiJTNynL0z/yC4/arw1TX5MhS9/2
+          Hx2rI3n9NUmgBwYFK4EEACKhZANiAAQ9K3AVNLYqzt/E3smV1OI8/tr9p4Im9COw
+          ASeHUIOWRHwu51tR74GyqMMI8ajyZ6QflvkVHJ7HbKY/dbsL/UVttnhjy2PDqLe3
+          IFC4rSF6QSdQoR0wjFpM0Pwt4wWAKHs=
+          -----END EC PRIVATE KEY-----
+
+    - id: apk_cert_with_ecdsa_sha256_v3
+      type: apk2
+      mode: v3enabled
       certificate: |
           -----BEGIN CERTIFICATE-----
           MIIEaDCCA+6gAwIBAgIBATAKBggqhkjOPQQDAjCBvDELMAkGA1UEBhMCVVMxCzAJ
@@ -1202,7 +1300,9 @@ authorizations:
           - testapp-android-legacy
           - legacy_apk_with_rsa
           - testapp-android
+          - testapp-android-v3
           - apk_cert_with_ecdsa_sha256
+          - apk_cert_with_ecdsa_sha256_v3
           - testmar
           - testmarecdsa
           - randompgp

--- a/signer/apk2/README.rst
+++ b/signer/apk2/README.rst
@@ -48,6 +48,7 @@ You can then place the certificate and private key in `autograph.yaml`:
 	signers:
     - id: some-android-app
       type: apk2
+      mode: v3enabled
       certificate: |
           -----BEGIN CERTIFICATE-----
           MIIH0zCCBbugAwIBAgIBATANBgkqhkiG9w0BAQsFADCBvDELMAkGA1UEBhMCVVMx
@@ -58,6 +59,9 @@ You can then place the certificate and private key in `autograph.yaml`:
           MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQDHV+bKFLr1p5FR
 		  ...
           -----END PRIVATE KEY-----
+
+Set the optional `mode` field to `v3enabled` to enable APK v3
+signatures (in addition to v1 and v2).
 
 Signature request
 -----------------

--- a/signer/apk2/README.rst
+++ b/signer/apk2/README.rst
@@ -8,12 +8,13 @@ APK is Android's application packaging format. It's basically a ZIP file that
 follows the `JAR Signing`_ specification, and stores a manifest of all file checksums
 that gets signed by a private RSA key.
 
-Android also supports a `v2 Signing`_ mechanism that puts a signature in the
-metadata of the zip file.
+Android also supports `v2 Signing`_ and `v3 Signing`_ (set `mode:
+v3enabled`) that put signatures in the metadata of the zip file.
 
 
 .. _`JAR Signing`: http://download.java.net/jdk7/archive/b125/docs/technotes/tools/solaris/jarsigner.html
 .. _`v2 Signing`: https://source.android.com/security/apksigning/v2
+.. _`v3 Signing`: https://source.android.com/security/apksigning/v3
 
 Configuration
 -------------

--- a/signer/apk2/apk2.go
+++ b/signer/apk2/apk2.go
@@ -23,6 +23,9 @@ const (
 	// Type of this signer is "apk2" represents a signer that
 	// shells out to apksigner to sign artifacts
 	Type = "apk2"
+
+	// ModeV3Enabled
+	ModeV3Enabled = "v3enabled"
 )
 
 // APK2Signer holds the configuration of the signer
@@ -35,6 +38,9 @@ type APK2Signer struct {
 	minSdkVersion string
 
 	pkcs8Key []byte
+
+	// v3Enabled indicates whether to issue v3 signatures
+	v3Enabled bool
 }
 
 // New initializes an apk signer using a configuration
@@ -50,6 +56,17 @@ func New(conf signer.Configuration) (s *APK2Signer, err error) {
 		return nil, errors.New("apk2: missing signer ID in signer configuration")
 	}
 	s.ID = conf.ID
+
+	switch conf.Mode {
+	case ModeV3Enabled:
+		log.Printf("apk2: %s: v3 signing enabled", s.ID)
+		s.v3Enabled = true
+	case "":
+		s.v3Enabled = false
+	default:
+		return nil, fmt.Errorf("apk2: invalid mode in signer configuration (must be empty or %s)", ModeV3Enabled)
+	}
+	s.Mode = conf.Mode
 
 	if conf.PrivateKey == "" {
 		return nil, errors.New("apk2: missing private key in signer configuration")
@@ -86,6 +103,7 @@ func (s *APK2Signer) Config() signer.Configuration {
 	return signer.Configuration{
 		ID:          s.ID,
 		Type:        s.Type,
+		Mode:        s.Mode,
 		PrivateKey:  s.PrivateKey,
 		Certificate: s.Certificate,
 	}
@@ -123,15 +141,25 @@ func (s *APK2Signer) SignFile(file []byte, options interface{}) (signer.SignedFi
 	defer os.Remove(tmpAPKFile.Name())
 	ioutil.WriteFile(tmpAPKFile.Name(), file, 0755)
 
-	apkSigCmd := exec.Command("java", "-jar", "/usr/share/java/apksigner.jar", "sign",
-		"--key", keyPath.Name(),
-		"--cert", certPath.Name(),
+	args := []string{
+		"-jar", "/usr/share/java/apksigner.jar", "sign",
 		"--v1-signing-enabled", "true",
 		"--v2-signing-enabled", "true",
-		"--v3-signing-enabled", "true",
+	}
+	if s.v3Enabled {
+		args = append(args, "--v3-signing-enabled", "true")
+	} else {
+		// apksigner signs with v3 if the minsdk version supports it
+		args = append(args, "--v3-signing-enabled", "false")
+	}
+	args = append(args,
+		"--key", keyPath.Name(),
+		"--cert", certPath.Name(),
 		"--min-sdk-version", s.minSdkVersion,
 		tmpAPKFile.Name(),
 	)
+	apkSigCmd := exec.Command("java", args...)
+
 	out, err := apkSigCmd.CombinedOutput()
 	if err != nil {
 		return nil, errors.Wrapf(err, "apk2: failed to sign\n%s", out)

--- a/signer/apk2/apk2.go
+++ b/signer/apk2/apk2.go
@@ -128,6 +128,7 @@ func (s *APK2Signer) SignFile(file []byte, options interface{}) (signer.SignedFi
 		"--cert", certPath.Name(),
 		"--v1-signing-enabled", "true",
 		"--v2-signing-enabled", "true",
+		"--v3-signing-enabled", "true",
 		"--min-sdk-version", s.minSdkVersion,
 		tmpAPKFile.Name(),
 	)

--- a/signer/apk2/apk2.go
+++ b/signer/apk2/apk2.go
@@ -123,7 +123,7 @@ func (s *APK2Signer) SignFile(file []byte, options interface{}) (signer.SignedFi
 	defer os.Remove(tmpAPKFile.Name())
 	ioutil.WriteFile(tmpAPKFile.Name(), file, 0755)
 
-	apkSigCmd := exec.Command("java", "-jar", "/usr/bin/apksigner", "sign",
+	apkSigCmd := exec.Command("java", "-jar", "/usr/share/java/apksigner.jar", "sign",
 		"--key", keyPath.Name(),
 		"--cert", certPath.Name(),
 		"--v1-signing-enabled", "true",

--- a/signer/apk2/apk2_test.go
+++ b/signer/apk2/apk2_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func assertNewSignerWithConfOK(t *testing.T, conf signer.Configuration) *APK2Signer {
-	s, err := New(apk2signerconf)
+	s, err := New(conf)
 	if s == nil {
 		t.Fatalf("%s: expected non-nil signer for valid conf, but got nil signer", t.Name())
 	}
@@ -33,10 +33,32 @@ func assertNewSignerWithConfErrs(t *testing.T, invalidConf signer.Configuration)
 func TestNewSigner(t *testing.T) {
 	t.Parallel()
 
-	t.Run("valid", func(t *testing.T) {
+	t.Run("valid no mode", func(t *testing.T) {
 		t.Parallel()
 
-		_ = assertNewSignerWithConfOK(t, apk2signerconf)
+		s := assertNewSignerWithConfOK(t, apk2signerconf)
+		if s.v3Enabled {
+			t.Fatalf("%s: unexpectedly enabled v3 signing", t.Name())
+		}
+	})
+
+	t.Run("valid empty mode", func(t *testing.T) {
+		t.Parallel()
+
+		apk2signerconf.Mode = ""
+		s := assertNewSignerWithConfOK(t, apk2signerconf)
+		if s.v3Enabled {
+			t.Fatalf("%s: unexpectedly enabled v3 signing", t.Name())
+		}
+	})
+
+	t.Run("valid v3enabled mode", func(t *testing.T) {
+		t.Parallel()
+
+		s := assertNewSignerWithConfOK(t, apk2signerconfModeV3enabled)
+		if !s.v3Enabled {
+			t.Fatalf("%s: did not enable v3 signing", t.Name())
+		}
 	})
 
 	t.Run("invalid type", func(t *testing.T) {
@@ -52,6 +74,14 @@ func TestNewSigner(t *testing.T) {
 
 		invalidConf := apk2signerconf
 		invalidConf.ID = ""
+		assertNewSignerWithConfErrs(t, invalidConf)
+	})
+
+	t.Run("invalid Mode", func(t *testing.T) {
+		t.Parallel()
+
+		invalidConf := apk2signerconf
+		invalidConf.Mode = "invalidEnabled"
 		assertNewSignerWithConfErrs(t, invalidConf)
 	})
 
@@ -75,16 +105,53 @@ func TestNewSigner(t *testing.T) {
 func TestConfig(t *testing.T) {
 	t.Parallel()
 
-	s := assertNewSignerWithConfOK(t, apk2signerconf)
+	type fields struct {
+		Configuration signer.Configuration
+		minSdkVersion string
+		pkcs8Key      []byte
+		v3Enabled     bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   signer.Configuration
+	}{
+		{
+			name: "config without mode",
+			fields: fields{
+				Configuration: apk2signerconf,
+			},
+			want: apk2signerconf,
+		},
+		{
+			name: "config v3enabled mode",
+			fields: fields{
+				Configuration: apk2signerconfModeV3enabled,
+			},
+			want: apk2signerconfModeV3enabled,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	if s.Config().Type != apk2signerconf.Type {
-		t.Fatalf("signer type %q does not match configuration %q", s.Config().Type, apk2signerconf.Type)
-	}
-	if s.Config().ID != apk2signerconf.ID {
-		t.Fatalf("signer id %q does not match configuration %q", s.Config().ID, apk2signerconf.ID)
-	}
-	if s.Config().PrivateKey != apk2signerconf.PrivateKey {
-		t.Fatalf("signer private key %q does not match configuration %q", s.Config().PrivateKey, apk2signerconf.PrivateKey)
+			s := assertNewSignerWithConfOK(t, tt.fields.Configuration)
+			got := s.Config()
+
+			if got.ID != tt.fields.Configuration.ID {
+				t.Fatalf("signer id %q does not match configuration %q", got.ID, tt.fields.Configuration.ID)
+			}
+			if got.Type != tt.fields.Configuration.Type {
+				t.Fatalf("signer type %q does not match configuration %q", got.Type, tt.fields.Configuration.Type)
+			}
+			if got.Mode != tt.fields.Configuration.Mode {
+				t.Fatalf("signer mode %q does not match configuration %q", got.Mode, tt.fields.Configuration.Mode)
+			}
+			if got.PrivateKey != tt.fields.Configuration.PrivateKey {
+				t.Fatalf("signer private key %q does not match configuration %q", got.PrivateKey, tt.fields.Configuration.PrivateKey)
+			}
+		})
+
 	}
 }
 
@@ -182,10 +249,8 @@ func TestVerifyUnfinishedSignature(t *testing.T) {
 	}
 }
 
-var apk2signerconf = signer.Configuration{
-	ID:   "apk2test",
-	Type: Type,
-	PrivateKey: `-----BEGIN PRIVATE KEY-----
+var (
+	apk2TestPrivateKeyPEM = `-----BEGIN PRIVATE KEY-----
 MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCAUrUDTS86CuqV
 ctCo8jG8SSd4W/m/A4UF0J8T+la/pnJsZt2HhQ+Ma/+HmXF8QSeVax0LfrOaRmLy
 OnfwOakP7QIGYtFsBQoLV5TWJzOr2ieonQS3h9xF865lNv+i9YPRGQT+ijjtKc49
@@ -212,8 +277,8 @@ ljx2rIvQQOw2FiuXLVKATUxo6/cre9Rgpp9lIQN2Sq6maS9ZSJeur4k8NpQFJMGT
 Q9+gIrgtjJrWCw6SHF3pIB749A1J4NMlQ+0XjPhcwSMrxxkMTwmLhgSEHZcVl3C6
 zw097oFSo1ZF/8Qpe3cb3252I9MOWKSXWTJ1BP2iVlCp0jRteFCJj8SB2CAnay9F
 1KDtwVd+U8cK/z6UQxo8YQ==
------END PRIVATE KEY-----`,
-	Certificate: `-----BEGIN CERTIFICATE-----
+-----END PRIVATE KEY-----`
+	apk2TestCert = `-----BEGIN CERTIFICATE-----
 MIIDyTCCArGgAwIBAgIEVxuKpDANBgkqhkiG9w0BAQsFADCBlDELMAkGA1UEBhMC
 VVMxEzARBgNVBAgTCkNhbGlmb3JuaWExFjAUBgNVBAcTDU1vdW50YWluIFZpZXcx
 HDAaBgNVBAoTE01vemlsbGEgQ29ycG9yYXRpb24xHDAaBgNVBAsTE1JlbGVhc2Ug
@@ -235,5 +300,18 @@ suWrrN6ireyvv+SoVYZHP6YxfcNlOos41wPG2548gL0OirAjdc7+3FRl2WAuseY5
 i+UaOY4AHXEAn1t3FuRW4J2W4tku4XmAZys9ATX0/LVbm/R3pqGYmTAqv0SDnStM
 Gg/He+3S+8Rq0zqXAbOVJDVSTCRV5C9ZOmTWedBzaqmykScsCxLSpmEffy2RrtBU
 dNKAPtSx4o34NaTpxg==
------END CERTIFICATE-----`,
-}
+-----END CERTIFICATE-----`
+	apk2signerconf = signer.Configuration{
+		ID:          "apk2test",
+		Type:        Type,
+		PrivateKey:  apk2TestPrivateKeyPEM,
+		Certificate: apk2TestCert,
+	}
+	apk2signerconfModeV3enabled = signer.Configuration{
+		ID:          "apk2testv3enabled",
+		Type:        Type,
+		Mode:        "v3enabled",
+		PrivateKey:  apk2TestPrivateKeyPEM,
+		Certificate: apk2TestCert,
+	}
+)

--- a/signer/apk2/apk2_test.go
+++ b/signer/apk2/apk2_test.go
@@ -121,7 +121,7 @@ func TestSignFile(t *testing.T) {
 		ioutil.WriteFile(tmpApk.Name(), signedFile, 0755)
 
 		// call apksigner to verify the APK
-		apkSignerVerifySig := exec.Command("java", "-jar", "/usr/bin/apksigner", "verify", "--verbose", tmpApk.Name())
+		apkSignerVerifySig := exec.Command("java", "-jar", "/usr/share/java/apksigner.jar", "verify", "--verbose", tmpApk.Name())
 		out, err := apkSignerVerifySig.CombinedOutput()
 		if err != nil {
 			t.Fatalf("error verifying apk signature: %s\n%s", err, out)

--- a/tools/autograph-client/build_test_apks.sh
+++ b/tools/autograph-client/build_test_apks.sh
@@ -32,11 +32,8 @@ go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f ../../signer/apk2/a
 
 VERIFY=${VERIFY:-"0"}
 if [ "$VERIFY" = "1" ]; then
-    # NB: need to be running as root
-    apt update -qq
-    apt install -y openjdk-11-jre android-sdk-build-tools apksigner
     for apk in $(ls *.resigned.apk); do
         echo "verifying ${apk}"
-        java -jar /usr/bin/apksigner verify --verbose $apk
+        java -jar /usr/share/java/apksigner.jar verify --verbose $apk
     done
 fi

--- a/tools/autograph-client/build_test_apks.sh
+++ b/tools/autograph-client/build_test_apks.sh
@@ -25,14 +25,14 @@ go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f Focus-arm.apk -o fo
 go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f Focus-arm.apk -o focus-rsa.resigned.apk -k testapp-android
 
 # Sign Aligned APK with ECDSA
-go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f ../../signer/apk2/aligned-two-files.apk -o aligned-two-files.ecdsa.resigned.apk -k apk_cert_with_ecdsa_sha256
+go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f ../../signer/apk2/aligned-two-files.apk -o aligned-two-files.ecdsa.signed.apk -k apk_cert_with_ecdsa_sha256
 
 # Sign Aligned APK with RSA
-go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f ../../signer/apk2/aligned-two-files.apk -o aligned-two-files.rsa.resigned.apk -k testapp-android-legacy
+go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f ../../signer/apk2/aligned-two-files.apk -o aligned-two-files.rsa.signed.apk -k testapp-android-legacy
 
 VERIFY=${VERIFY:-"0"}
 if [ "$VERIFY" = "1" ]; then
-    for apk in $(ls *.resigned.apk); do
+    for apk in $(ls *.resigned.apk *.signed.apk); do
         echo "verifying ${apk}"
         java -jar /usr/share/java/apksigner.jar verify --verbose $apk
     done

--- a/tools/autograph-monitor/Dockerfile
+++ b/tools/autograph-monitor/Dockerfile
@@ -14,9 +14,11 @@ RUN addgroup --gid 10001 app \
       --home /app --shell /sbin/nologin \
       --disabled-password app \
       && \
+      echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/buster-backports.list && \
       apt update && \
       apt -y upgrade && \
-      apt -y install gpg apksigner && \
+      apt -y install gpg && \
+      apt -y install -t buster-backports apksigner && \
       apt-get clean
 
 USER app


### PR DESCRIPTION
fix: #403 

refs: https://jira.mozilla.com/browse/RELENG-9

Functional Tests:

- [x] force verify test in `apk2_test.go` to fail artificially and confirm verify output includes v3 format verification

```
=== CONT  TestSignFile/VerifyWithAPKSigner                                                                                                   
    apk2_test.go:126: error verifying apk signature: %!s(<nil>)                                                                              
        Verifies                                                                                                                             
        Verified using v1 scheme (JAR signing): true                                                                                         
        Verified using v2 scheme (APK Signature Scheme v2): true                                                                             
        Verified using v3 scheme (APK Signature Scheme v3): true                                                                             
        Number of signers: 1   
```  

r? @ajvb

NB: I'm going to hold off on landing this until I get the go ahead from RelEng and Mobile