### PR TITLE
fix 621 containerize monitor lambda

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,16 @@ showcoverage: test
 generate:
 	go generate
 
+# image build order:
+#
+# app -> {app-hsm,monitor}
+# monitor -> monitor-lambda-emulator,monitor-hsm-lambda-emulator
+# app-hsm -> monitor-hsm-lambda-emulator (app-hsm writes chains and updated config to shared /tmp volume)
+#
 build: generate
-	docker-compose build --no-cache app app-hsm monitor monitor-hsm
+	docker-compose build --no-cache --parallel app db
+	docker-compose build --no-cache --parallel app-hsm monitor
+	docker-compose build --no-cache --parallel monitor-lambda-emulator monitor-hsm-lambda-emulator
 
 integration-test:
 	./bin/run_integration_tests.sh

--- a/bin/test_monitor.sh
+++ b/bin/test_monitor.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+# invoke a test monitor run in a lambda monitor
+
+MONITOR_ERROR=$(curl -w '\n' -X POST 'http://localhost:8080/2015-03-31/functions/function/invocations' -d '{}')
+test "$MONITOR_ERROR = null"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,10 +81,10 @@ services:
       - apptmpdir:/tmp/
     command:
       [
-        "/app/src/autograph/bin/wait-for-it.sh",
+        "/usr/bin/wait-for-it.sh",
         "autograph-app:8001",
         "--",
-        "/go/bin/autograph-monitor",
+        "/usr/bin/autograph-monitor",
       ]
 
   monitor-hsm:
@@ -104,10 +104,10 @@ services:
       - hsmtmpdir:/tmp/
     command:
       [
-        "/app/src/autograph/bin/wait-for-it.sh",
+        "/usr/bin/wait-for-it.sh",
         "autograph-app-hsm:8001",
         "--",
-        "/go/bin/autograph-monitor",
+        "/usr/bin/autograph-monitor",
       ]
 
   unit-test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,46 +69,48 @@ services:
     image: autograph-monitor
     build:
       context: tools/autograph-monitor/
+
+  monitor-lambda-emulator:
+    container_name: autograph-monitor-lambda-emulator
+    image: autograph-monitor-lambda-emulator
+    build:
+      context: tools/autograph-monitor/
+      dockerfile: Dockerfile.lambda-emulator
     environment:
       - AUTOGRAPH_URL=http://autograph-app:8000/
       - AUTOGRAPH_KEY=19zd4w3xirb5syjgdx8atq6g91m03bdsmzjifs2oddivswlu9qs
+      # set a non-empty value to use the lambda handler
+      - LAMBDA_TASK_ROOT=/usr/local/bin/
       - AUTOGRAPH_ROOT_HASH
+    ports:
+      - "9000:8080"
     links:
       - app
     depends_on:
       - app
     volumes:
       - apptmpdir:/tmp/
-    command:
-      [
-        "/usr/bin/wait-for-it.sh",
-        "autograph-app:8001",
-        "--",
-        "/usr/bin/autograph-monitor",
-      ]
 
-  monitor-hsm:
-    container_name: autograph-monitor-hsm
-    image: autograph-monitor
+  monitor-hsm-lambda-emulator:
+    container_name: autograph-monitor-hsm-lambda-emulator
+    image: autograph-monitor-lambda-emulator
     build:
       context: tools/autograph-monitor/
+      dockerfile: Dockerfile.lambda-emulator
     environment:
       - AUTOGRAPH_URL=http://autograph-app-hsm:8001/
       - AUTOGRAPH_KEY=19zd4w3xirb5syjgdx8atq6g91m03bdsmzjifs2oddivswlu9qs
+      # set a non-empty value to use the lambda handler
+      - LAMBDA_TASK_ROOT=/usr/local/bin/
       - AUTOGRAPH_ROOT_HASH
+    ports:
+      - "9001:8080"
     links:
       - app-hsm
     depends_on:
       - app-hsm
     volumes:
       - hsmtmpdir:/tmp/
-    command:
-      [
-        "/usr/bin/wait-for-it.sh",
-        "autograph-app-hsm:8001",
-        "--",
-        "/usr/bin/autograph-monitor",
-      ]
 
   unit-test:
     container_name: autograph-unit-test

--- a/tools/autograph-monitor/.dockerignore
+++ b/tools/autograph-monitor/.dockerignore
@@ -1,0 +1,3 @@
+*.pem
+*coverage.out
+testdata/

--- a/tools/autograph-monitor/Dockerfile
+++ b/tools/autograph-monitor/Dockerfile
@@ -1,9 +1,24 @@
-FROM autograph-app
+FROM autograph-app as build
 
 USER root
-
 RUN cd /app/src/autograph/tools/autograph-monitor && go build -o /go/bin/autograph-monitor .
 
-USER app
+# copy artifacts to a clean image
+FROM debian:buster
 
-CMD /go/bin/autograph-monitor
+COPY --from=build /go/bin/autograph-monitor /usr/bin/autograph-monitor
+COPY --from=build /app/src/autograph/bin/wait-for-it.sh /usr/bin/wait-for-it.sh
+
+RUN addgroup --gid 10001 app \
+      && \
+      adduser --gid 10001 --uid 10001 \
+      --home /app --shell /sbin/nologin \
+      --disabled-password app \
+      && \
+      apt update && \
+      apt -y upgrade && \
+      apt -y install gpg apksigner && \
+      apt-get clean
+
+USER app
+CMD ["/usr/bin/autograph-monitor"]

--- a/tools/autograph-monitor/Dockerfile
+++ b/tools/autograph-monitor/Dockerfile
@@ -7,7 +7,6 @@ RUN cd /app/src/autograph/tools/autograph-monitor && go build -o /go/bin/autogra
 FROM debian:buster
 
 COPY --from=build /go/bin/autograph-monitor /usr/bin/autograph-monitor
-COPY --from=build /app/src/autograph/bin/wait-for-it.sh /usr/bin/wait-for-it.sh
 
 RUN addgroup --gid 10001 app \
       && \

--- a/tools/autograph-monitor/Dockerfile.lambda-emulator
+++ b/tools/autograph-monitor/Dockerfile.lambda-emulator
@@ -1,0 +1,18 @@
+FROM autograph-app as app
+FROM autograph-monitor
+
+USER root
+
+COPY --from=app /app/src/autograph/bin/test_monitor.sh /usr/local/bin/test_monitor.sh
+
+RUN apt update \
+    && \
+    apt -y install curl \
+    && \
+    curl -Lo /usr/local/bin/aws-lambda-rie \
+    https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie \
+    && \
+    chmod +x /usr/local/bin/aws-lambda-rie /usr/local/bin/test_monitor.sh
+
+USER app
+CMD ["/usr/local/bin/aws-lambda-rie", "/usr/bin/autograph-monitor"]

--- a/tools/autograph-monitor/Makefile
+++ b/tools/autograph-monitor/Makefile
@@ -1,6 +1,8 @@
 build:
 	go build -o autograph-monitor *.go
 	zip -r autograph-monitor.zip autograph-monitor
+build-image:
+	docker build -t autograph-monitor:latest .
 doc:
 	go doc -all .
 doc-http:

--- a/tools/autograph-monitor/README.md
+++ b/tools/autograph-monitor/README.md
@@ -29,6 +29,7 @@ And additional optional environment variables:
   alerts for warnings like a content signature certificate expiring in
   30 days.
 
+When the upstream app is down monitor requests will time out after 30 seconds.
 
 An example run looks like:
 


### PR DESCRIPTION
fix: #621 

Changes:
* build and test the monitor in the lambda runtime emulator
* add a `build-image` target to the monitor Makefile (retain the ability to build and deploy the lambda as a zip file for now) 

Decrease the compressed monitor image size to 154M from 864M (~82% reduction or ~84% pre #651).

NB: increases the lambda memory footprint to 3GB (as measured by the emulator)