### PR TITLE
593 extract verifier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
             make install-golint lint check-no-crypto11-in-signers
             make show-lint
             make -C tools/autograph-monitor lint
+            make -C verifier/contentsignature lint
       - run:
           name: run gofmt
           command: |
@@ -32,6 +33,7 @@ jobs:
           command: |
             make vet
             make -C tools/autograph-monitor vet
+            make -C verifier/contentsignature vet
 
   unit-test:
     # based on the official golang image with more docker stuff

--- a/bin/run_unit_tests.sh
+++ b/bin/run_unit_tests.sh
@@ -17,10 +17,12 @@ fi
 make generate test
 # run monitor unit tests
 make -C tools/autograph-monitor test
+make -C verifier/contentsignature test
 
 if [ "$RACE_TEST" = "1" ]; then
     make race
     make -C tools/autograph-monitor race
+    make -C verifier/contentsignature test
 fi
 
 if [ "$REPORT_COVERAGE" = "true" ]; then

--- a/verifier/contentsignature/Makefile
+++ b/verifier/contentsignature/Makefile
@@ -1,0 +1,16 @@
+.DEFAULT_GOAL := all
+all: lint vet fmt-fix test race
+doc:
+	go doc .
+fmt-fix:
+	go fmt .
+lint:
+	golint .
+race:
+	go test -race -covermode=atomic -count=1 .
+showcoverage: test
+	go tool cover -html=coverage.out
+test:
+	go test -v -coverprofile coverage.out -covermode=count -count=1 .
+vet:
+	go vet .

--- a/verifier/contentsignature/go.mod
+++ b/verifier/contentsignature/go.mod
@@ -1,0 +1,3 @@
+module github.com/mozilla-services/autograph/verifier/contentsignature
+
+go 1.15

--- a/verifier/contentsignature/signature.go
+++ b/verifier/contentsignature/signature.go
@@ -1,0 +1,170 @@
+// Package contentsignature provides a type, marshal/unmarshaller, and
+// verifier for the Firefox content signing scheme.
+//
+// It is intended for use in autograph tools and services without
+// including the rest of autograph and its dependencies.
+//
+// Prefer [the NSS
+// verifier](https://searchfox.org/mozilla-central/source/security/manager/ssl/nsIContentSignatureVerifier.idl)
+// in Firefox Desktop or [the rust application services
+// component](https://github.com/mozilla/application-services/) in
+// other Mozilla products.
+//
+package contentsignature // import "github.com/mozilla-services/autograph/verifier/contentsignature"
+
+import (
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"fmt"
+	"hash"
+	"math/big"
+)
+
+const (
+	// P256ECDSA defines an ecdsa content signature on the P-256 curve
+	P256ECDSA = "p256ecdsa"
+
+	// P256ECDSABYTESIZE defines the bytes length of a P256ECDSA signature
+	P256ECDSABYTESIZE = 64
+
+	// P384ECDSA defines an ecdsa content signature on the P-384 curve
+	P384ECDSA = "p384ecdsa"
+
+	// P384ECDSABYTESIZE defines the bytes length of a P384ECDSA signature
+	P384ECDSABYTESIZE = 96
+
+	// P521ECDSA defines an ecdsa content signature on the P-521 curve
+	P521ECDSA = "p521ecdsa"
+
+	// P521ECDSABYTESIZE defines the bytes length of a P521ECDSA signature
+	P521ECDSABYTESIZE = 132
+
+	// SignaturePrefix is a string preprended to data prior to signing
+	SignaturePrefix = "Content-Signature:\x00"
+)
+
+// ContentSignature contains the parsed representation of a signature
+type ContentSignature struct {
+	R, S     *big.Int // fields must be exported for ASN.1 marshalling
+	HashName string
+	Mode     string
+	X5U      string
+	ID       string
+	Len      int
+	Finished bool
+}
+
+func (sig *ContentSignature) String() string {
+	return fmt.Sprintf("ID=%s Mode=%s Len=%d HashName=%s X5U=%s Finished=%t R=%s S=%s",
+		sig.ID, sig.Mode, sig.Len, sig.HashName, sig.X5U, sig.Finished, sig.R.String(), sig.S.String())
+}
+
+// VerifyData verifies a signatures on its raw, untemplated, input using a public key
+func (sig *ContentSignature) VerifyData(input []byte, pubKey *ecdsa.PublicKey) bool {
+	_, hash := makeTemplatedHash(input, sig.Mode)
+	return sig.VerifyHash(hash, pubKey)
+}
+
+// VerifyHash verifies a signature on its templated hash using a public key
+func (sig *ContentSignature) VerifyHash(hash []byte, pubKey *ecdsa.PublicKey) bool {
+	return ecdsa.Verify(pubKey, hash, sig.R, sig.S)
+}
+
+// Marshal returns the R||S signature is encoded in base64 URL safe,
+// following DL/ECSSA format spec from IEEE Std 1363-2000.
+func (sig *ContentSignature) Marshal() (str string, err error) {
+	if !sig.Finished {
+		return "", fmt.Errorf("contentsignature.Marshal: unfinished cannot be encoded")
+	}
+	if sig.Len != P256ECDSABYTESIZE && sig.Len != P384ECDSABYTESIZE && sig.Len != P521ECDSABYTESIZE {
+		return "", fmt.Errorf("contentsignature.Marshal: invalid signature length %d", sig.Len)
+	}
+	// write R and S into a slice of len
+	// both R and S are zero-padded to the left to be exactly
+	// len/2 in length
+	Rstart := (sig.Len / 2) - len(sig.R.Bytes())
+	Rend := (sig.Len / 2)
+	Sstart := sig.Len - len(sig.S.Bytes())
+	Send := sig.Len
+	rs := make([]byte, sig.Len)
+	copy(rs[Rstart:Rend], sig.R.Bytes())
+	copy(rs[Sstart:Send], sig.S.Bytes())
+	encodedsig := base64.RawURLEncoding.EncodeToString(rs)
+	return fmt.Sprintf("%s", encodedsig), nil
+}
+
+// Unmarshal parses a base64 url encoded content signature
+// and returns it into a ContentSignature structure that can be verified.
+//
+// Note this function does not set the X5U value of a signature.
+func Unmarshal(signature string) (sig *ContentSignature, err error) {
+	if len(signature) < 30 {
+		return nil, fmt.Errorf("contentsignature: signature cannot be shorter than 30 characters, got %d", len(signature))
+	}
+	// decode the actual signature into its R and S values
+	data, err := base64.RawURLEncoding.DecodeString(signature)
+	if err != nil {
+		return nil, fmt.Errorf("contentsignature: error decoding %w", err)
+	}
+	// Use the length to determine the mode
+	sig = new(ContentSignature)
+	sig.Len = len(data)
+	switch sig.Len {
+	case P256ECDSABYTESIZE:
+		sig.Mode = P256ECDSA
+	case P384ECDSABYTESIZE:
+		sig.Mode = P384ECDSA
+	case P521ECDSABYTESIZE:
+		sig.Mode = P521ECDSA
+	default:
+		return nil, fmt.Errorf("contentsignature: unknown signature length %d", len(data))
+	}
+	sig.HashName = getSignatureHash(sig.Mode)
+	// parse the signature into R and S value by splitting it in the middle
+	sig.R, sig.S = new(big.Int), new(big.Int)
+	sig.R.SetBytes(data[:len(data)/2])
+	sig.S.SetBytes(data[len(data)/2:])
+	sig.Finished = true
+	return sig, nil
+}
+
+// makeTemplatedHash returns the templated sha384 of the input data. The template adds
+// the string "Content-Signature:\x00" before the input data prior to
+// calculating the sha384.
+//
+// The name of the hash function is returned, followed by the hash bytes
+func makeTemplatedHash(data []byte, curvename string) (alg string, out []byte) {
+	templated := make([]byte, len(SignaturePrefix)+len(data))
+	copy(templated[:len(SignaturePrefix)], []byte(SignaturePrefix))
+	copy(templated[len(SignaturePrefix):], data)
+	var md hash.Hash
+	switch curvename {
+	case P384ECDSA:
+		md = sha512.New384()
+		alg = "sha384"
+	case P521ECDSA:
+		md = sha512.New()
+		alg = "sha512"
+	default:
+		md = sha256.New()
+		alg = "sha256"
+	}
+	md.Write(templated)
+	return alg, md.Sum(nil)
+}
+
+// getSignatureHash returns the name of the hash function used by a given mode,
+// or an empty string if the mode is unknown
+func getSignatureHash(mode string) string {
+	switch mode {
+	case P256ECDSA:
+		return "sha256"
+	case P384ECDSA:
+		return "sha384"
+	case P521ECDSA:
+		return "sha512"
+	}
+	return ""
+}

--- a/verifier/contentsignature/signature_test.go
+++ b/verifier/contentsignature/signature_test.go
@@ -1,0 +1,460 @@
+package contentsignature
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"encoding/hex"
+	"log"
+	"math/big"
+	"reflect"
+	"testing"
+)
+
+// helper funcs  -----------------------------------------------------------------
+
+func mustBigIntFromDecimalString(s string) *big.Int {
+	n, ok := big.NewInt(0).SetString(s, 10)
+	if !ok {
+		log.Fatalf("failed to convert %s to big int", s)
+	}
+	return n
+}
+
+func mustDecodeHexString(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		log.Fatalf("failed to decode hex string %s to bytes", s)
+	}
+	return b
+}
+
+// fixtures --------------------------------------------------------------
+
+var (
+	// from signer/contentsignature/contentsignature_test.go TestSign
+	signerTestData = []byte("foobarbaz1234abcd")
+
+	p256TestSig = &ContentSignature{
+		R:        mustBigIntFromDecimalString("62909702126755073161249936578520261285964055865546934671113657432774849950157"),
+		S:        mustBigIntFromDecimalString("30559927079695968215018070878464328164176070041378591122567041460364132574773"),
+		HashName: "sha256",
+		Mode:     "p256ecdsa",
+		X5U:      "",
+		ID:       "",
+		Len:      64,
+		Finished: true,
+	}
+	p384TestSig = &ContentSignature{
+		R:        mustBigIntFromDecimalString("25920589312451551818559626767476922317217633145615568746572798912184410409902866527161616588296492756386189696060451"),
+		S:        mustBigIntFromDecimalString("28210502812388841842522738679512519041668180649087645905259177260095000465474300888386313361778093884370722950365201"),
+		HashName: "sha384",
+		Mode:     "p384ecdsa",
+		X5U:      "",
+		ID:       "",
+		Len:      96,
+		Finished: true,
+	}
+	p521TestSig = &ContentSignature{
+		R:        mustBigIntFromDecimalString("4646476664527617645941630225174709716850049149725353056943824849449843640252251197065601102039208646719010730687701233201185001625186775785774002588460423236"),
+		S:        mustBigIntFromDecimalString("1404016930457956301674587914836594763521686195945104894183479324476177014864689510664290222914854912594609934251721782786584615945638878682397815690212480403"),
+		HashName: "sha512",
+		Mode:     "p521ecdsa",
+		X5U:      "",
+		ID:       "",
+		Len:      132,
+		Finished: true,
+	}
+)
+
+// Tests -----------------------------------------------------------------
+
+func TestContentSignature_Marshal(t *testing.T) {
+	tests := []struct {
+		name       string
+		sig        *ContentSignature
+		wantStr    string
+		wantErr    bool
+		wantErrStr string
+	}{
+		{
+			name:       "marshal p256 ok",
+			sig:        p256TestSig,
+			wantStr:    "ixWhLKosDeaHn4sd_F094_Cby1rQc6I9AhMj1_8lcc1DkE5G4ruDcwUjH1FOiMM71AQzRDY68jm0-xr0mh1mNQ",
+			wantErr:    false,
+			wantErrStr: "n/a",
+		},
+		{
+			name:       "p384 signature ok",
+			sig:        p384TestSig,
+			wantStr:    "qGjS1QmB2xANizjJqrGmIPoojzjBrTV5kgi01p1ELnfKwH4E3UDTZRf-9K7PCEwjt0mOzd1bBmRBKcnWZNFAMvAduBwfAPHFGpX-YKBoRSLHuA6QuiosEydnZEs5ykAR",
+			wantErr:    false,
+			wantErrStr: "n/a",
+		},
+		{
+			name:       "p521 signature ok",
+			sig:        p521TestSig,
+			wantStr:    "AVqM0NbiKRu9xcVk2yvE0OUfPiNI6Dph0Omgw5eSU6Hpr8HU9aFWgkbWfQMyFjYxDto5WItUqrDbXfgrIbe-bphEAGi3Y80jUZSshnfkI6o_0DSFj6SsmiMYO7FCis6CwXNzG5R9DpGjXsahASdQXcf7Xj2DEviII6H4pHfR_jwUWRWT",
+			wantErr:    false,
+			wantErrStr: "n/a",
+		},
+		// failing test cases.
+		{
+			name: "Marshal unfinished sig errs",
+			sig: &ContentSignature{
+				Finished: false,
+			},
+			wantStr:    "",
+			wantErr:    true,
+			wantErrStr: "contentsignature.Marshal: unfinished cannot be encoded",
+		},
+		{
+			name: "Marshal invalid signature length errs",
+			sig: &ContentSignature{
+				Finished: true,
+				Len:      1,
+			},
+			wantStr:    "",
+			wantErr:    true,
+			wantErrStr: "contentsignature.Marshal: invalid signature length 1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotStr, err := tt.sig.Marshal()
+			if tt.wantErr && (err != nil) && err.Error() != tt.wantErrStr {
+				t.Errorf("Unmarshal() error.Error() = '%s', wanted wantErrStr '%s'", err, tt.wantErrStr)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ContentSignature.Marshal() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotStr != tt.wantStr {
+				t.Errorf("ContentSignature.Marshal() = %v, want %v", gotStr, tt.wantStr)
+			}
+		})
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	type args struct {
+		signature string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantSig    *ContentSignature
+		wantErr    bool
+		wantErrStr string
+	}{
+		{
+			name: "p256 signature ok",
+			args: args{
+				signature: "ixWhLKosDeaHn4sd_F094_Cby1rQc6I9AhMj1_8lcc1DkE5G4ruDcwUjH1FOiMM71AQzRDY68jm0-xr0mh1mNQ",
+			},
+			wantSig:    p256TestSig,
+			wantErr:    false,
+			wantErrStr: "n/a",
+		},
+		{
+			name: "p384 signature ok",
+			args: args{
+				signature: "qGjS1QmB2xANizjJqrGmIPoojzjBrTV5kgi01p1ELnfKwH4E3UDTZRf-9K7PCEwjt0mOzd1bBmRBKcnWZNFAMvAduBwfAPHFGpX-YKBoRSLHuA6QuiosEydnZEs5ykAR",
+			},
+			wantSig:    p384TestSig,
+			wantErr:    false,
+			wantErrStr: "n/a",
+		},
+		{
+			name: "p521 signature ok",
+			args: args{
+				signature: "AVqM0NbiKRu9xcVk2yvE0OUfPiNI6Dph0Omgw5eSU6Hpr8HU9aFWgkbWfQMyFjYxDto5WItUqrDbXfgrIbe-bphEAGi3Y80jUZSshnfkI6o_0DSFj6SsmiMYO7FCis6CwXNzG5R9DpGjXsahASdQXcf7Xj2DEviII6H4pHfR_jwUWRWT",
+			},
+			wantSig:    p521TestSig,
+			wantErr:    false,
+			wantErrStr: "n/a",
+		},
+		// failing testcases
+		{
+			name: "empty signature errors",
+			args: args{
+				signature: "",
+			},
+			wantSig:    nil,
+			wantErr:    true,
+			wantErrStr: "contentsignature: signature cannot be shorter than 30 characters, got 0",
+		},
+		{
+			name: "short signature errors",
+			args: args{
+				signature: "stilltooooshort",
+			},
+			wantSig:    nil,
+			wantErr:    true,
+			wantErrStr: "contentsignature: signature cannot be shorter than 30 characters, got 15",
+		},
+		{
+			name: "invalid base64 signature errors",
+			args: args{
+				signature: `69d63fd587971092b5cb930f3e41e9331f0584c5660dbf13060045feae024621\0\+====`,
+			},
+			wantSig:    nil,
+			wantErr:    true,
+			wantErrStr: "contentsignature: error decoding illegal base64 data at input byte 64",
+		},
+		{
+			name: "unknown signature length errors",
+			args: args{
+				signature: "gZimwQAsuCj_JcgxrIjw1wzON8WYN9YKp3I5I9NmOgnGLOJJwHDxjOA2QEnzN7bXBGWFgn8HJ7fGRYxBy1SHiDMiF8VX7V49KkanO9MO-RRN1AyC9xmghuEcF4ndhQaIgZimwQAsuCj_JcgxrIjw1wzON8WYN9YKp3I5I9NmOgnGLOJJwHDxjOA2QEnzN7bXBGWFgn8HJ7fGRYxBy1SHiDMiF8VX7V49KkanO9MO-RRN1AyC9xmghuEcF4ndhQaI",
+			},
+			wantSig:    nil,
+			wantErr:    true,
+			wantErrStr: "contentsignature: unknown signature length 192",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSig, err := Unmarshal(tt.args.signature)
+			if tt.wantErr && (err != nil) && err.Error() != tt.wantErrStr {
+				t.Errorf("Unmarshal() error.Error() = '%s', wanted wantErrStr '%s'", err, tt.wantErrStr)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Unmarshal() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotSig, tt.wantSig) {
+				t.Errorf("Unmarshal() = %v, want %v", gotSig, tt.wantSig)
+			}
+		})
+	}
+}
+
+func TestContentSignature_VerifyHash(t *testing.T) {
+	type args struct {
+		hash   []byte
+		pubKey *ecdsa.PublicKey
+	}
+	tests := []struct {
+		name string
+		sig  *ContentSignature
+		args args
+		want bool
+	}{
+		{
+			name: "verify p256 with hashed test data",
+			sig:  p256TestSig,
+			args: args{
+				hash: mustDecodeHexString("4ee8adc2df47cf373e1f76a6c21337ceada8be0ce065e50b87e18e8018dbf207"),
+				pubKey: &ecdsa.PublicKey{
+					Curve: elliptic.P256(),
+					X:     mustBigIntFromDecimalString("22553365886807321974704376035318458672319825144968346123404118269995097711781"),
+					Y:     mustBigIntFromDecimalString("108244837256420658593099768393894446089592395710437410913712129226183066280052"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "verify p384 with hashed test data",
+			sig:  p384TestSig,
+			args: args{
+				hash: mustDecodeHexString("de26bbd0ca62d01c25da2bdf4cc9e3a74b2febde46a1fefc80f3c5551ba43d82d68af4f4daf51141848667b34412ecdb"),
+				pubKey: &ecdsa.PublicKey{
+					Curve: elliptic.P384(),
+					X:     mustBigIntFromDecimalString("36710462446480588216284689807627817014646721200492924145398531433235091994318991197136051265123969581598624769673277"),
+					Y:     mustBigIntFromDecimalString("13321657710580770815189509910471560427735973610987090311580468484926183799307630222506225442637593506669214941325644"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "verify p521 with hashed test data",
+			sig:  p521TestSig,
+			args: args{
+				hash: mustDecodeHexString("858aadfa55e677ec54ac32886beabf48ecbb47ad0ac89dfac52a1765a10ee3367dd4fa2c222635426dbe1a515c38140140c4b7c4a61ab345527e57917696b200"),
+				pubKey: &ecdsa.PublicKey{
+					Curve: elliptic.P521(),
+					X:     mustBigIntFromDecimalString("286552129222061894591899553727916711846697303481941651268255086723851847297946360274929851689688740326236568882843713781062271837109982630496462930539210780"),
+					Y:     mustBigIntFromDecimalString("4465986104604937627280307749790047390503295541438697600342307857260719588592376747937866471348953390906248103628086397664284123962827478845690817485707485531"),
+				},
+			},
+			want: true,
+		},
+		// failing test cases.
+		{
+			name: "verify p521 with pubkey with wrong curve",
+			sig:  p521TestSig,
+			args: args{
+				hash: mustDecodeHexString("858aadfa55e677ec54ac32886beabf48ecbb47ad0ac89dfac52a1765a10ee3367dd4fa2c222635426dbe1a515c38140140c4b7c4"),
+				pubKey: &ecdsa.PublicKey{
+					Curve: elliptic.P256(),
+					X:     mustBigIntFromDecimalString("286552129222061894591899553727916711846697303481941651268255086723851847297946360274929851689688740326236568882843713781062271837109982630496462930539210780"),
+					Y:     mustBigIntFromDecimalString("4465986104604937627280307749790047390503295541438697600342307857260719588592376747937866471348953390906248103628086397664284123962827478845690817485707485531"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "verify p521 with invalid short hash",
+			sig:  p521TestSig,
+			args: args{
+				hash: mustDecodeHexString("858aadfa55e677ec54ac32886beabf48ecbb47ad0ac89dfac52a1765a10ee3367dd4fa2c222635426dbe1a515c38140140c4b7c4"),
+				pubKey: &ecdsa.PublicKey{
+					Curve: elliptic.P521(),
+					X:     mustBigIntFromDecimalString("286552129222061894591899553727916711846697303481941651268255086723851847297946360274929851689688740326236568882843713781062271837109982630496462930539210780"),
+					Y:     mustBigIntFromDecimalString("4465986104604937627280307749790047390503295541438697600342307857260719588592376747937866471348953390906248103628086397664284123962827478845690817485707485531"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "verify p521 with invalid doubled hash",
+			sig:  p521TestSig,
+			args: args{
+				hash: mustDecodeHexString("858aadfa55e677ec54ac32886beabf48ecbb47ad0ac89dfac52a1765a10ee3367dd4fa2c222635426dbe1a515c38140140c4b7c4a61ab345527e57917696b200858aadfa55e677ec54ac32886beabf48ecbb47ad0ac89dfac52a1765a10ee3367dd4fa2c222635426dbe1a515c38140140c4b7c4a61ab345527e57917696b200"),
+				pubKey: &ecdsa.PublicKey{
+					Curve: elliptic.P521(),
+					X:     mustBigIntFromDecimalString("286552129222061894591899553727916711846697303481941651268255086723851847297946360274929851689688740326236568882843713781062271837109982630496462930539210780"),
+					Y:     mustBigIntFromDecimalString("4465986104604937627280307749790047390503295541438697600342307857260719588592376747937866471348953390906248103628086397664284123962827478845690817485707485531"),
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.sig.VerifyHash(tt.args.hash, tt.args.pubKey); got != tt.want {
+				t.Errorf("ContentSignature.VerifyHash() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContentSignature_VerifyData(t *testing.T) {
+	type args struct {
+		input  []byte
+		pubKey *ecdsa.PublicKey
+	}
+	tests := []struct {
+		name string
+		sig  *ContentSignature
+		args args
+		want bool
+	}{
+		{
+			name: "verify p256 with test data",
+			sig:  p256TestSig,
+			args: args{
+				input: signerTestData,
+				pubKey: &ecdsa.PublicKey{
+					Curve: elliptic.P256(),
+					X:     mustBigIntFromDecimalString("22553365886807321974704376035318458672319825144968346123404118269995097711781"),
+					Y:     mustBigIntFromDecimalString("108244837256420658593099768393894446089592395710437410913712129226183066280052"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "verify p384 with test data",
+			sig:  p384TestSig,
+			args: args{
+				input: signerTestData,
+				pubKey: &ecdsa.PublicKey{
+					Curve: elliptic.P384(),
+					X:     mustBigIntFromDecimalString("36710462446480588216284689807627817014646721200492924145398531433235091994318991197136051265123969581598624769673277"),
+					Y:     mustBigIntFromDecimalString("13321657710580770815189509910471560427735973610987090311580468484926183799307630222506225442637593506669214941325644"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "verify p521 with test data",
+			sig:  p521TestSig,
+			args: args{
+				input: signerTestData,
+				pubKey: &ecdsa.PublicKey{
+					Curve: elliptic.P521(),
+					X:     mustBigIntFromDecimalString("286552129222061894591899553727916711846697303481941651268255086723851847297946360274929851689688740326236568882843713781062271837109982630496462930539210780"),
+					Y:     mustBigIntFromDecimalString("4465986104604937627280307749790047390503295541438697600342307857260719588592376747937866471348953390906248103628086397664284123962827478845690817485707485531"),
+				},
+			},
+			want: true,
+		},
+		// failing test cases.
+		{
+			name: "verify p521 with invalid empty data fails",
+			sig:  p521TestSig,
+			args: args{
+				input: []byte(""),
+				pubKey: &ecdsa.PublicKey{
+					Curve: elliptic.P521(),
+					X:     mustBigIntFromDecimalString("286552129222061894591899553727916711846697303481941651268255086723851847297946360274929851689688740326236568882843713781062271837109982630496462930539210780"),
+					Y:     mustBigIntFromDecimalString("4465986104604937627280307749790047390503295541438697600342307857260719588592376747937866471348953390906248103628086397664284123962827478845690817485707485531"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "verify p521 with invalid other data fails",
+			sig:  p521TestSig,
+			args: args{
+				input: []byte("foobarbaz !!!!"),
+				pubKey: &ecdsa.PublicKey{
+					Curve: elliptic.P521(),
+					X:     mustBigIntFromDecimalString("286552129222061894591899553727916711846697303481941651268255086723851847297946360274929851689688740326236568882843713781062271837109982630496462930539210780"),
+					Y:     mustBigIntFromDecimalString("4465986104604937627280307749790047390503295541438697600342307857260719588592376747937866471348953390906248103628086397664284123962827478845690817485707485531"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "verify p384 with P-256 curve pubkey fails",
+			sig:  p384TestSig,
+			args: args{
+				input: signerTestData,
+				pubKey: &ecdsa.PublicKey{
+					Curve: elliptic.P256(),
+					X:     mustBigIntFromDecimalString("36710462446480588216284689807627817014646721200492924145398531433235091994318991197136051265123969581598624769673277"),
+					Y:     mustBigIntFromDecimalString("13321657710580770815189509910471560427735973610987090311580468484926183799307630222506225442637593506669214941325644"),
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.sig.VerifyData(tt.args.input, tt.args.pubKey); got != tt.want {
+				t.Errorf("ContentSignature.VerifyData() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContentSignature_String(t *testing.T) {
+	tests := []struct {
+		name string
+		sig  *ContentSignature
+		want string
+	}{
+		{
+			name: "p256 str ok",
+			sig:  p256TestSig,
+			want: "ID= Mode=p256ecdsa Len=64 HashName=sha256 X5U= Finished=true R=62909702126755073161249936578520261285964055865546934671113657432774849950157 S=30559927079695968215018070878464328164176070041378591122567041460364132574773",
+		},
+		{
+			name: "p384 str ok",
+			sig:  p384TestSig,
+			want: "ID= Mode=p384ecdsa Len=96 HashName=sha384 X5U= Finished=true R=25920589312451551818559626767476922317217633145615568746572798912184410409902866527161616588296492756386189696060451 S=28210502812388841842522738679512519041668180649087645905259177260095000465474300888386313361778093884370722950365201",
+		},
+		{
+			name: "p521 str ok",
+			sig:  p521TestSig,
+			want: "ID= Mode=p521ecdsa Len=132 HashName=sha512 X5U= Finished=true R=4646476664527617645941630225174709716850049149725353056943824849449843640252251197065601102039208646719010730687701233201185001625186775785774002588460423236 S=1404016930457956301674587914836594763521686195945104894183479324476177014864689510664290222914854912594609934251721782786584615945638878682397815690212480403",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.sig.String(); got != tt.want {
+				t.Errorf("ContentSignature.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/verifier/contentsignature/verifier.go
+++ b/verifier/contentsignature/verifier.go
@@ -1,0 +1,201 @@
+package contentsignature // import "github.com/mozilla-services/autograph/verifier/contentsignature"
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// chainBytesToCerts parses a PEM-encoded certificate chain.
+//
+// It parses the end entity/leaf then the intermediate then the root
+// cert. It does not validate the certificates or the chain.
+//
+// It returns the slice of three certs or an empty slice and an error.
+//
+func chainBytesToCerts(chain []byte) (certs []*x509.Certificate, err error) {
+	block, rest := pem.Decode(chain)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("failed to PEM decode EE/leaf certificate from chain")
+	}
+	ee, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing EE/leaf certificate from chain: %w", err)
+	}
+	certs = append(certs, ee)
+
+	// the second cert is the intermediate
+	block, rest = pem.Decode(rest)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("failed to PEM decode intermediate certificate from chain")
+	}
+	inter, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse intermediate certificate from chain: %w", err)
+	}
+	certs = append(certs, inter)
+
+	// the third and last cert is the root
+	block, rest = pem.Decode(rest)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("failed to PEM decode root certificate from chain")
+	}
+	root, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse root certificate from chain: %w", err)
+	}
+	if len(rest) != 0 {
+		return nil, fmt.Errorf("found trailing data after root certificate in chain")
+	}
+	certs = append(certs, root)
+	return certs, nil
+}
+
+// verifyRoot checks that a root cert is:
+//
+// 1) self-signed
+// 2) a CA
+// 3) has the x509v3 Extentions for CodeSigning use
+//
+// and SHA2 sum of raw bytes matches the provided hex-encoded with
+// optional colons rootHash param (as from openssl x509 -noout -text
+// -fingerprint -sha256 -in ca.crt)
+func verifyRoot(rootHash string, cert *x509.Certificate) error {
+	// this is the last cert, it should be self signed
+	if !bytes.Equal(cert.RawSubject, cert.RawIssuer) {
+		return fmt.Errorf("subject does not match issuer, should be equal")
+	}
+	if !cert.IsCA {
+		return fmt.Errorf("missing IS CA extension")
+	}
+	if rootHash == "" {
+		return fmt.Errorf("rootHash must not be empty")
+	}
+	rhash := strings.Replace(rootHash, ":", "", -1)
+	// We're configure to check the root hash matches expected value
+	h := sha256.Sum256(cert.Raw)
+	certHash := fmt.Sprintf("%X", h[:])
+	if rhash != certHash {
+		return fmt.Errorf("hash does not match expected root: expected=%s; got=%s", rhash, certHash)
+	}
+	hasCodeSigningExtension := false
+	for _, ext := range cert.ExtKeyUsage {
+		if ext == x509.ExtKeyUsageCodeSigning {
+			hasCodeSigningExtension = true
+			break
+		}
+	}
+	if !hasCodeSigningExtension {
+		return fmt.Errorf("missing codeSigning key usage extension")
+	}
+	return nil
+}
+
+// verifyCertChain checks certs in a three certificate chain [EE, intermediate, root] are:
+//
+// 1) signed by their parent/issuer/the next cert in the chain or all verifyRoot checks for the root
+// 2) valid for the current time i.e. cert NotBefore < current time < cert NotAfter
+// 3) the chain follows name constraints and extended key usage as checked by x509 Certificate.Verify
+//
+func verifyCertChain(rootHash string, certs []*x509.Certificate, currentTime time.Time) error {
+	if len(certs) != 3 {
+		return fmt.Errorf("can only verify 3 certificate chain, got %d certs", len(certs))
+	}
+
+	var (
+		inters = x509.NewCertPool()
+		roots  = x509.NewCertPool()
+	)
+	for i, cert := range certs {
+		var (
+			timeToExpiration = cert.NotAfter.Sub(currentTime)
+			timeToValid      = cert.NotBefore.Sub(currentTime)
+		)
+		if timeToExpiration < -time.Nanosecond {
+			return fmt.Errorf("Certificate %d %q expired: notAfter=%s",
+				i, cert.Subject.CommonName, cert.NotAfter)
+		}
+		if timeToValid > time.Nanosecond {
+			return fmt.Errorf("Certificate %d %q is not yet valid: notBefore=%s",
+				i, cert.Subject.CommonName, cert.NotBefore)
+		}
+		switch i {
+		case 2: // the last cert is the root
+			err := verifyRoot(rootHash, cert)
+			if err != nil {
+				return fmt.Errorf("Certificate %d %q is root but fails validation: %w",
+					i, cert.Subject.CommonName, err)
+			}
+			roots.AddCert(cert)
+		case 1:
+			inters.AddCert(cert)
+			fallthrough // fall through to check intermediate is signed by root
+		case 0:
+			fallthrough // fall through to check leaf is signed by intermediate
+		default:
+			// check that cert is signed by parent
+			err := cert.CheckSignatureFrom(certs[i+1])
+			if err != nil {
+				return fmt.Errorf("Certificate %d %q is not signed by parent certificate %d %q: %v",
+					i, cert.Subject.CommonName, i+1, certs[i+1].Subject.CommonName, err)
+			}
+		}
+	}
+	opts := x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: inters,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		CurrentTime:   currentTime,
+	}
+	_, err := certs[0].Verify(opts)
+	if err != nil {
+		return fmt.Errorf("error verifying certificate chain: %w", err)
+	}
+	return nil
+}
+
+// Verify validates the signature and certificate chain of a content signature response
+//
+// It takes:
+//
+// input data
+// a content signature metadata
+// a PEM-encoded of the cert chain string
+// a rootHash
+//
+// It parses the certificate chain, verifies input data using the end-entity certificate of the chain,
+// then verifies the cert chain of trust maps to the signed data.
+//
+// It returns an error if it fails or nil on success.
+//
+func Verify(input, certChain []byte, signature, rootHash string) error {
+	certs, err := chainBytesToCerts(certChain)
+	if err != nil {
+		return fmt.Errorf("Error parsing cert chain: %w", err)
+	}
+	// Get the public key from the end-entity (certs[0] is the end entity)
+	key, ok := certs[0].PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return fmt.Errorf("Cannot verify EE/leaf cert with non-ECDSA public key type: %T", key)
+	}
+	// parse the json signature
+	sig, err := Unmarshal(signature)
+	if err != nil {
+		return fmt.Errorf("Error unmarshal content signature: %w", err)
+	}
+	// make a templated hash
+	if !sig.VerifyData(input, key) {
+		return fmt.Errorf("ECDSA signature verification failed")
+	}
+
+	err = verifyCertChain(rootHash, certs, time.Now())
+	if err != nil {
+		return fmt.Errorf("Error verifying content signature certificate chain: %w", err)
+	}
+	return nil
+}

--- a/verifier/contentsignature/verifier_test.go
+++ b/verifier/contentsignature/verifier_test.go
@@ -1,0 +1,1480 @@
+package contentsignature
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"math/big"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// helper funcs  -----------------------------------------------------------------
+
+func mustPEMToCert(s string) *x509.Certificate {
+	block, _ := pem.Decode([]byte(s))
+	if block == nil {
+		log.Fatalf("Failed to parse certificate PEM")
+	}
+	certX509, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		log.Fatalf("Could not parse X.509 certificate: %v", err)
+	}
+	return certX509
+}
+
+func mustPEMToECKey(s string) *ecdsa.PrivateKey {
+	block, _ := pem.Decode([]byte(s))
+	if block == nil {
+		log.Fatalf("Failed to parse EC key PEM")
+	}
+	key, err := x509.ParseECPrivateKey(block.Bytes)
+	if err != nil {
+		log.Fatalf("Could not parse EC key: %q", err)
+	}
+	return key
+}
+
+// mustChainToCerts
+func mustChainToCerts(chain string) (certs []*x509.Certificate) {
+	certs, err := chainBytesToCerts([]byte(chain))
+	if err != nil {
+		log.Fatalf("error parsing chain: %q", err)
+	}
+	return certs
+}
+
+func mustCertsToChain(certs []*x509.Certificate) (chain []byte) {
+	for _, cert := range certs {
+		chain = append(chain, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})...)
+	}
+	return chain
+}
+
+// mustParseUTC
+func mustParseUTC(s string) time.Time {
+	ts, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		log.Fatalf("error parsing time: %q", err)
+	}
+	return ts
+}
+
+type signOptions struct {
+	commonName                  string
+	extKeyUsages                []x509.ExtKeyUsage
+	keyUsage                    x509.KeyUsage
+	privateKey                  *ecdsa.PrivateKey
+	publicKey                   crypto.PublicKey
+	isCA                        bool
+	issuer                      *x509.Certificate
+	notBefore                   time.Time
+	notAfter                    time.Time
+	permittedDNSDomainsCritical bool
+	permittedDNSDomains         []string
+	DNSNames                    []string
+}
+
+func signTestCert(options signOptions) *x509.Certificate {
+	var (
+		issuer = options.issuer
+	)
+	certTpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject: pkix.Name{
+			Organization:       []string{"Mozilla"},
+			OrganizationalUnit: []string{"Cloud Services Autograph Unit Testing"},
+			Country:            []string{"US"},
+			Province:           []string{"CA"},
+			Locality:           []string{"Mountain View"},
+			CommonName:         options.commonName,
+		},
+		DNSNames:                    options.DNSNames,
+		NotBefore:                   options.notBefore,
+		NotAfter:                    options.notAfter,
+		SignatureAlgorithm:          x509.ECDSAWithSHA384,
+		IsCA:                        options.isCA,
+		BasicConstraintsValid:       true,
+		ExtKeyUsage:                 options.extKeyUsages,
+		KeyUsage:                    options.keyUsage,
+		PermittedDNSDomainsCritical: options.permittedDNSDomainsCritical,
+		PermittedDNSDomains:         options.permittedDNSDomains,
+	}
+	if options.issuer == nil {
+		issuer = certTpl
+	}
+	certBytes, err := x509.CreateCertificate(rand.Reader, certTpl, issuer, options.publicKey, options.privateKey)
+	if err != nil {
+		log.Fatalf("Could not self sign an X.509 root certificate: %v", err)
+	}
+	certX509, err := x509.ParseCertificate(certBytes)
+	if err != nil {
+		log.Fatalf("Could not parse X.509 certificate: %v", err)
+	}
+	return certX509
+}
+
+func sha2Fingerprint(cert *x509.Certificate) string {
+	return strings.ToUpper(fmt.Sprintf("%x", sha256.Sum256(cert.Raw)))
+}
+
+func generateTestKey() *ecdsa.PrivateKey {
+	priv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		log.Fatalf("Could not generate private key: %v", err)
+	}
+	return priv
+}
+
+func generateTestRSAKey() *rsa.PrivateKey {
+	priv, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		log.Fatalf("Could not generate private key: %v", err)
+	}
+	return priv
+}
+
+// fixtures -----------------------------------------------------------------
+
+const normandyDev2021Roothash = `4C:35:B1:C3:E3:12:D9:55:E7:78:ED:D0:A7:E7:8A:38:83:04:EF:01:BF:FA:03:29:B2:46:9F:3C:C5:EC:36:04`
+
+// autographDevRootHash is the SHA2 hash of the cacert in the
+// autograph dev config:
+// https://github.com/mozilla-services/autograph/blob/b3081068f4a9c0c1de02150432f2d02887dd6722/autograph.yaml#L113-L126
+// used on the normandy and remote settings development servers
+const autographDevRootHash = `5E:36:F2:14:DE:82:3F:8B:29:96:89:23:5F:03:41:AC:AF:A0:75:AF:82:CB:4C:D4:30:7C:3D:B3:43:39:2A:FE`
+
+// firefoxPkiStageRootHash is the SHA2 hash of the firefoxPkiStageRoot
+// cert raw bytes
+const firefoxPkiStageRootHash = `DB:74:CE:58:E4:F9:D0:9E:E0:42:36:BE:6C:C5:C4:F6:6A:E7:74:7D:C0:21:42:7A:03:BC:2F:57:0C:8B:9B:90`
+
+// firefoxPkiStageRoot is the CA root cert for the Addon stage code
+// signing PKI
+const firefoxPkiStageRoot = `-----BEGIN CERTIFICATE-----
+MIIHYzCCBUugAwIBAgIBATANBgkqhkiG9w0BAQwFADCBqDELMAkGA1UEBhMCVVMx
+CzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRwwGgYDVQQKExNB
+ZGRvbnMgVGVzdCBTaWduaW5nMSQwIgYDVQQDExt0ZXN0LmFkZG9ucy5zaWduaW5n
+LnJvb3QuY2ExMDAuBgkqhkiG9w0BCQEWIW9wc2VjK3N0YWdlcm9vdGFkZG9uc0Bt
+b3ppbGxhLmNvbTAeFw0xNTAyMTAxNTI4NTFaFw0yNTAyMDcxNTI4NTFaMIGoMQsw
+CQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExFjAUBgNVBAcTDU1vdW50YWluIFZpZXcx
+HDAaBgNVBAoTE0FkZG9ucyBUZXN0IFNpZ25pbmcxJDAiBgNVBAMTG3Rlc3QuYWRk
+b25zLnNpZ25pbmcucm9vdC5jYTEwMC4GCSqGSIb3DQEJARYhb3BzZWMrc3RhZ2Vy
+b290YWRkb25zQG1vemlsbGEuY29tMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIIC
+CgKCAgEAv/OSHh5uUMMKKuBh83kikuJ+BW4fQCHVZvADZh2qHNH8pSaME/YqMItP
+5XQ1N5oLq1tRQO77AKn+eYPDAQkg+9VV+ct4u76YctcU/gvjieGKQ0fvuDH18QLD
+hqa4DHgDmpCa/w+Eqzd54HaFj7ew9Bb7GZPHuZfk7Ct9fcN6kHneEj3KeuLiqzSV
+VCRFV9RTlrUdsc1/VwF4A97JTXc3HJeWJO3azOlFpaJ8QHhmgXLLmB59HPeZ10Sf
+9QwVGaKcn7yLuwtIA+wDhs8iwGZWcgmknW4DkkRDbQo7L+//4kVK+Yqq0HamZArm
+vE4xENvbwOze4XYkCO3PwgmCotU7K5D3sMUUxkOaodlemO9OqRW8vJOJH3b6mhST
+aunQR9/GOJ7sl4egrn2fOVZhBvM29lyBCKBffeQgtIMcKpeEKa4TNx4nTrWu1J9k
+jHlvNeVL3FzMzJXRPl0RV71cYak+G6GnQ4fg3+4ZSSPxTvbwRJAO2xajkURxFSZo
+sXcjYG8iPTSrDazj4LN2+882t4Q2/rMYpkowwLGbvJqHiw2tg9/hpLn1K4W18vcC
+vFgzNRrTdKaJ/KjD17eJl8s8oPA7TiophPeezy1WzAc4mdlXS6A85b0mKDDU2A/4
+3YmltjsSmizR2LnfeNs125EsCWxSUrAsnUYRO+lJOyNr7GGKGscCAwZVN6OCAZQw
+ggGQMAwGA1UdEwQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMBYGA1UdJQEB/wQMMAoG
+CCsGAQUFBwMDMCwGCWCGSAGG+EIBDQQfFh1PcGVuU1NMIEdlbmVyYXRlZCBDZXJ0
+aWZpY2F0ZTAzBglghkgBhvhCAQQEJhYkaHR0cDovL2FkZG9ucy5tb3ppbGxhLm9y
+Zy9jYS9jcmwucGVtMB0GA1UdDgQWBBSE6l/Nb0ySL+rR9PXIo7LCDLqm9jCB1QYD
+VR0jBIHNMIHKgBSE6l/Nb0ySL+rR9PXIo7LCDLqm9qGBrqSBqzCBqDELMAkGA1UE
+BhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRwwGgYD
+VQQKExNBZGRvbnMgVGVzdCBTaWduaW5nMSQwIgYDVQQDExt0ZXN0LmFkZG9ucy5z
+aWduaW5nLnJvb3QuY2ExMDAuBgkqhkiG9w0BCQEWIW9wc2VjK3N0YWdlcm9vdGFk
+ZG9uc0Btb3ppbGxhLmNvbYIBATANBgkqhkiG9w0BAQwFAAOCAgEAck21RaAcTzbT
+vmqqcCezBd5Gej6jV53HItXfF06tLLzAxKIU1loLH/330xDdOGyiJdvUATDVn8q6
+5v4Kae2awON6ytWZp9b0sRdtlLsRo8EWOoRszCqiMWdl1gnGMaV7e2ycz/tR+PoK
+GxHCh8rbOtG0eiVJIyRijLDjtExW8Eg+uz6Zkg1IWXqInj7Gqr23FOqD76uAfE82
+YTWW3lzxpP3gL7pmV5G7ob/tIyAfrPEB4w0Nt2HEl9h7NDtKPMprrOLPkrI9eAVU
+QeeI3RpAKnXOFQkqPYPXIlAaJ6qxtYa6tWHOqRyS1xKnvy/uWjEtU3tYJ5eUL1+2
+vzNTdakJgkZDRdDNg0V3NYwza6BwL80VPSfqc1H6R8CU1uj+kjTlCEsoTPLeW7k5
+t+lKHFMj0HZLNymgDD5f9UpI7yiOAIF0z4WKAMv/f12vnAPwmOPuOikRNOv0nNuL
+RIpKO53Cd7aV5PdB0pNSPNjc6V+5IPrepALNQhKIpzoHA4oG+LlVVy4R3csPcj4e
+zQQ9gt3NC2OXF4hveHfKZdCnb+BBl4S71QMYYCCTe+EDCsIGuyXWD/K2hfLD8TPW
+thPX5WNsS8bwno2ccqncVLQ4PZxOIB83DFBFmAvTuBiAYWq874rneTXqInHyeCq+
+819l9s72pDsFaGevmm0Us9bYuufTS5U=
+-----END CERTIFICATE-----`
+
+// firefoxPkiContentSignatureStageRootHash is the SHA2 hash of the
+// firefoxPkiContentSignatureStageRoot cert raw bytes
+const firefoxPkiContentSignatureStageRootHash = `3C:01:44:6A:BE:90:36:CE:A9:A0:9A:CA:A3:A5:20:AC:62:8F:20:A7:AE:32:CE:86:1C:B2:EF:B7:0F:A0:C7:45`
+
+// firefoxPkiContentSignatureStageRoot is the CA root cert for the
+// content signature stage code signing PKI
+const firefoxPkiContentSignatureStageRoot = `-----BEGIN CERTIFICATE-----
+MIIHbDCCBVSgAwIBAgIEYCWYOzANBgkqhkiG9w0BAQwFADCBqTELMAkGA1UEBhMC
+VVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRwwGgYDVQQK
+ExNBZGRvbnMgVGVzdCBTaWduaW5nMSQwIgYDVQQDExt0ZXN0LmFkZG9ucy5zaWdu
+aW5nLnJvb3QuY2ExMTAvBgkqhkiG9w0BCQEWInNlY29wcytzdGFnZXJvb3RhZGRv
+bnNAbW96aWxsYS5jb20wHhcNMjEwMjExMjA0ODU5WhcNMjQxMTE0MjA0ODU5WjCB
+qTELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBW
+aWV3MRwwGgYDVQQKExNBZGRvbnMgVGVzdCBTaWduaW5nMSQwIgYDVQQDExt0ZXN0
+LmFkZG9ucy5zaWduaW5nLnJvb3QuY2ExMTAvBgkqhkiG9w0BCQEWInNlY29wcytz
+dGFnZXJvb3RhZGRvbnNAbW96aWxsYS5jb20wggIiMA0GCSqGSIb3DQEBAQUAA4IC
+DwAwggIKAoICAQDKRVty/FRsO4Ech6EYleyaKgAueaLYfMSsAIyPC/N8n/P8QcH8
+rjoiMJrKHRlqiJmMBSmjUZVzZAP0XJku0orLKWPKq7cATt+xhGY/RJtOzenMMsr5
+eN02V3GzUd1jOShUpERjzXdaO3pnfZqhdqNYqP9ocqQpyno7bZ3FZQ2vei+bF52k
+51uPioTZo+1zduoR/rT01twGtZm3QpcwU4mO74ysyxxgqEy3kpojq8Nt6haDwzrj
+khV9M6DGPLHZD71QaUiz5lOhD9CS8x0uqXhBhwMUBBkHsUDSxbN4ZhjDDWpCmwaD
+OtbJMUJxDGPCr9qj49QESccb367OeXLrfZ2Ntu/US2Bw9EDfhyNsXr9dg9NHj5yf
+4sDUqBHG0W8zaUvJx5T2Ivwtno1YZLyJwQW5pWeWn8bEmpQKD2KS/3y2UjlDg+YM
+NdNASjFe0fh6I5NCFYmFWA73DpDGlUx0BtQQU/eZQJ+oLOTLzp8d3dvenTBVnKF+
+uwEmoNfZwc4TTWJOhLgwxA4uK+Paaqo4Ap2RGS2ZmVkPxmroB3gL5n3k3QEXvULh
+7v8Psk4+MuNWnxudrPkN38MGJo7ju7gDOO8h1jLD4tdfuAqbtQLduLXzT4DJPA4y
+JBTFIRMIpMqP9CovaS8VPtMFLTrYlFh9UnEGpCeLPanJr+VEj7ae5sc8YwIDAQAB
+o4IBmDCCAZQwDAYDVR0TBAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwFgYDVR0lAQH/
+BAwwCgYIKwYBBQUHAwMwLAYJYIZIAYb4QgENBB8WHU9wZW5TU0wgR2VuZXJhdGVk
+IENlcnRpZmljYXRlMDMGCWCGSAGG+EIBBAQmFiRodHRwOi8vYWRkb25zLm1vemls
+bGEub3JnL2NhL2NybC5wZW0wHQYDVR0OBBYEFIbYNBxOWNETXJlf2EKY7RQPGfJd
+MIHZBgNVHSMEgdEwgc6AFIbYNBxOWNETXJlf2EKY7RQPGfJdoYGvpIGsMIGpMQsw
+CQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExFjAUBgNVBAcTDU1vdW50YWluIFZpZXcx
+HDAaBgNVBAoTE0FkZG9ucyBUZXN0IFNpZ25pbmcxJDAiBgNVBAMTG3Rlc3QuYWRk
+b25zLnNpZ25pbmcucm9vdC5jYTExMC8GCSqGSIb3DQEJARYic2Vjb3BzK3N0YWdl
+cm9vdGFkZG9uc0Btb3ppbGxhLmNvbYIEYCWYOzANBgkqhkiG9w0BAQwFAAOCAgEA
+nowyJv8UaIV7NA0B3wkWratq6FgA1s/PzetG/ZKZDIW5YtfUvvyy72HDAwgKbtap
+Eog6zGI4L86K0UGUAC32fBjE5lWYEgsxNM5VWlQjbgTG0dc3dYiufxfDFeMbAPmD
+DzpIgN3jHW2uRqa/MJ+egHhv7kGFL68uVLboqk/qHr+SOCc1LNeSMCuQqvHwwM0+
+AU1GxhzBWDkealTS34FpVxF4sT5sKLODdIS5HXJr2COHHfYkw2SW/Sfpt6fsOwaF
+2iiDaK4LPWHWhhIYa6yaynJ+6O6KPlpvKYCChaTOVdc+ikyeiSO6AakJykr5Gy7d
+PkkK7MDCxuY6psHj7iJQ59YK7ujQB8QYdzuXBuLLo5hc5gBcq3PJs0fLT2YFcQHA
+dj+olGaDn38T0WI8ycWaFhQfKwATeLWfiQepr8JfoNlC2vvSDzGUGfdAfZfsJJZ8
+5xZxahHoTFGS0mDRfXqzKH5uD578GgjOZp0fULmzkcjWsgzdpDhadGjExRZFKlAy
+iKv8cXTONrGY0fyBDKennuX0uAca3V0Qm6v2VRp+7wG/pywWwc5n+04qgxTQPxgO
+6pPB9UUsNbaLMDR5QPYAWrNhqJ7B07XqIYJZSwGP5xB9NqUZLF4z+AOMYgWtDpmg
+IKdcFKAt3fFrpyMhlfIKkLfmm0iDjmfmIXbDGBJw9SE=
+-----END CERTIFICATE-----`
+
+// firefoxPkiProdRootHash is the SHA2 hash of the firefoxPkiProdRoot
+// cert raw bytes
+const firefoxPkiProdRootHash = `97:E8:BA:9C:F1:2F:B3:DE:53:CC:42:A4:E6:57:7E:D6:4D:F4:93:C2:47:B4:14:FE:A0:36:81:8D:38:23:56:0E`
+
+// firefoxPkiProdRoot is the CA root cert for the Content Signature
+// and Addon prod code signing PKI
+const firefoxPkiProdRoot = `-----BEGIN CERTIFICATE-----
+MIIGYTCCBEmgAwIBAgIBATANBgkqhkiG9w0BAQwFADB9MQswCQYDVQQGEwJVUzEc
+MBoGA1UEChMTTW96aWxsYSBDb3Jwb3JhdGlvbjEvMC0GA1UECxMmTW96aWxsYSBB
+TU8gUHJvZHVjdGlvbiBTaWduaW5nIFNlcnZpY2UxHzAdBgNVBAMTFnJvb3QtY2Et
+cHJvZHVjdGlvbi1hbW8wHhcNMTUwMzE3MjI1MzU3WhcNMjUwMzE0MjI1MzU3WjB9
+MQswCQYDVQQGEwJVUzEcMBoGA1UEChMTTW96aWxsYSBDb3Jwb3JhdGlvbjEvMC0G
+A1UECxMmTW96aWxsYSBBTU8gUHJvZHVjdGlvbiBTaWduaW5nIFNlcnZpY2UxHzAd
+BgNVBAMTFnJvb3QtY2EtcHJvZHVjdGlvbi1hbW8wggIgMA0GCSqGSIb3DQEBAQUA
+A4ICDQAwggIIAoICAQC0u2HXXbrwy36+MPeKf5jgoASMfMNz7mJWBecJgvlTf4hH
+JbLzMPsIUauzI9GEpLfHdZ6wzSyFOb4AM+D1mxAWhuZJ3MDAJOf3B1Rs6QorHrl8
+qqlNtPGqepnpNJcLo7JsSqqE3NUm72MgqIHRgTRsqUs+7LIPGe7262U+N/T0LPYV
+Le4rZ2RDHoaZhYY7a9+49mHOI/g2YFB+9yZjE+XdplT2kBgA4P8db7i7I0tIi4b0
+B0N6y9MhL+CRZJyxdFe2wBykJX14LsheKsM1azHjZO56SKNrW8VAJTLkpRxCmsiT
+r08fnPyDKmaeZ0BtsugicdipcZpXriIGmsZbI12q5yuwjSELdkDV6Uajo2n+2ws5
+uXrP342X71WiWhC/dF5dz1LKtjBdmUkxaQMOP/uhtXEKBrZo1ounDRQx1j7+SkQ4
+BEwjB3SEtr7XDWGOcOIkoJZWPACfBLC3PJCBWjTAyBlud0C5n3Cy9regAAnOIqI1
+t16GU2laRh7elJ7gPRNgQgwLXeZcFxw6wvyiEcmCjOEQ6PM8UQjthOsKlszMhlKw
+vjyOGDoztkqSBy/v+Asx7OW2Q7rlVfKarL0mREZdSMfoy3zTgtMVCM0vhNl6zcvf
+5HNNopoEdg5yuXo2chZ1p1J+q86b0G5yJRMeT2+iOVY2EQ37tHrqUURncCy4uwIB
+A6OB7TCB6jAMBgNVHRMEBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAWBgNVHSUBAf8E
+DDAKBggrBgEFBQcDAzCBkgYDVR0jBIGKMIGHoYGBpH8wfTELMAkGA1UEBhMCVVMx
+HDAaBgNVBAoTE01vemlsbGEgQ29ycG9yYXRpb24xLzAtBgNVBAsTJk1vemlsbGEg
+QU1PIFByb2R1Y3Rpb24gU2lnbmluZyBTZXJ2aWNlMR8wHQYDVQQDExZyb290LWNh
+LXByb2R1Y3Rpb24tYW1vggEBMB0GA1UdDgQWBBSzvOpYdKvhbngqsqucIx6oYyyX
+tzANBgkqhkiG9w0BAQwFAAOCAgEAaNSRYAaECAePQFyfk12kl8UPLh8hBNidP2H6
+KT6O0vCVBjxmMrwr8Aqz6NL+TgdPmGRPDDLPDpDJTdWzdj7khAjxqWYhutACTew5
+eWEaAzyErbKQl+duKvtThhV2p6F6YHJ2vutu4KIciOMKB8dslIqIQr90IX2Usljq
+8Ttdyf+GhUmazqLtoB0GOuESEqT4unX6X7vSGu1oLV20t7t5eCnMMYD67ZBn0YIU
+/cm/+pan66hHrja+NeDGF8wabJxdqKItCS3p3GN1zUGuJKrLykxqbOp/21byAGog
+Z1amhz6NHUcfE6jki7sM7LHjPostU5ZWs3PEfVVgha9fZUhOrIDsyXEpCWVa3481
+LlAq3GiUMKZ5DVRh9/Nvm4NwrTfB3QkQQJCwfXvO9pwnPKtISYkZUqhEqvXk5nBg
+QCkDSLDjXTx39naBBGIVIqBtKKuVTla9enngdq692xX/CgO6QJVrwpqdGjebj5P8
+5fNZPABzTezG3Uls5Vp+4iIWVAEDkK23cUj3c/HhE+Oo7kxfUeu5Y1ZV3qr61+6t
+ZARKjbu1TuYQHf0fs+GwID8zeLc2zJL7UzcHFwwQ6Nda9OJN4uPAuC/BKaIpxCLL
+26b24/tRam4SJjqpiq20lynhUrmTtt6hbG3E1Hpy3bmkt2DYnuMFwEx2gfXNcnbT
+wNuvFqc=
+-----END CERTIFICATE-----`
+
+// P384ECDSA test signer from signer/contentsignature/contentsignature_test.go TestSign
+const testSignerP384PEM = `-----BEGIN EC PRIVATE KEY-----
+MIGkAgEBBDART/nn3fKlhyENdc2u3klbvRJ5+odP0kWzt9p+v5hDyggbtVA4M1Mb
+fL9KoaiAAv2gBwYFK4EEACKhZANiAATugz97A6HPqq0fJCGom9PdKJ58Y9aobARQ
+BkZWS5IjC+15Uqt3yOcCMdjIJpikiD1WjXRaeFe+b3ovcoBs4ToLK7d8y0qFlkgx
+/5Cp6z37rpp781N4haUOIauM14P4KUw=
+-----END EC PRIVATE KEY-----`
+
+var (
+	badPEMContent = strings.Replace(testSignerP384PEM, "EC PRIVATE KEY", "CERTIFICATE", -1)
+
+	testRootKey    = generateTestKey()
+	testInterKey   = generateTestKey()
+	testLeafKey    = mustPEMToECKey(testSignerP384PEM)
+	testLeafRSAKey = generateTestRSAKey()
+	testRoot       = signTestCert(signOptions{
+		commonName:   "autograph unit test self-signed root",
+		keyUsage:     x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		extKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		privateKey:   testRootKey,
+		publicKey:    &testRootKey.PublicKey,
+		isCA:         true,
+		issuer:       nil, // self-sign
+		notBefore:    time.Now().Add(-3 * 24 * time.Hour),
+		notAfter:     time.Now().Add(time.Hour),
+	})
+	testRootExpired = signTestCert(signOptions{
+		commonName:   "autograph unit test self-signed root",
+		keyUsage:     x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		extKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		privateKey:   testRootKey,
+		publicKey:    &testRootKey.PublicKey,
+		isCA:         true,
+		issuer:       nil, // self-sign
+		notBefore:    time.Now().Add(-2 * time.Hour),
+		notAfter:     time.Now().Add(-time.Hour),
+	})
+	testRootNotYetValid = signTestCert(signOptions{
+		commonName:   "autograph unit test self-signed root",
+		keyUsage:     x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		extKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		privateKey:   testRootKey,
+		publicKey:    &testRootKey.PublicKey,
+		isCA:         true,
+		issuer:       nil, // self-sign
+		notBefore:    time.Now().Add(2 * time.Hour),
+		notAfter:     time.Now().Add(4 * time.Hour),
+	})
+	testInter = signTestCert(signOptions{
+		commonName:                  "autograph unit test content signing intermediate",
+		extKeyUsages:                []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		keyUsage:                    x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		privateKey:                  testRootKey,
+		publicKey:                   &testInterKey.PublicKey,
+		isCA:                        true,
+		issuer:                      testRoot,
+		notBefore:                   time.Now().Add(-2 * 24 * time.Hour),
+		notAfter:                    time.Now().Add(time.Hour),
+		permittedDNSDomainsCritical: true,
+		permittedDNSDomains:         []string{".content-signature.mozilla.org", "content-signature.mozilla.org"},
+	})
+	testInterExpired = signTestCert(signOptions{
+		commonName:                  "autograph unit test content signing intermediate",
+		extKeyUsages:                []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		keyUsage:                    x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		privateKey:                  testRootKey,
+		publicKey:                   &testInterKey.PublicKey,
+		isCA:                        true,
+		issuer:                      testRoot,
+		notBefore:                   time.Now().Add(-2 * time.Hour),
+		notAfter:                    time.Now().Add(-time.Hour),
+		permittedDNSDomainsCritical: true,
+		permittedDNSDomains:         []string{".content-signature.mozilla.org", "content-signature.mozilla.org"},
+	})
+	testInterNotYetValid = signTestCert(signOptions{
+		commonName:                  "autograph unit test content signing intermediate",
+		extKeyUsages:                []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		keyUsage:                    x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		privateKey:                  testRootKey,
+		publicKey:                   &testInterKey.PublicKey,
+		isCA:                        true,
+		issuer:                      testRoot,
+		notBefore:                   time.Now().Add(2 * time.Hour),
+		notAfter:                    time.Now().Add(4 * time.Hour),
+		permittedDNSDomainsCritical: true,
+		permittedDNSDomains:         []string{".content-signature.mozilla.org", "content-signature.mozilla.org"},
+	})
+	testLeaf = signTestCert(signOptions{
+		commonName:   "example.content-signature.mozilla.org",
+		DNSNames:     []string{"example.content-signature.mozilla.org"},
+		extKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		keyUsage:     x509.KeyUsageDigitalSignature,
+		privateKey:   testInterKey,
+		publicKey:    &testLeafKey.PublicKey,
+		isCA:         false,
+		issuer:       testInter,
+		notBefore:    time.Now().Add(-2 * time.Hour),
+		notAfter:     time.Now().Add(time.Hour),
+	})
+	testLeafExpired = signTestCert(signOptions{
+		commonName:   "example.content-signature.mozilla.org",
+		DNSNames:     []string{"example.content-signature.mozilla.org"},
+		extKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		keyUsage:     x509.KeyUsageDigitalSignature,
+		privateKey:   testInterKey,
+		publicKey:    &testLeafKey.PublicKey,
+		isCA:         false,
+		issuer:       testInter,
+		notBefore:    time.Now().Add(-2 * time.Hour),
+		notAfter:     time.Now().Add(-time.Hour),
+	})
+	testLeafNotYetValid = signTestCert(signOptions{
+		commonName:   "example.content-signature.mozilla.org",
+		DNSNames:     []string{"example.content-signature.mozilla.org"},
+		extKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		keyUsage:     x509.KeyUsageDigitalSignature,
+		privateKey:   testInterKey,
+		publicKey:    &testLeafKey.PublicKey,
+		isCA:         false,
+		issuer:       testInter,
+		notBefore:    time.Now().Add(2 * time.Hour),
+		notAfter:     time.Now().Add(4 * time.Hour),
+	})
+	testLeafInvalidDNSName = signTestCert(signOptions{
+		commonName:   "example.content-signature.mozilla.org",
+		DNSNames:     []string{"example.org"},
+		extKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		keyUsage:     x509.KeyUsageDigitalSignature,
+		privateKey:   testInterKey,
+		publicKey:    &testLeafKey.PublicKey,
+		isCA:         false,
+		issuer:       testInter,
+		notBefore:    time.Now().Add(-2 * time.Hour),
+		notAfter:     time.Now().Add(time.Hour),
+	})
+	testLeafRSAPub = signTestCert(signOptions{
+		commonName:   "example.content-signature.mozilla.org",
+		DNSNames:     []string{"example.content-signature.mozilla.org"},
+		extKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		keyUsage:     x509.KeyUsageDigitalSignature,
+		privateKey:   testInterKey,
+		publicKey:    &testLeafRSAKey.PublicKey,
+		isCA:         false,
+		issuer:       testInter,
+		notBefore:    time.Now().Add(-2 * time.Hour),
+		notAfter:     time.Now().Add(time.Hour),
+	})
+
+	testRootNonCA = signTestCert(signOptions{
+		commonName:   "autograph unit test self-signed root",
+		extKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		privateKey:   testRootKey,
+		publicKey:    &testRootKey.PublicKey,
+		isCA:         false,
+		issuer:       nil, // self-sign
+		notBefore:    time.Now(),
+		notAfter:     time.Now().Add(time.Hour),
+	})
+	testInterNonCA = signTestCert(signOptions{
+		commonName:                  "autograph unit test content signing intermediate",
+		extKeyUsages:                []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		keyUsage:                    x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		privateKey:                  testRootKey,
+		publicKey:                   &testInterKey.PublicKey,
+		isCA:                        true,
+		issuer:                      testRootNonCA,
+		notBefore:                   time.Now().Add(-2 * 24 * time.Hour),
+		notAfter:                    time.Now().Add(time.Hour),
+		permittedDNSDomainsCritical: true,
+		permittedDNSDomains:         []string{".content-signature.mozilla.org", "content-signature.mozilla.org"},
+	})
+	testLeafNonCA = signTestCert(signOptions{
+		commonName:   "example.content-signature.mozilla.org",
+		DNSNames:     []string{"example.content-signature.mozilla.org"},
+		extKeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		keyUsage:     x509.KeyUsageDigitalSignature,
+		privateKey:   testInterKey,
+		publicKey:    &testLeafKey.PublicKey,
+		isCA:         false,
+		issuer:       testInterNonCA,
+		notBefore:    time.Now().Add(-2 * time.Hour),
+		notAfter:     time.Now().Add(time.Hour),
+	})
+
+	testRootNoExt = signTestCert(signOptions{
+		commonName:   "autograph unit test self-signed root",
+		extKeyUsages: []x509.ExtKeyUsage{},
+		privateKey:   testRootKey,
+		publicKey:    &testRootKey.PublicKey,
+		isCA:         true,
+		issuer:       nil, // self-sign
+		notBefore:    time.Now(),
+		notAfter:     time.Now().Add(time.Hour),
+	})
+)
+
+// This chain has an expired end-entity certificate
+var ExpiredEndEntityChain = `-----BEGIN CERTIFICATE-----
+MIIEnTCCBCSgAwIBAgIEAQAAFzAKBggqhkjOPQQDAzCBpjELMAkGA1UEBhMCVVMx
+HDAaBgNVBAoTE01vemlsbGEgQ29ycG9yYXRpb24xLzAtBgNVBAsTJk1vemlsbGEg
+QU1PIFByb2R1Y3Rpb24gU2lnbmluZyBTZXJ2aWNlMSUwIwYDVQQDExxDb250ZW50
+IFNpZ25pbmcgSW50ZXJtZWRpYXRlMSEwHwYJKoZIhvcNAQkBFhJmb3hzZWNAbW96
+aWxsYS5jb20wHhcNMTcwNTA5MTQwMjM3WhcNMTcxMTA3MTQwMjM3WjCBrzELMAkG
+A1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWExHDAaBgNVBAoTE01vemlsbGEg
+Q29ycG9yYXRpb24xFzAVBgNVBAsTDkNsb3VkIFNlcnZpY2VzMS8wLQYDVQQDEyZu
+b3JtYW5keS5jb250ZW50LXNpZ25hdHVyZS5tb3ppbGxhLm9yZzEjMCEGCSqGSIb3
+DQEJARYUc2VjdXJpdHlAbW96aWxsYS5vcmcwdjAQBgcqhkjOPQIBBgUrgQQAIgNi
+AAShRFsGyg6DkUX+J2mMDM6cLK8V6HawjGVlQ/w5H5fHiGJDMrkl4ktnN+O37mSs
+dReHcVxxpPNEpIfkWQ2TFmJgOUzqi/CzO06APlAJ9mnIcaobgdqRQxoTchFEyzUx
+nTijggIWMIICEjAdBgNVHQ4EFgQUKnGLJ9po8ea5qUNjJyV/c26VZfswgaoGA1Ud
+IwSBojCBn4AUiHVymVvwUPJguD2xCZYej3l5nu6hgYGkfzB9MQswCQYDVQQGEwJV
+UzEcMBoGA1UEChMTTW96aWxsYSBDb3Jwb3JhdGlvbjEvMC0GA1UECxMmTW96aWxs
+YSBBTU8gUHJvZHVjdGlvbiBTaWduaW5nIFNlcnZpY2UxHzAdBgNVBAMTFnJvb3Qt
+Y2EtcHJvZHVjdGlvbi1hbW+CAxAABjAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQE
+AwIHgDAWBgNVHSUBAf8EDDAKBggrBgEFBQcDAzBFBgNVHR8EPjA8MDqgOKA2hjRo
+dHRwczovL2NvbnRlbnQtc2lnbmF0dXJlLmNkbi5tb3ppbGxhLm5ldC9jYS9jcmwu
+cGVtMEMGCWCGSAGG+EIBBAQ2FjRodHRwczovL2NvbnRlbnQtc2lnbmF0dXJlLmNk
+bi5tb3ppbGxhLm5ldC9jYS9jcmwucGVtME8GCCsGAQUFBwEBBEMwQTA/BggrBgEF
+BQcwAoYzaHR0cHM6Ly9jb250ZW50LXNpZ25hdHVyZS5jZG4ubW96aWxsYS5uZXQv
+Y2EvY2EucGVtMDEGA1UdEQQqMCiCJm5vcm1hbmR5LmNvbnRlbnQtc2lnbmF0dXJl
+Lm1vemlsbGEub3JnMAoGCCqGSM49BAMDA2cAMGQCMGeeyXYM3+r1fcaXzd90PwGb
+h9nrl1fZNXrCu17lCPn2JntBVh7byT3twEbr+Hmv8gIwU9klAW6yHLG/ZpAZ0jdf
+38Rciz/FDEAdrzH2QlYAOw+uDdpcmon9oiRgIxzwNlUe
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIFfjCCA2agAwIBAgIDEAAGMA0GCSqGSIb3DQEBDAUAMH0xCzAJBgNVBAYTAlVT
+MRwwGgYDVQQKExNNb3ppbGxhIENvcnBvcmF0aW9uMS8wLQYDVQQLEyZNb3ppbGxh
+IEFNTyBQcm9kdWN0aW9uIFNpZ25pbmcgU2VydmljZTEfMB0GA1UEAxMWcm9vdC1j
+YS1wcm9kdWN0aW9uLWFtbzAeFw0xNzA1MDQwMDEyMzlaFw0xOTA1MDQwMDEyMzla
+MIGmMQswCQYDVQQGEwJVUzEcMBoGA1UEChMTTW96aWxsYSBDb3Jwb3JhdGlvbjEv
+MC0GA1UECxMmTW96aWxsYSBBTU8gUHJvZHVjdGlvbiBTaWduaW5nIFNlcnZpY2Ux
+JTAjBgNVBAMTHENvbnRlbnQgU2lnbmluZyBJbnRlcm1lZGlhdGUxITAfBgkqhkiG
+9w0BCQEWEmZveHNlY0Btb3ppbGxhLmNvbTB2MBAGByqGSM49AgEGBSuBBAAiA2IA
+BMCmt4C33KfMzsyKokc9SXmMSxozksQglhoGAA1KjlgqEOzcmKEkxtvnGWOA9FLo
+A6U7Wmy+7sqmvmjLboAPQc4G0CEudn5Nfk36uEqeyiyKwKSAT+pZsqS4/maXIC7s
+DqOCAYkwggGFMAwGA1UdEwQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMBYGA1UdJQEB
+/wQMMAoGCCsGAQUFBwMDMB0GA1UdDgQWBBSIdXKZW/BQ8mC4PbEJlh6PeXme7jCB
+qAYDVR0jBIGgMIGdgBSzvOpYdKvhbngqsqucIx6oYyyXt6GBgaR/MH0xCzAJBgNV
+BAYTAlVTMRwwGgYDVQQKExNNb3ppbGxhIENvcnBvcmF0aW9uMS8wLQYDVQQLEyZN
+b3ppbGxhIEFNTyBQcm9kdWN0aW9uIFNpZ25pbmcgU2VydmljZTEfMB0GA1UEAxMW
+cm9vdC1jYS1wcm9kdWN0aW9uLWFtb4IBATAzBglghkgBhvhCAQQEJhYkaHR0cDov
+L2FkZG9ucy5hbGxpem9tLm9yZy9jYS9jcmwucGVtME4GA1UdHgRHMEWgQzAggh4u
+Y29udGVudC1zaWduYXR1cmUubW96aWxsYS5vcmcwH4IdY29udGVudC1zaWduYXR1
+cmUubW96aWxsYS5vcmcwDQYJKoZIhvcNAQEMBQADggIBAKWhLjJB8XmW3VfLvyLF
+OOUNeNs7Aju+EZl1PMVXf+917LB//FcJKUQLcEo86I6nC3umUNl+kaq4d3yPDpMV
+4DKLHgGmegRsvAyNFQfd64TTxzyfoyfNWH8uy5vvxPmLvWb+jXCoMNF5FgFWEVon
+5GDEK8hoHN/DMVe0jveeJhUSuiUpJhMzEf6Vbo0oNgfaRAZKO+VOY617nkTOPnVF
+LSEcUPIdE8pcd+QP1t/Ysx+mAfkxAbt+5K298s2bIRLTyNUj1eBtTcCbBbFyWsly
+rSMkJihFAWU2MVKqvJ74YI3uNhFzqJ/AAUAPoet14q+ViYU+8a1lqEWj7y8foF3r
+m0ZiQpuHULiYCO4y4NR7g5ijj6KsbruLv3e9NyUAIRBHOZEKOA7EiFmWJgqH1aZv
+/eS7aQ9HMtPKrlbEwUjV0P3K2U2ljs0rNvO8KO9NKQmocXaRpLm+s8PYBGxby92j
+5eelLq55028BSzhJJc6G+cRT9Hlxf1cg2qtqcVJa8i8wc2upCaGycZIlBSX4gj/4
+k9faY4qGuGnuEdzAyvIXWMSkb8jiNHQfZrebSr00vShkUEKOLmfFHbkwIaWNK0+2
+2c3RL4tDnM5u0kvdgWf0B742JskkxqqmEeZVofsOZJLOhXxO9NO/S0hM16/vf/tl
+Tnsnhv0nxUR0B9wxN7XmWmq4
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIGYTCCBEmgAwIBAgIBATANBgkqhkiG9w0BAQwFADB9MQswCQYDVQQGEwJVUzEc
+MBoGA1UEChMTTW96aWxsYSBDb3Jwb3JhdGlvbjEvMC0GA1UECxMmTW96aWxsYSBB
+TU8gUHJvZHVjdGlvbiBTaWduaW5nIFNlcnZpY2UxHzAdBgNVBAMTFnJvb3QtY2Et
+cHJvZHVjdGlvbi1hbW8wHhcNMTUwMzE3MjI1MzU3WhcNMjUwMzE0MjI1MzU3WjB9
+MQswCQYDVQQGEwJVUzEcMBoGA1UEChMTTW96aWxsYSBDb3Jwb3JhdGlvbjEvMC0G
+A1UECxMmTW96aWxsYSBBTU8gUHJvZHVjdGlvbiBTaWduaW5nIFNlcnZpY2UxHzAd
+BgNVBAMTFnJvb3QtY2EtcHJvZHVjdGlvbi1hbW8wggIgMA0GCSqGSIb3DQEBAQUA
+A4ICDQAwggIIAoICAQC0u2HXXbrwy36+MPeKf5jgoASMfMNz7mJWBecJgvlTf4hH
+JbLzMPsIUauzI9GEpLfHdZ6wzSyFOb4AM+D1mxAWhuZJ3MDAJOf3B1Rs6QorHrl8
+qqlNtPGqepnpNJcLo7JsSqqE3NUm72MgqIHRgTRsqUs+7LIPGe7262U+N/T0LPYV
+Le4rZ2RDHoaZhYY7a9+49mHOI/g2YFB+9yZjE+XdplT2kBgA4P8db7i7I0tIi4b0
+B0N6y9MhL+CRZJyxdFe2wBykJX14LsheKsM1azHjZO56SKNrW8VAJTLkpRxCmsiT
+r08fnPyDKmaeZ0BtsugicdipcZpXriIGmsZbI12q5yuwjSELdkDV6Uajo2n+2ws5
+uXrP342X71WiWhC/dF5dz1LKtjBdmUkxaQMOP/uhtXEKBrZo1ounDRQx1j7+SkQ4
+BEwjB3SEtr7XDWGOcOIkoJZWPACfBLC3PJCBWjTAyBlud0C5n3Cy9regAAnOIqI1
+t16GU2laRh7elJ7gPRNgQgwLXeZcFxw6wvyiEcmCjOEQ6PM8UQjthOsKlszMhlKw
+vjyOGDoztkqSBy/v+Asx7OW2Q7rlVfKarL0mREZdSMfoy3zTgtMVCM0vhNl6zcvf
+5HNNopoEdg5yuXo2chZ1p1J+q86b0G5yJRMeT2+iOVY2EQ37tHrqUURncCy4uwIB
+A6OB7TCB6jAMBgNVHRMEBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAWBgNVHSUBAf8E
+DDAKBggrBgEFBQcDAzCBkgYDVR0jBIGKMIGHoYGBpH8wfTELMAkGA1UEBhMCVVMx
+HDAaBgNVBAoTE01vemlsbGEgQ29ycG9yYXRpb24xLzAtBgNVBAsTJk1vemlsbGEg
+QU1PIFByb2R1Y3Rpb24gU2lnbmluZyBTZXJ2aWNlMR8wHQYDVQQDExZyb290LWNh
+LXByb2R1Y3Rpb24tYW1vggEBMB0GA1UdDgQWBBSzvOpYdKvhbngqsqucIx6oYyyX
+tzANBgkqhkiG9w0BAQwFAAOCAgEAaNSRYAaECAePQFyfk12kl8UPLh8hBNidP2H6
+KT6O0vCVBjxmMrwr8Aqz6NL+TgdPmGRPDDLPDpDJTdWzdj7khAjxqWYhutACTew5
+eWEaAzyErbKQl+duKvtThhV2p6F6YHJ2vutu4KIciOMKB8dslIqIQr90IX2Usljq
+8Ttdyf+GhUmazqLtoB0GOuESEqT4unX6X7vSGu1oLV20t7t5eCnMMYD67ZBn0YIU
+/cm/+pan66hHrja+NeDGF8wabJxdqKItCS3p3GN1zUGuJKrLykxqbOp/21byAGog
+Z1amhz6NHUcfE6jki7sM7LHjPostU5ZWs3PEfVVgha9fZUhOrIDsyXEpCWVa3481
+LlAq3GiUMKZ5DVRh9/Nvm4NwrTfB3QkQQJCwfXvO9pwnPKtISYkZUqhEqvXk5nBg
+QCkDSLDjXTx39naBBGIVIqBtKKuVTla9enngdq692xX/CgO6QJVrwpqdGjebj5P8
+5fNZPABzTezG3Uls5Vp+4iIWVAEDkK23cUj3c/HhE+Oo7kxfUeu5Y1ZV3qr61+6t
+ZARKjbu1TuYQHf0fs+GwID8zeLc2zJL7UzcHFwwQ6Nda9OJN4uPAuC/BKaIpxCLL
+26b24/tRam4SJjqpiq20lynhUrmTtt6hbG3E1Hpy3bmkt2DYnuMFwEx2gfXNcnbT
+wNuvFqc=
+-----END CERTIFICATE-----`
+
+// NB: these certs do no exactly match the result of parsing
+// ExpiredEndEntityChain
+var ExpiredEndEntityChainCerts = []*x509.Certificate{
+	&x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:         "normandy.content-signature.mozilla.org",
+			Organization:       []string{"Mozilla Corporation"},
+			OrganizationalUnit: []string{"Cloud Services"},
+			Country:            []string{"US"},
+			Province:           []string{"California"},
+			Locality:           nil,
+		},
+		NotBefore: mustParseUTC("2017-05-09T14:02:37Z"),
+		NotAfter:  mustParseUTC("2017-11-07T14:02:37Z"),
+		IsCA:      false,
+		DNSNames:  []string{"normandy.content-signature.mozilla.org"},
+		KeyUsage:  x509.KeyUsageDigitalSignature,
+	},
+	&x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:         "Content Signing Intermediate",
+			Organization:       []string{"Mozilla Corporation"},
+			OrganizationalUnit: []string{"Mozilla AMO Production Signing Service"},
+			Country:            []string{"US"},
+			Province:           nil,
+			Locality:           nil,
+		},
+		NotBefore:           mustParseUTC("2017-05-04T00:12:39Z"),
+		NotAfter:            mustParseUTC("2019-05-04T00:12:39Z"),
+		IsCA:                true,
+		DNSNames:            nil,
+		KeyUsage:            x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		PermittedDNSDomains: []string{".content-signature.mozilla.org", "content-signature.mozilla.org"},
+	},
+	&x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:         "root-ca-production-amo",
+			Organization:       []string{"Mozilla Corporation"},
+			OrganizationalUnit: []string{"Mozilla AMO Production Signing Service"},
+			Country:            []string{"US"},
+			Province:           nil,
+			Locality:           nil,
+		},
+		NotBefore: mustParseUTC("2015-03-17T22:53:57Z"),
+		NotAfter:  mustParseUTC("2025-03-14T22:53:57Z"),
+		IsCA:      true,
+		DNSNames:  nil,
+		KeyUsage:  x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	},
+}
+
+// This chain is in the wrong order: the intermediate cert is
+// placed first, followed by the EE then the root
+var WronglyOrderedChain = `
+-----BEGIN CERTIFICATE-----
+MIIFfzCCA2egAwIBAgIDEAAJMA0GCSqGSIb3DQEBDAUAMH0xCzAJBgNVBAYTAlVT
+MRwwGgYDVQQKExNNb3ppbGxhIENvcnBvcmF0aW9uMS8wLQYDVQQLEyZNb3ppbGxh
+IEFNTyBQcm9kdWN0aW9uIFNpZ25pbmcgU2VydmljZTEfMB0GA1UEAxMWcm9vdC1j
+YS1wcm9kdWN0aW9uLWFtbzAiGA8yMDIwMTIzMTAwMDAwMFoYDzIwMjUwMzE0MjI1
+MzU3WjCBozELMAkGA1UEBhMCVVMxHDAaBgNVBAoTE01vemlsbGEgQ29ycG9yYXRp
+b24xLzAtBgNVBAsTJk1vemlsbGEgQU1PIFByb2R1Y3Rpb24gU2lnbmluZyBTZXJ2
+aWNlMUUwQwYDVQQDDDxDb250ZW50IFNpZ25pbmcgSW50ZXJtZWRpYXRlL2VtYWls
+QWRkcmVzcz1mb3hzZWNAbW96aWxsYS5jb20wdjAQBgcqhkjOPQIBBgUrgQQAIgNi
+AAQklaclq89BKPcYIfUdVS4JF/pZxjTVOlYVdj4QJ5xopHAngXkUggYkkHj0tmZV
+EcrXrCVq1qEtB/k7wXXkU4HN9rX7WcUkksClDJmUQ2qabzP7i20q3epGNq57RE2p
+3hKjggGJMIIBhTAMBgNVHRMEBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAWBgNVHSUB
+Af8EDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUoB1KF0+Mwis1RfFj8dpwcKfO+OEw
+gagGA1UdIwSBoDCBnYAUs7zqWHSr4W54KrKrnCMeqGMsl7ehgYGkfzB9MQswCQYD
+VQQGEwJVUzEcMBoGA1UEChMTTW96aWxsYSBDb3Jwb3JhdGlvbjEvMC0GA1UECxMm
+TW96aWxsYSBBTU8gUHJvZHVjdGlvbiBTaWduaW5nIFNlcnZpY2UxHzAdBgNVBAMT
+FnJvb3QtY2EtcHJvZHVjdGlvbi1hbW+CAQEwMwYJYIZIAYb4QgEEBCYWJGh0dHA6
+Ly9hZGRvbnMuYWxsaXpvbS5vcmcvY2EvY3JsLnBlbTBOBgNVHR4ERzBFoEMwIIIe
+LmNvbnRlbnQtc2lnbmF0dXJlLm1vemlsbGEub3JnMB+CHWNvbnRlbnQtc2lnbmF0
+dXJlLm1vemlsbGEub3JnMA0GCSqGSIb3DQEBDAUAA4ICAQALeUuF/7hcmM/LFnK6
+6a5lBQk5z5JBr2bNNvKVs/mtdIcVKcxjWxOBM5rorZiM5UWE7BmAm8E7gFCCq30y
+ZnNn6BO04z5LtDRHxa3IGhgECloyOJUSi9xxFxe5p5wJzFdArl7happSOUwOi+z2
+aDqS6uTJWubIY4Uz7h7S2UkUm52CTYnvpioS7eQoovvrlUsgIhkkIwDQnu7RWSej
+6nkc5o5SNwAJWsQvxIko32AxhvPmmtv1T/mtXY488TJ0VoBZ6lRkJJIxIJ48pGHJ
++YRt1tzO2aqCEs9pNPGWfhrpcDc2mu4fvlSX1elWYiGrpQBVbdEJlDkGAD0AC8on
+/7ybD2pEdh7pViVLV78Md+DNNquqqNhRJpn65k4lhvgDLHYvLNOrrtAmcmQonNdU
+OSumIuqcGk7dm/7gr9lrwAm8V8/GwDyzTgi4wNA4vwln3c7iMFGLL/b2piEQCSl+
+mqL1LeWJV+8rkbi8l2T0QIBwjDgR97ZxpLPwmUdDNiGAWeEFxn0jU9CQtQKjOj84
+VPZUM7aSHhVQ0bQpnjua7IWvLKK7F2fOo3PmuLacnnfyrzr2C/Le5k6EK/0q2cKf
+P6JzDWwt8werc6E3C6z3jbUdAwgNpv/fGz8gQBPf7NeiYkqMUNB2Z3aF8He8Jg15
+Abv+2+rSOLpBsTU67AHzMKJ8hw==
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIEnTCCBCSgAwIBAgIEAQAAFzAKBggqhkjOPQQDAzCBpjELMAkGA1UEBhMCVVMx
+HDAaBgNVBAoTE01vemlsbGEgQ29ycG9yYXRpb24xLzAtBgNVBAsTJk1vemlsbGEg
+QU1PIFByb2R1Y3Rpb24gU2lnbmluZyBTZXJ2aWNlMSUwIwYDVQQDExxDb250ZW50
+IFNpZ25pbmcgSW50ZXJtZWRpYXRlMSEwHwYJKoZIhvcNAQkBFhJmb3hzZWNAbW96
+aWxsYS5jb20wHhcNMTcwNTA5MTQwMjM3WhcNMTcxMTA3MTQwMjM3WjCBrzELMAkG
+A1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWExHDAaBgNVBAoTE01vemlsbGEg
+Q29ycG9yYXRpb24xFzAVBgNVBAsTDkNsb3VkIFNlcnZpY2VzMS8wLQYDVQQDEyZu
+b3JtYW5keS5jb250ZW50LXNpZ25hdHVyZS5tb3ppbGxhLm9yZzEjMCEGCSqGSIb3
+DQEJARYUc2VjdXJpdHlAbW96aWxsYS5vcmcwdjAQBgcqhkjOPQIBBgUrgQQAIgNi
+AAShRFsGyg6DkUX+J2mMDM6cLK8V6HawjGVlQ/w5H5fHiGJDMrkl4ktnN+O37mSs
+dReHcVxxpPNEpIfkWQ2TFmJgOUzqi/CzO06APlAJ9mnIcaobgdqRQxoTchFEyzUx
+nTijggIWMIICEjAdBgNVHQ4EFgQUKnGLJ9po8ea5qUNjJyV/c26VZfswgaoGA1Ud
+IwSBojCBn4AUiHVymVvwUPJguD2xCZYej3l5nu6hgYGkfzB9MQswCQYDVQQGEwJV
+UzEcMBoGA1UEChMTTW96aWxsYSBDb3Jwb3JhdGlvbjEvMC0GA1UECxMmTW96aWxs
+YSBBTU8gUHJvZHVjdGlvbiBTaWduaW5nIFNlcnZpY2UxHzAdBgNVBAMTFnJvb3Qt
+Y2EtcHJvZHVjdGlvbi1hbW+CAxAABjAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQE
+AwIHgDAWBgNVHSUBAf8EDDAKBggrBgEFBQcDAzBFBgNVHR8EPjA8MDqgOKA2hjRo
+dHRwczovL2NvbnRlbnQtc2lnbmF0dXJlLmNkbi5tb3ppbGxhLm5ldC9jYS9jcmwu
+cGVtMEMGCWCGSAGG+EIBBAQ2FjRodHRwczovL2NvbnRlbnQtc2lnbmF0dXJlLmNk
+bi5tb3ppbGxhLm5ldC9jYS9jcmwucGVtME8GCCsGAQUFBwEBBEMwQTA/BggrBgEF
+BQcwAoYzaHR0cHM6Ly9jb250ZW50LXNpZ25hdHVyZS5jZG4ubW96aWxsYS5uZXQv
+Y2EvY2EucGVtMDEGA1UdEQQqMCiCJm5vcm1hbmR5LmNvbnRlbnQtc2lnbmF0dXJl
+Lm1vemlsbGEub3JnMAoGCCqGSM49BAMDA2cAMGQCMGeeyXYM3+r1fcaXzd90PwGb
+h9nrl1fZNXrCu17lCPn2JntBVh7byT3twEbr+Hmv8gIwU9klAW6yHLG/ZpAZ0jdf
+38Rciz/FDEAdrzH2QlYAOw+uDdpcmon9oiRgIxzwNlUe
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIGYTCCBEmgAwIBAgIBATANBgkqhkiG9w0BAQwFADB9MQswCQYDVQQGEwJVUzEc
+MBoGA1UEChMTTW96aWxsYSBDb3Jwb3JhdGlvbjEvMC0GA1UECxMmTW96aWxsYSBB
+TU8gUHJvZHVjdGlvbiBTaWduaW5nIFNlcnZpY2UxHzAdBgNVBAMTFnJvb3QtY2Et
+cHJvZHVjdGlvbi1hbW8wHhcNMTUwMzE3MjI1MzU3WhcNMjUwMzE0MjI1MzU3WjB9
+MQswCQYDVQQGEwJVUzEcMBoGA1UEChMTTW96aWxsYSBDb3Jwb3JhdGlvbjEvMC0G
+A1UECxMmTW96aWxsYSBBTU8gUHJvZHVjdGlvbiBTaWduaW5nIFNlcnZpY2UxHzAd
+BgNVBAMTFnJvb3QtY2EtcHJvZHVjdGlvbi1hbW8wggIgMA0GCSqGSIb3DQEBAQUA
+A4ICDQAwggIIAoICAQC0u2HXXbrwy36+MPeKf5jgoASMfMNz7mJWBecJgvlTf4hH
+JbLzMPsIUauzI9GEpLfHdZ6wzSyFOb4AM+D1mxAWhuZJ3MDAJOf3B1Rs6QorHrl8
+qqlNtPGqepnpNJcLo7JsSqqE3NUm72MgqIHRgTRsqUs+7LIPGe7262U+N/T0LPYV
+Le4rZ2RDHoaZhYY7a9+49mHOI/g2YFB+9yZjE+XdplT2kBgA4P8db7i7I0tIi4b0
+B0N6y9MhL+CRZJyxdFe2wBykJX14LsheKsM1azHjZO56SKNrW8VAJTLkpRxCmsiT
+r08fnPyDKmaeZ0BtsugicdipcZpXriIGmsZbI12q5yuwjSELdkDV6Uajo2n+2ws5
+uXrP342X71WiWhC/dF5dz1LKtjBdmUkxaQMOP/uhtXEKBrZo1ounDRQx1j7+SkQ4
+BEwjB3SEtr7XDWGOcOIkoJZWPACfBLC3PJCBWjTAyBlud0C5n3Cy9regAAnOIqI1
+t16GU2laRh7elJ7gPRNgQgwLXeZcFxw6wvyiEcmCjOEQ6PM8UQjthOsKlszMhlKw
+vjyOGDoztkqSBy/v+Asx7OW2Q7rlVfKarL0mREZdSMfoy3zTgtMVCM0vhNl6zcvf
+5HNNopoEdg5yuXo2chZ1p1J+q86b0G5yJRMeT2+iOVY2EQ37tHrqUURncCy4uwIB
+A6OB7TCB6jAMBgNVHRMEBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAWBgNVHSUBAf8E
+DDAKBggrBgEFBQcDAzCBkgYDVR0jBIGKMIGHoYGBpH8wfTELMAkGA1UEBhMCVVMx
+HDAaBgNVBAoTE01vemlsbGEgQ29ycG9yYXRpb24xLzAtBgNVBAsTJk1vemlsbGEg
+QU1PIFByb2R1Y3Rpb24gU2lnbmluZyBTZXJ2aWNlMR8wHQYDVQQDExZyb290LWNh
+LXByb2R1Y3Rpb24tYW1vggEBMB0GA1UdDgQWBBSzvOpYdKvhbngqsqucIx6oYyyX
+tzANBgkqhkiG9w0BAQwFAAOCAgEAaNSRYAaECAePQFyfk12kl8UPLh8hBNidP2H6
+KT6O0vCVBjxmMrwr8Aqz6NL+TgdPmGRPDDLPDpDJTdWzdj7khAjxqWYhutACTew5
+eWEaAzyErbKQl+duKvtThhV2p6F6YHJ2vutu4KIciOMKB8dslIqIQr90IX2Usljq
+8Ttdyf+GhUmazqLtoB0GOuESEqT4unX6X7vSGu1oLV20t7t5eCnMMYD67ZBn0YIU
+/cm/+pan66hHrja+NeDGF8wabJxdqKItCS3p3GN1zUGuJKrLykxqbOp/21byAGog
+Z1amhz6NHUcfE6jki7sM7LHjPostU5ZWs3PEfVVgha9fZUhOrIDsyXEpCWVa3481
+LlAq3GiUMKZ5DVRh9/Nvm4NwrTfB3QkQQJCwfXvO9pwnPKtISYkZUqhEqvXk5nBg
+QCkDSLDjXTx39naBBGIVIqBtKKuVTla9enngdq692xX/CgO6QJVrwpqdGjebj5P8
+5fNZPABzTezG3Uls5Vp+4iIWVAEDkK23cUj3c/HhE+Oo7kxfUeu5Y1ZV3qr61+6t
+ZARKjbu1TuYQHf0fs+GwID8zeLc2zJL7UzcHFwwQ6Nda9OJN4uPAuC/BKaIpxCLL
+26b24/tRam4SJjqpiq20lynhUrmTtt6hbG3E1Hpy3bmkt2DYnuMFwEx2gfXNcnbT
+wNuvFqc=
+-----END CERTIFICATE-----`
+
+// NB: these certs do no exactly match the result of parsing
+// WronglyOrderedChain
+var WronglyOrderedChainCerts = []*x509.Certificate{
+	&x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:         "Content Signing Intermediate/emailAddress=foxsec@mozilla.com",
+			Organization:       []string{"Mozilla Corporation"},
+			OrganizationalUnit: []string{"Mozilla AMO Production Signing Service"},
+			Country:            []string{"US"},
+			Province:           nil,
+			Locality:           nil,
+		},
+		NotBefore:           mustParseUTC("2020-12-31T00:00:00Z"),
+		NotAfter:            mustParseUTC("2025-03-14T22:53:57Z"),
+		IsCA:                true,
+		DNSNames:            nil,
+		KeyUsage:            x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		PermittedDNSDomains: []string{".content-signature.mozilla.org", "content-signature.mozilla.org"},
+	},
+	&x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:         "normandy.content-signature.mozilla.org",
+			Organization:       []string{"Mozilla Corporation"},
+			OrganizationalUnit: []string{"Cloud Services"},
+			Country:            []string{"US"},
+			Province:           []string{"California"},
+			Locality:           nil,
+		},
+		NotBefore: mustParseUTC("2017-05-09T14:02:37Z"),
+		NotAfter:  mustParseUTC("2017-11-07T14:02:37Z"),
+		IsCA:      false,
+		DNSNames:  []string{"normandy.content-signature.mozilla.org"},
+		KeyUsage:  x509.KeyUsageDigitalSignature,
+	},
+	&x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:         "root-ca-production-amo",
+			Organization:       []string{"Mozilla Corporation"},
+			OrganizationalUnit: []string{"Mozilla AMO Production Signing Service"},
+			Country:            []string{"US"},
+			Province:           nil,
+			Locality:           nil,
+		},
+		NotBefore: mustParseUTC("2015-03-17T22:53:57Z"),
+		NotAfter:  mustParseUTC("2025-03-14T22:53:57Z"),
+		IsCA:      true,
+		DNSNames:  nil,
+		KeyUsage:  x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	},
+}
+
+var NormandyDevChain2021Intermediate = `-----BEGIN CERTIFICATE-----
+MIIHijCCBXKgAwIBAgIEAQAABDANBgkqhkiG9w0BAQwFADCBvzELMAkGA1UEBhMC
+VVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MSYwJAYDVQQK
+Ex1Db250ZW50IFNpZ25hdHVyZSBEZXYgU2lnbmluZzEmMCQGA1UEAxMdZGV2LmNv
+bnRlbnQtc2lnbmF0dXJlLnJvb3QuY2ExOzA5BgkqhkiG9w0BCQEWLGNsb3Vkc2Vj
+K2RldnJvb3Rjb250ZW50c2lnbmF0dXJlQG1vemlsbGEuY29tMB4XDTE2MDcwNjIx
+NDkyNloXDTIxMDcwNTIxNDkyNlowazELMAkGA1UEBhMCVVMxEDAOBgNVBAoTB0Fs
+bGl6b20xFzAVBgNVBAsTDkNsb3VkIFNlcnZpY2VzMTEwLwYDVQQDEyhEZXZ6aWxs
+YSBTaWduaW5nIFNlcnZpY2VzIEludGVybWVkaWF0ZSAxMIICIjANBgkqhkiG9w0B
+AQEFAAOCAg8AMIICCgKCAgEAypIfUURYgWzGw8G/1Pz9zW+Tsjirx2owThiv2gys
+wJiWL/9/2gzKOrYDEqlDUudfA/BjVRtT9+NbYgnhaCkNfADOAacWS83aMhedAqhP
+bVd5YhGQdpijI7f1AVTSb0ehrU2nhOZHvHX5Tk2fbRx3ryefIazNTLFGpiMBbsNv
+tSI/+fjW8s0MhKNqlLnk6a9mZKo0mEy7HjGYV8nzsgI17rKLx/s2HG4TFG0+JQzc
+UGlum3Tg58ritDzWdyKIkmKNZ48oLBX99Qc8j8B1UyiLv6TZmjVX0I+Ds7eSWHZk
+0axLEpTyf2r7fHvN4iDNCPajw+ZpuuBfbs80Ha8b8MHvnpf9fbwiirodNQOVpY4c
+t5E3Us3eYwBKdqDEbECWxCKGAS2/iVVUCNKHsg0sSxgqcwxrxyrddQRUQ0EM38DZ
+F/vHt+vTdHt07kezbjJe0Kklel59uSpghA0iL4vxzbTns1fuwYOgVrNGs3acTkiB
+GhFOxRXUPGtpdYmv+AaR9WlWJQY1GIEoVrinPVH7bcCwyh1CcUbHL+oAFTcmc6kZ
+7azNg21tWILIRL7R0IZYQm0tF5TTwCsjVC7FuHaBtkxtVrrZqeKjvVXQ8TK5VoI0
+BUQ6BKHGeTtm+0HBpheYBDy3wkOsEGbGHLEM6cMeiz6PyCXF8wXli8Qb/TjN3LHZ
+e30CAwEAAaOCAd8wggHbMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgGG
+MBYGA1UdJQEB/wQMMAoGCCsGAQUFBwMDMB0GA1UdDgQWBBT9huhQhcCi8KESm50M
+G6h0cpuNSzCB7AYDVR0jBIHkMIHhgBSDx8s0qJaMyQCehKcuzgzVNRA75qGBxaSB
+wjCBvzELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFp
+biBWaWV3MSYwJAYDVQQKEx1Db250ZW50IFNpZ25hdHVyZSBEZXYgU2lnbmluZzEm
+MCQGA1UEAxMdZGV2LmNvbnRlbnQtc2lnbmF0dXJlLnJvb3QuY2ExOzA5BgkqhkiG
+9w0BCQEWLGNsb3Vkc2VjK2RldnJvb3Rjb250ZW50c2lnbmF0dXJlQG1vemlsbGEu
+Y29tggEBMEIGCWCGSAGG+EIBBAQ1FjNodHRwczovL2NvbnRlbnQtc2lnbmF0dXJl
+LmRldi5tb3phd3MubmV0L2NhL2NybC5wZW0wTgYIKwYBBQUHAQEEQjBAMD4GCCsG
+AQUFBzAChjJodHRwczovL2NvbnRlbnQtc2lnbmF0dXJlLmRldi5tb3phd3MubmV0
+L2NhL2NhLnBlbTANBgkqhkiG9w0BAQwFAAOCAgEAbum0z0ccqI1Wp49VtsGmUPHA
+gjPPy2Xa5NePmqY87WrGdhjN3xbLVb3hx8T2N6pqDjMY2rEynXKEOek3oJkQ3C6J
+8AFP6Y93gaAlNz6EA0J0mqdW5TMI8YEYsu2ma+dQQ8wm9f/5b+/Y8qwfhztP06W5
+H6IG04/RvgUwYMnSR4QvT309fu5UmCRUDzsO53ZmQCfmN94u3NxHc4S6n0Q6AKAM
+kh5Ld9SQnlqqqDykzn7hYDi8nTLWc7IYqkGfNMilDEKbAl4CjnSfyEvpdFAJ9sPR
+UL+kaWFSMvaqIPNpxS5OpoPZjmxEc9HHnCHxtfDHWdXTJILjijPrCdMaxOCHfIqV
+5roOJggI4RZ0YM68IL1MfN4IEVOrHhKjDHtd1gcmy2KU4jfj9LQq9YTnyvZ2z1yS
+lS310HG3or1K8Nnu5Utfe7T6ppX8bLRMkS1/w0p7DKxHaf4D/GJcCtM9lcSt9JpW
+6ACKFikjWR4ZxczYKgApc0wcjd7XBuO5777xtOeyEUDHdDft3jiXA91dYM5UAzc3
+69z/3zmaELzo0gWcrjLXh7fU9AvbU4EUF6rwzxbPGF78jJcGK+oBf8uWUCkBykDt
+VsAEZI1u4EDg8e/C1nFqaH9gNMArAgquYIB9rve+hdprIMnva0S147pflWopBWcb
+jwzgpfquuYnnxe0CNBA=
+-----END CERTIFICATE-----`
+
+var NormandyDevChain2021 = `-----BEGIN CERTIFICATE-----
+MIIGRTCCBC2gAwIBAgIEAQAABTANBgkqhkiG9w0BAQwFADBrMQswCQYDVQQGEwJV
+UzEQMA4GA1UEChMHQWxsaXpvbTEXMBUGA1UECxMOQ2xvdWQgU2VydmljZXMxMTAv
+BgNVBAMTKERldnppbGxhIFNpZ25pbmcgU2VydmljZXMgSW50ZXJtZWRpYXRlIDEw
+HhcNMTYwNzA2MjE1NzE1WhcNMjEwNzA1MjE1NzE1WjCBrzELMAkGA1UEBhMCVVMx
+EzARBgNVBAgTCkNhbGlmb3JuaWExHDAaBgNVBAoTE01vemlsbGEgQ29ycG9yYXRp
+b24xFzAVBgNVBAsTDkNsb3VkIFNlcnZpY2VzMS8wLQYDVQQDEyZub3JtYW5keS5j
+b250ZW50LXNpZ25hdHVyZS5tb3ppbGxhLm9yZzEjMCEGCSqGSIb3DQEJARYUc2Vj
+dXJpdHlAbW96aWxsYS5vcmcwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAARUQqIIAiTB
+GDVUWw/wk5h1IXpreq+BtE+gQr15O4tusHpCLGjOxwpHiJYnxk45fpE8JGAV19UO
+hmqMUEU0k31C1EGTSZW0ducSvHrh3a8wXShZ6dxLWHItbbCGA6A7PumjggJYMIIC
+VDAdBgNVHQ4EFgQUVfksSjlZ0i1TBiS1vcoObaMeXn0wge8GA1UdIwSB5zCB5IAU
+/YboUIXAovChEpudDBuodHKbjUuhgcWkgcIwgb8xCzAJBgNVBAYTAlVTMQswCQYD
+VQQIEwJDQTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEmMCQGA1UEChMdQ29udGVu
+dCBTaWduYXR1cmUgRGV2IFNpZ25pbmcxJjAkBgNVBAMTHWRldi5jb250ZW50LXNp
+Z25hdHVyZS5yb290LmNhMTswOQYJKoZIhvcNAQkBFixjbG91ZHNlYytkZXZyb290
+Y29udGVudHNpZ25hdHVyZUBtb3ppbGxhLmNvbYIEAQAABDAMBgNVHRMBAf8EAjAA
+MA4GA1UdDwEB/wQEAwIHgDAWBgNVHSUBAf8EDDAKBggrBgEFBQcDAzBEBgNVHR8E
+PTA7MDmgN6A1hjNodHRwczovL2NvbnRlbnQtc2lnbmF0dXJlLmRldi5tb3phd3Mu
+bmV0L2NhL2NybC5wZW0wQgYJYIZIAYb4QgEEBDUWM2h0dHBzOi8vY29udGVudC1z
+aWduYXR1cmUuZGV2Lm1vemF3cy5uZXQvY2EvY3JsLnBlbTBOBggrBgEFBQcBAQRC
+MEAwPgYIKwYBBQUHMAKGMmh0dHBzOi8vY29udGVudC1zaWduYXR1cmUuZGV2Lm1v
+emF3cy5uZXQvY2EvY2EucGVtMDEGA1UdEQQqMCiCJm5vcm1hbmR5LmNvbnRlbnQt
+c2lnbmF0dXJlLm1vemlsbGEub3JnMA0GCSqGSIb3DQEBDAUAA4ICAQCwb+8JTAB7
+ZfQmFqPUIV2cQQv696AaDPQCtA9YS4zmUfcLMvfZVAbK397zFr0RMDdLiTUQDoeq
+rBEmPXhJRPiv6JAK4n7Jf6Y6XfXcNxx+q3garR09Vm/0CnEq/iV+ZAtPkoKIO9kr
+Nkzecd894yQCF4hIuPQ5qtMySeqJmH3Dp13eq4T0Oew1Bu32rNHuBJh2xYBkWdun
+aAw/YX0I5EqZBP/XA6gbiA160tTK+hnpnlMtw/ljkvfhHbWpICD4aSiTL8L3vABQ
+j7bqjMKR5xDkuGWshZfcmonpvQhGTye/RZ1vz5IzA3VOJt1mz5bdZlitpaOm/Yv0
+x6aODz8GP/PiRWFQ5CW8Uf/7pGc5rSyvnfZV2ix8EzFlo8cUtuN1fjrPFPOFOLvG
+iiB6S9nlXiKBGYIDdd8V8iC5xJpzjiAWJQigwSNzuc2K30+iPo3w0zazkwe5V8jW
+gj6gItYxh5xwVQTPHD0EOd9HvV1ou42+rH5Y+ISFUm25zz02UtUHEK0BKtL0lmdt
+DwVq5jcHn6bx2/iwUtlKvPXtfM/6JjTJlkLZLtS7U5/pwcS0owo9zAL0qg3bdm16
++v/olmPqQFLUHmamJTzv3rojj5X/uVdx1HMM3wBjV9tRYoYaZw9RIInRmM8Z1pHv
+JJ+CIZgCyd5vgp57BKiodRZcgHoCH+BkOQ==
+-----END CERTIFICATE-----
+` + NormandyDevChain2021Intermediate + `
+-----BEGIN CERTIFICATE-----
+MIIH3DCCBcSgAwIBAgIBATANBgkqhkiG9w0BAQwFADCBvzELMAkGA1UEBhMCVVMx
+CzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MSYwJAYDVQQKEx1D
+b250ZW50IFNpZ25hdHVyZSBEZXYgU2lnbmluZzEmMCQGA1UEAxMdZGV2LmNvbnRl
+bnQtc2lnbmF0dXJlLnJvb3QuY2ExOzA5BgkqhkiG9w0BCQEWLGNsb3Vkc2VjK2Rl
+dnJvb3Rjb250ZW50c2lnbmF0dXJlQG1vemlsbGEuY29tMB4XDTE2MDcwNjE4MTUy
+MloXDTI2MDcwNDE4MTUyMlowgb8xCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEW
+MBQGA1UEBxMNTW91bnRhaW4gVmlldzEmMCQGA1UEChMdQ29udGVudCBTaWduYXR1
+cmUgRGV2IFNpZ25pbmcxJjAkBgNVBAMTHWRldi5jb250ZW50LXNpZ25hdHVyZS5y
+b290LmNhMTswOQYJKoZIhvcNAQkBFixjbG91ZHNlYytkZXZyb290Y29udGVudHNp
+Z25hdHVyZUBtb3ppbGxhLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoC
+ggIBAJcPcXhD8MzF6OTn5qZ0L7lX1+PEgLKhI9g1HxxDYDVup4Zm0kZhPGmFSlml
+6eVO99OvvHdAlHhQGCIG7h+w1cp66mWjfpcvtQH23uRoKZfiW3jy1jUWrvdXolxR
+t1taZosjzo+9OP8TvG6LpJj7AvqUiYD4wYnQJtt0jNRN4d6MUfQwiavSS5uTBuxd
+ZJ4TsPvEI+Iv4A4PSobSzxkg79LTMvsGtDLQv7nN5hMs9T18EL5GnIKoqnSQCU0d
+n2CN7S3QiQ+cbORWsSYqCTj1gUbFh6X3duEB/ypLcyWFbqeJmPHikjY8q8pLjZSB
+IYiTJYLyvYlKdM5QleC/xuBNnMPCftrwwLHjWE4Dd7C9t7k0R5xyOetuiHLCwOcQ
+tuckp7RgFKoviMNv3gdkzwVapOklcsaRkRscv6OMTKJNsdJVIDLrPF1wMABhbEQB
+64BL0uL4lkFtpXXbJzQ6mgUNQveJkfUWOoB+cA/6GtI4J0aQfvQgloCYI6jxNn/e
+Nvk5OV9KFOhXS2dnDft3wHU46sg5yXOuds1u6UrOoATBNFlkS95m4zIX1Svu091+
+CKTiLK85+ZiFtAlU2bPr3Bk3GhL3Z586ae6a4QUEx6SPQVXc18ezB4qxKqFc+avI
+ylccYMRhVP+ruADxtUM5Vy6x3U8BwBK5RLdecRx2FEBDImY1AgMBAAGjggHfMIIB
+2zAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjAWBgNVHSUBAf8EDDAK
+BggrBgEFBQcDAzAdBgNVHQ4EFgQUg8fLNKiWjMkAnoSnLs4M1TUQO+YwgewGA1Ud
+IwSB5DCB4YAUg8fLNKiWjMkAnoSnLs4M1TUQO+ahgcWkgcIwgb8xCzAJBgNVBAYT
+AlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEmMCQGA1UE
+ChMdQ29udGVudCBTaWduYXR1cmUgRGV2IFNpZ25pbmcxJjAkBgNVBAMTHWRldi5j
+b250ZW50LXNpZ25hdHVyZS5yb290LmNhMTswOQYJKoZIhvcNAQkBFixjbG91ZHNl
+YytkZXZyb290Y29udGVudHNpZ25hdHVyZUBtb3ppbGxhLmNvbYIBATBCBglghkgB
+hvhCAQQENRYzaHR0cHM6Ly9jb250ZW50LXNpZ25hdHVyZS5kZXYubW96YXdzLm5l
+dC9jYS9jcmwucGVtME4GCCsGAQUFBwEBBEIwQDA+BggrBgEFBQcwAoYyaHR0cHM6
+Ly9jb250ZW50LXNpZ25hdHVyZS5kZXYubW96YXdzLm5ldC9jYS9jYS5wZW0wDQYJ
+KoZIhvcNAQEMBQADggIBAAAQ+fotZE79FfZ8Lz7eiTUzlwHXCdSE2XD3nMROu6n6
+uLTBPrf2C+k+U1FjKVvL5/WCUj6hIzP2X6Sb8+o0XHX9mKN0yoMORTEYJOnazYPK
+KSUUFnE4vGgQkr6k/31gGRMTICdnf3VOOAlUCQ5bOmGIuWi401E3sbd85U+TJe0A
+nHlU+XjtfzlqcBvQivdbA0s+GEG55uRPvn952aTBEMHfn+2JqKeLShl4AtUAfu+h
+6md3Z2HrEC7B3GK8ekWPu0G/ZuWTuFvOimZ+5C8IPRJXcIR/siPQl1x6dpTCew6t
+lPVcVuvg6SQwzvxetkNrGUe2Wb2s9+PK2PUvfOS8ee25SNmfG3XK9qJpqGUhzSBX
+T8QQgyxd0Su5G7Wze7aaHZd/fqIm/G8YFR0HiC2xni/lnDTXFDPCe+HCnSk0bH6U
+wpr6I1yK8oZ2IdnNVfuABGMmGOhvSQ8r7//ea9WKhCsGNQawpVWVioY7hpyNAJ0O
+Vn4xqG5f6allz8lgpwAQ+AeEEClHca6hh6mj9KhD1Of1CC2Vx52GHNh/jMYEc3/g
+zLKniencBqn3Y2XH2daITGJddcleN09+a1NaTkT3hgr7LumxM8EVssPkC+z9j4Vf
+Gbste+8S5QCMhh00g5vR9QF8EaFqdxCdSxrsA4GmpCa5UQl8jtCnpp2DLKXuOh72
+-----END CERTIFICATE-----`
+
+// NB: these certs do no exactly match the result of parsing
+// NormandyDevChain2021
+var NormandyDevChain2021Certs = []*x509.Certificate{
+	&x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:         "normandy.content-signature.mozilla.org",
+			Organization:       []string{"Mozilla Corporation"},
+			OrganizationalUnit: []string{"Cloud Services"},
+			Country:            []string{"US"},
+			Province:           []string{"California"},
+			Locality:           nil,
+		},
+		NotBefore: mustParseUTC("2016-07-06T21:57:15Z"),
+		NotAfter:  mustParseUTC("2021-07-05T21:57:15Z"),
+		IsCA:      false,
+		DNSNames:  []string{"normandy.content-signature.mozilla.org"},
+		KeyUsage:  x509.KeyUsageDigitalSignature,
+	},
+	&x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:         "Devzilla Signing Services Intermediate 1",
+			Organization:       []string{"Allizom"},
+			OrganizationalUnit: []string{"Cloud Services"},
+			Country:            []string{"US"},
+			Province:           nil,
+			Locality:           nil,
+		},
+		NotBefore: mustParseUTC("2016-07-06T21:49:26Z"),
+		NotAfter:  mustParseUTC("2021-07-05T21:49:26Z"),
+		KeyUsage:  x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		IsCA:      true,
+		DNSNames:  nil,
+	},
+	&x509.Certificate{
+		Subject: pkix.Name{
+			CommonName:         "dev.content-signature.root.ca",
+			Organization:       []string{"Content Signature Dev Signing"},
+			OrganizationalUnit: nil,
+			Country:            []string{"US"},
+			Province:           []string{"CA"},
+			Locality:           []string{"Mountain View"},
+		},
+		NotBefore: mustParseUTC("2016-07-06T18:15:22Z"),
+		NotAfter:  mustParseUTC("2026-07-04T18:15:22Z"),
+		KeyUsage:  x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		IsCA:      true,
+		DNSNames:  nil,
+	},
+}
+
+// Tests -----------------------------------------------------------------
+
+func Test_chainBytesToCerts(t *testing.T) {
+	tests := []struct {
+		name       string
+		chain      []byte
+		wantCerts  []*x509.Certificate
+		wantErr    bool
+		wantErrStr string
+	}{
+		{
+			name:      "NormandyDevChain2021 parses",
+			chain:     []byte(NormandyDevChain2021),
+			wantCerts: NormandyDevChain2021Certs,
+			wantErr:   false,
+		},
+		{
+			name:      "ExpiredEndEntityChain parses",
+			chain:     []byte(ExpiredEndEntityChain),
+			wantCerts: ExpiredEndEntityChainCerts,
+			wantErr:   false,
+		},
+		{
+			name:      "WronglyOrderedChain parses",
+			chain:     []byte(WronglyOrderedChain),
+			wantCerts: WronglyOrderedChainCerts,
+			wantErr:   false,
+		},
+		// failing test cases.
+		{
+			name:       "empty chain fails",
+			chain:      []byte(""),
+			wantCerts:  []*x509.Certificate{},
+			wantErr:    true,
+			wantErrStr: "failed to PEM decode EE/leaf certificate from chain",
+		},
+		{
+			name:       "EE bad PEM type fails",
+			chain:      []byte(testSignerP384PEM),
+			wantCerts:  []*x509.Certificate{},
+			wantErr:    true,
+			wantErrStr: "failed to PEM decode EE/leaf certificate from chain",
+		},
+		{
+			name:       "EE bad PEM content fails",
+			chain:      []byte(badPEMContent),
+			wantCerts:  []*x509.Certificate{},
+			wantErr:    true,
+			wantErrStr: "error parsing EE/leaf certificate from chain: asn1: structure error: tags don't match (16 vs {class:0 tag:2 length:1 isCompound:false}) {optional:false explicit:false application:false private:false defaultValue:<nil> tag:<nil> stringType:0 timeType:0 set:false omitEmpty:false} tbsCertificate @2",
+		},
+		{
+			name:       "inter bad PEM type fails",
+			chain:      []byte(firefoxPkiStageRoot + "\nthis is not a PEM"),
+			wantCerts:  []*x509.Certificate{},
+			wantErr:    true,
+			wantErrStr: "failed to PEM decode intermediate certificate from chain",
+		},
+		{
+			name:       "inter bad PEM content fails",
+			chain:      []byte(firefoxPkiStageRoot + "\n" + badPEMContent),
+			wantCerts:  []*x509.Certificate{},
+			wantErr:    true,
+			wantErrStr: "failed to parse intermediate certificate from chain: asn1: structure error: tags don't match (16 vs {class:0 tag:2 length:1 isCompound:false}) {optional:false explicit:false application:false private:false defaultValue:<nil> tag:<nil> stringType:0 timeType:0 set:false omitEmpty:false} tbsCertificate @2",
+		},
+		{
+			name:       "root bad PEM type fails",
+			chain:      []byte(firefoxPkiStageRoot + "\n" + firefoxPkiStageRoot + "\nthis is not a PEM"),
+			wantCerts:  []*x509.Certificate{},
+			wantErr:    true,
+			wantErrStr: "failed to PEM decode root certificate from chain",
+		},
+		{
+			name:       "inter bad PEM content fails",
+			chain:      []byte(firefoxPkiStageRoot + "\n" + firefoxPkiStageRoot + "\n" + badPEMContent),
+			wantCerts:  []*x509.Certificate{},
+			wantErr:    true,
+			wantErrStr: "failed to parse root certificate from chain: asn1: structure error: tags don't match (16 vs {class:0 tag:2 length:1 isCompound:false}) {optional:false explicit:false application:false private:false defaultValue:<nil> tag:<nil> stringType:0 timeType:0 set:false omitEmpty:false} tbsCertificate @2",
+		},
+		{
+			name:       "trailing data fails",
+			chain:      []byte(firefoxPkiStageRoot + "\n" + firefoxPkiStageRoot + "\n" + firefoxPkiStageRoot + "\n!!!!extra"),
+			wantCerts:  []*x509.Certificate{},
+			wantErr:    true,
+			wantErrStr: "found trailing data after root certificate in chain",
+		},
+		{
+			name:       "extra cert fails",
+			chain:      []byte(firefoxPkiStageRoot + "\n" + firefoxPkiStageRoot + "\n" + firefoxPkiStageRoot + "\n" + firefoxPkiStageRoot),
+			wantCerts:  []*x509.Certificate{},
+			wantErr:    true,
+			wantErrStr: "found trailing data after root certificate in chain",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCerts, err := chainBytesToCerts(tt.chain)
+			if tt.wantErr && (err != nil) && err.Error() != tt.wantErrStr {
+				t.Errorf("chainBytesToCerts() error.Error() = '%s', wanted wantErrStr '%s'", err, tt.wantErrStr)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("chainBytesToCerts() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			for i, cert := range gotCerts {
+				if cert.IsCA != tt.wantCerts[i].IsCA {
+					t.Errorf("chainBytesToCerts() certs[%d].IsCA = %#v, want %#v", i, gotCerts[i].IsCA, tt.wantCerts[i].IsCA)
+				}
+				if !reflect.DeepEqual(cert.Subject.CommonName, tt.wantCerts[i].Subject.CommonName) {
+					t.Errorf("chainBytesToCerts() certs[%d].Subject.CommonName = %#v, want %#v", i, gotCerts[i].Subject.CommonName, tt.wantCerts[i].Subject.CommonName)
+				}
+				if !reflect.DeepEqual(cert.Subject.Country, tt.wantCerts[i].Subject.Country) {
+					t.Errorf("chainBytesToCerts() certs[%d].Subject.Country = %#v, want %#v", i, gotCerts[i].Subject.Country, tt.wantCerts[i].Subject.Country)
+				}
+				if !reflect.DeepEqual(cert.Subject.Province, tt.wantCerts[i].Subject.Province) {
+					t.Errorf("chainBytesToCerts() certs[%d].Subject.Province = %#v, want %#v", i, gotCerts[i].Subject.Province, tt.wantCerts[i].Subject.Province)
+				}
+				if !reflect.DeepEqual(cert.Subject.Locality, tt.wantCerts[i].Subject.Locality) {
+					t.Errorf("chainBytesToCerts() certs[%d].Subject.Locality = %#v, want %#v", i, gotCerts[i].Subject.Locality, tt.wantCerts[i].Subject.Locality)
+				}
+				if !reflect.DeepEqual(cert.Subject.Organization, tt.wantCerts[i].Subject.Organization) {
+					t.Errorf("chainBytesToCerts() certs[%d].Subject.Organization = %#v, want %#v", i, gotCerts[i].Subject.Organization, tt.wantCerts[i].Subject.Organization)
+				}
+				if !reflect.DeepEqual(cert.Subject.OrganizationalUnit, tt.wantCerts[i].Subject.OrganizationalUnit) {
+					t.Errorf("chainBytesToCerts() certs[%d].Subject.OrganizationalUnit = %#v, want %#v", i, gotCerts[i].Subject.OrganizationalUnit, tt.wantCerts[i].Subject.OrganizationalUnit)
+				}
+				if !reflect.DeepEqual(cert.DNSNames, tt.wantCerts[i].DNSNames) {
+					t.Errorf("chainBytesToCerts() certs[%d].DNSNames = %#v, want %#v", i, gotCerts[i].DNSNames, tt.wantCerts[i].DNSNames)
+				}
+				if cert.NotBefore != tt.wantCerts[i].NotBefore {
+					t.Errorf("chainBytesToCerts() certs[%d].NotBefore = %s, want %s", i, gotCerts[i].NotBefore, tt.wantCerts[i].NotBefore)
+				}
+				if cert.NotAfter != tt.wantCerts[i].NotAfter {
+					t.Errorf("chainBytesToCerts() certs[%d].NotAfter = %s, want %s", i, gotCerts[i].NotAfter, tt.wantCerts[i].NotAfter)
+				}
+				if !reflect.DeepEqual(cert.KeyUsage, tt.wantCerts[i].KeyUsage) {
+					t.Errorf("chainBytesToCerts() certs[%d].KeyUsage = %+v, want %+v", i, gotCerts[i].KeyUsage, tt.wantCerts[i].KeyUsage)
+				}
+				if !reflect.DeepEqual(cert.PermittedDNSDomains, tt.wantCerts[i].PermittedDNSDomains) {
+					t.Errorf("chainBytesToCerts() certs[%d].PermittedDNSDomains = %+v, want %+v", i, gotCerts[i].PermittedDNSDomains, tt.wantCerts[i].PermittedDNSDomains)
+				}
+				if !reflect.DeepEqual(cert.ExcludedDNSDomains, tt.wantCerts[i].ExcludedDNSDomains) {
+					t.Errorf("chainBytesToCerts() certs[%d].ExcludedDNSDomains = %+v, want %+v", i, gotCerts[i].ExcludedDNSDomains, tt.wantCerts[i].ExcludedDNSDomains)
+				}
+			}
+			// TODO: test remaining attributes
+			// if !reflect.DeepEqual(gotCerts, tt.wantCerts) {
+			// 	t.Errorf("chainBytesToCerts() = %#v, want %#v", gotCerts, tt.wantCerts)
+			// }
+		})
+	}
+}
+
+func Test_verifyRoot(t *testing.T) {
+	type args struct {
+		rootHash string
+		cert     *x509.Certificate
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "verify Firefox prod root",
+			args: args{
+				rootHash: firefoxPkiProdRootHash,
+				cert:     mustPEMToCert(firefoxPkiProdRoot),
+			},
+			wantErr: false,
+		},
+		{
+			name: "verify Firefox stage root",
+			args: args{
+				rootHash: firefoxPkiContentSignatureStageRootHash,
+				cert:     mustPEMToCert(firefoxPkiContentSignatureStageRoot),
+			},
+			wantErr: false,
+		},
+		{
+			name: "verify sign-signed root",
+			args: args{
+				rootHash: sha2Fingerprint(testRoot),
+				cert:     testRoot,
+			},
+			wantErr: false,
+		},
+		// error testcases
+		{
+			name: "root not self-signed errs",
+			args: args{
+				rootHash: sha2Fingerprint(mustPEMToCert(NormandyDevChain2021Intermediate)),
+				cert:     mustPEMToCert(NormandyDevChain2021Intermediate),
+			},
+			wantErr: true,
+		},
+		{
+			name: "root not CA errs",
+			args: args{
+				rootHash: sha2Fingerprint(testRootNonCA),
+				cert:     testRootNonCA,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid empty root hash errs",
+			args: args{
+				rootHash: "",
+				cert:     mustPEMToCert(firefoxPkiProdRoot),
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid root hash all colons errs",
+			args: args{
+				rootHash: ":::::::",
+				cert:     mustPEMToCert(firefoxPkiProdRoot),
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid root hash errs",
+			args: args{
+				rootHash: "foo",
+				cert:     mustPEMToCert(firefoxPkiProdRoot),
+			},
+			wantErr: true,
+		},
+		{
+			name: "root without code signing ext errs",
+			args: args{
+				rootHash: sha2Fingerprint(testRootNoExt),
+				cert:     testRootNoExt,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := verifyRoot(tt.args.rootHash, tt.args.cert); (err != nil) != tt.wantErr {
+				t.Errorf("verifyRoot() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_verifyCertChain(t *testing.T) {
+	type args struct {
+		rootHash    string
+		certs       []*x509.Certificate
+		currentTime time.Time
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantErr   bool
+		errSubStr string
+	}{
+		{
+			name: "valid chain NormandyDevChain2021 passes",
+			args: args{
+				rootHash:    normandyDev2021Roothash,
+				certs:       mustChainToCerts(NormandyDevChain2021),
+				currentTime: mustParseUTC("2020-05-09T14:02:37Z"),
+			},
+			wantErr:   false,
+			errSubStr: "",
+		},
+		{
+			name: "valid test chain passes",
+			args: args{
+				rootHash:    sha2Fingerprint(testRoot),
+				certs:       []*x509.Certificate{testLeaf, testInter, testRoot},
+				currentTime: time.Now(),
+			},
+			wantErr:   false,
+			errSubStr: "",
+		},
+		// failing test cases.
+		{
+			name: "short chain fails",
+			args: args{
+				rootHash:    sha2Fingerprint(testRoot),
+				certs:       []*x509.Certificate{NormandyDevChain2021Certs[2]},
+				currentTime: mustParseUTC("2020-05-09T14:02:37Z"),
+			},
+			wantErr:   true,
+			errSubStr: "can only verify 3 certificate chain, got 1 certs",
+		},
+		{
+			name: "long chain with extra root fails",
+			args: args{
+				rootHash: sha2Fingerprint(testRoot),
+				certs: []*x509.Certificate{
+					NormandyDevChain2021Certs[0],
+					NormandyDevChain2021Certs[1],
+					NormandyDevChain2021Certs[2],
+					NormandyDevChain2021Certs[2],
+				},
+				currentTime: mustParseUTC("2020-05-09T14:02:37Z"),
+			},
+			wantErr:   true,
+			errSubStr: "can only verify 3 certificate chain, got 4 certs",
+		},
+		{
+			name: "wrongly ordered chain fails",
+			args: args{
+				rootHash:    sha2Fingerprint(testRoot),
+				certs:       mustChainToCerts(WronglyOrderedChain),
+				currentTime: mustParseUTC("2021-05-09T14:02:37Z"),
+			},
+			wantErr:   true,
+			errSubStr: "is not signed by parent certificate",
+		},
+		{
+			name: "invalid root non-CA chain fails",
+			args: args{
+				rootHash:    sha2Fingerprint(testRootNonCA),
+				certs:       []*x509.Certificate{testLeafNonCA, testInterNonCA, testRootNonCA},
+				currentTime: time.Now(),
+			},
+			wantErr:   true,
+			errSubStr: " x509: invalid signature: parent certificate cannot sign this kind of certificate",
+		},
+		{
+			name: "root hash mismatch fails",
+			args: args{
+				rootHash:    "invalid hash",
+				certs:       []*x509.Certificate{testLeaf, testInter, testRoot},
+				currentTime: time.Now(),
+			},
+			wantErr:   true,
+			errSubStr: "is root but fails validation",
+		},
+		{
+			name: "invalid DNS name fails",
+			args: args{
+				rootHash:    sha2Fingerprint(testRoot),
+				certs:       []*x509.Certificate{testLeafInvalidDNSName, testInter, testRoot},
+				currentTime: time.Now(),
+			},
+			wantErr:   true,
+			errSubStr: "x509: a root or intermediate certificate is not authorized to sign for this name: DNS name \"example.org\" is not permitted by any constraint",
+		},
+		// failing validity NotAfter / NotBefore test cases.
+		{
+			name: "expired end-entity chain fails",
+			args: args{
+				rootHash:    sha2Fingerprint(testRoot),
+				certs:       []*x509.Certificate{testLeafExpired, testInter, testRoot},
+				currentTime: time.Now(),
+			},
+			wantErr:   true,
+			errSubStr: "expired",
+		},
+		{
+			name: "not yet valid end-entity chain fails",
+			args: args{
+				rootHash:    sha2Fingerprint(testRoot),
+				certs:       []*x509.Certificate{testLeafNotYetValid, testInter, testRoot},
+				currentTime: time.Now(),
+			},
+			wantErr:   true,
+			errSubStr: "is not yet valid",
+		},
+		{
+			name: "expired intermediate chain fails",
+			args: args{
+				rootHash:    sha2Fingerprint(testRoot),
+				certs:       []*x509.Certificate{testLeaf, testInterExpired, testRoot},
+				currentTime: time.Now(),
+			},
+			wantErr:   true,
+			errSubStr: "expired",
+		},
+		{
+			name: "not yet valid intermediate chain fails",
+			args: args{
+				rootHash:    sha2Fingerprint(testRoot),
+				certs:       []*x509.Certificate{testLeaf, testInterNotYetValid, testRoot},
+				currentTime: time.Now(),
+			},
+			wantErr:   true,
+			errSubStr: "is not yet valid",
+		},
+		{
+			name: "expired root chain fails",
+			args: args{
+				rootHash:    sha2Fingerprint(testRoot),
+				certs:       []*x509.Certificate{testLeaf, testInter, testRootExpired},
+				currentTime: time.Now(),
+			},
+			wantErr:   true,
+			errSubStr: "expired",
+		},
+		{
+			name: "not yet valid root chain fails",
+			args: args{
+				rootHash:    sha2Fingerprint(testRoot),
+				certs:       []*x509.Certificate{testLeaf, testInter, testRootNotYetValid},
+				currentTime: time.Now(),
+			},
+			wantErr:   true,
+			errSubStr: "is not yet valid",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				err error
+			)
+
+			err = verifyCertChain(tt.args.rootHash, tt.args.certs, tt.args.currentTime)
+
+			if tt.wantErr == false && err != nil { // unexpected error
+				t.Errorf("verifyCertChain() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr == true && err == nil { // unexpected pass
+				t.Errorf("verifyCertChain() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr == true && !strings.Contains(err.Error(), tt.errSubStr) {
+				t.Fatalf("verifyCertChain() expected to fail with '%s' but failed with: '%v'", tt.errSubStr, err.Error())
+			}
+		})
+	}
+}
+
+func TestVerify(t *testing.T) {
+	type args struct {
+		input     []byte
+		certChain []byte
+		signature string
+		rootHash  string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "test valid content signature response ok",
+			args: args{
+				input:     signerTestData,
+				certChain: mustCertsToChain([]*x509.Certificate{testLeaf, testInter, testRoot}),
+				signature: "qGjS1QmB2xANizjJqrGmIPoojzjBrTV5kgi01p1ELnfKwH4E3UDTZRf-9K7PCEwjt0mOzd1bBmRBKcnWZNFAMvAduBwfAPHFGpX-YKBoRSLHuA6QuiosEydnZEs5ykAR",
+				rootHash:  sha2Fingerprint(testRoot),
+			},
+			wantErr: false,
+		},
+		// failing test cases.
+		{
+			name: "default args fails",
+			args: args{
+				input:     []byte(""),
+				certChain: []byte(""),
+				signature: "",
+				rootHash:  "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid key type fails",
+			args: args{
+				input:     []byte(""),
+				certChain: mustCertsToChain([]*x509.Certificate{testLeafRSAPub, testInter, testRoot}),
+				signature: "",
+				rootHash:  "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "signature unmarshal fails",
+			args: args{
+				input:     []byte(""),
+				certChain: mustCertsToChain([]*x509.Certificate{testLeaf, testInter, testRoot}),
+				signature: "",
+				rootHash:  "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "data verification fails",
+			args: args{
+				input:     []byte(""),
+				certChain: mustCertsToChain([]*x509.Certificate{testLeaf, testInter, testRoot}),
+				signature: "qGjS1QmB2xANizjJqrGmIPoojzjBrTV5kgi01p1ELnfKwH4E3UDTZRf-9K7PCEwjt0mOzd1bBmRBKcnWZNFAMvAduBwfAPHFGpX-YKBoRSLHuA6QuiosEydnZEs5ykAR",
+				rootHash:  "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "chain verification fails",
+			args: args{
+				input:     signerTestData,
+				certChain: mustCertsToChain([]*x509.Certificate{testLeaf, testInter, testRootExpired}),
+				signature: "qGjS1QmB2xANizjJqrGmIPoojzjBrTV5kgi01p1ELnfKwH4E3UDTZRf-9K7PCEwjt0mOzd1bBmRBKcnWZNFAMvAduBwfAPHFGpX-YKBoRSLHuA6QuiosEydnZEs5ykAR",
+				rootHash:  sha2Fingerprint(testRoot),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := Verify(tt.args.input, tt.args.certChain, tt.args.signature, tt.args.rootHash); (err != nil) != tt.wantErr {
+				t.Errorf("Verify() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
refs: #593 

Extract a separate verifier/contentsignature module for reuse.

Note that the module isn't accessible on `main`, so we can't just add it to the top level makefile package names. 