### PR TITLE
monitor: build x5u client with timeouts

### DIFF
--- a/tools/autograph-monitor/monitor.go
+++ b/tools/autograph-monitor/monitor.go
@@ -158,7 +158,7 @@ func monitor() (err error) {
 		return fmt.Errorf("Request failed with %s: %s", resp.Status, resp.Body)
 	}
 
-	x5uClient := &http.Client{}
+	x5uClient := defaultX5UClient()
 
 	dec := json.NewDecoder(resp.Body)
 	failed := false

--- a/tools/autograph-monitor/x5uclient.go
+++ b/tools/autograph-monitor/x5uclient.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"time"
+)
+
+// config params from
+// https://github.com/aws/aws-sdk-go-v2/blob/main/aws/transport/http/client.go#L12-L25
+// (Apache v2 licensed)
+
+// Defaults for the HTTPTransportBuilder.
+var (
+	// Default connection pool options
+	DefaultHTTPTransportMaxIdleConns        = 100
+	DefaultHTTPTransportMaxIdleConnsPerHost = 10
+
+	// Default connection timeouts
+	DefaultHTTPTransportIdleConnTimeout       = 90 * time.Second
+	DefaultHTTPTransportTLSHandleshakeTimeout = 10 * time.Second
+	DefaultHTTPTransportExpectContinueTimeout = 1 * time.Second
+
+	// Default to TLS 1.2 for all HTTPS requests.
+	DefaultHTTPTransportTLSMinVersion uint16 = tls.VersionTLS12
+)
+
+// Timeouts for net.Dialer's network connection.
+var (
+	DefaultDialConnectTimeout   = 30 * time.Second
+	DefaultDialKeepAliveTimeout = 30 * time.Second
+)
+
+// DefaultHTTPClientTimeout is the http.Client timeout for the
+// defaultX5UClient
+var DefaultHTTPClientTimeout = 5 * time.Minute
+
+// defaultX5UClient
+func defaultX5UClient() *http.Client {
+	dialer := &net.Dialer{
+		Timeout:   DefaultDialConnectTimeout,
+		KeepAlive: DefaultDialKeepAliveTimeout,
+		// try IPv4 if IPv6 appears to be misconfigured and hanging
+		DualStack: true,
+	}
+	return &http.Client{
+		Timeout: DefaultHTTPClientTimeout,
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           dialer.DialContext,
+			TLSHandshakeTimeout:   DefaultHTTPTransportTLSHandleshakeTimeout,
+			MaxIdleConns:          DefaultHTTPTransportMaxIdleConns,
+			MaxIdleConnsPerHost:   DefaultHTTPTransportMaxIdleConnsPerHost,
+			IdleConnTimeout:       DefaultHTTPTransportIdleConnTimeout,
+			ExpectContinueTimeout: DefaultHTTPTransportExpectContinueTimeout,
+			ForceAttemptHTTP2:     true,
+			TLSClientConfig: &tls.Config{
+				MinVersion: DefaultHTTPTransportTLSMinVersion,
+			},
+		},
+	}
+}

--- a/tools/autograph-monitor/x5uclient_test.go
+++ b/tools/autograph-monitor/x5uclient_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+func Test_defaultX5UClient(t *testing.T) {
+	tests := []struct {
+		name string
+		want *http.Client
+	}{
+		{
+			name: "builds test client with 5 minute timeout",
+			want: &http.Client{
+				Timeout: DefaultHTTPClientTimeout,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := defaultX5UClient()
+			if got.Timeout != tt.want.Timeout {
+				t.Errorf("defaultX5UClient().Timeout = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fix: #674 #594

Set timeouts closer to the aws sdk go v2 s3 client https://github.com/mozilla-services/autograph/issues/674#issuecomment-828510317

We'll need to monitor changes to see if it fixes the issue.