### PR TITLE
monitor: bump go.mod golang version to 1.15

### DIFF
--- a/tools/autograph-monitor/go.mod
+++ b/tools/autograph-monitor/go.mod
@@ -1,6 +1,6 @@
 module github.com/mozilla-services/autograph/tools/autograph-monitor
 
-go 1.13
+go 1.15
 
 require (
 	github.com/PagerDuty/go-pagerduty v1.4.1


### PR DESCRIPTION
blocked on https://github.com/mozilla-services/cloudops-deployment/pull/4236