### PR TITLE
tools: add cloudhsm cleanup scripts

### DIFF
--- a/tools/cloudhsm-cleanup/README.md
+++ b/tools/cloudhsm-cleanup/README.md
@@ -1,0 +1,86 @@
+## CloudHSM cleanup scripts
+
+### Background
+
+* `contentsignaturepki` signers generate new key pairs to sign End
+Entity/Leaf certs at a frequency configurable in the signer
+
+* CloudHSM has [a limit of 3.3k keys per cluster](
+https://docs.aws.amazon.com/cloudhsm/latest/userguide/limits.html)
+
+* new key have labels in the format `<signer id>-<UTC timestamp from
+when the key was generated>` e.g. `normandy-20200806150717` in
+CloudHSM and a row in the autograph `endentities` table with the key
+label and private key handle
+
+These scripts help clean up old keys before hitting the limit.
+
+
+### Cleaning up old key pairs
+
+#### Find key handles for inactive key pairs
+
+1. Source the helper functions `source hsm_cleanup_functions.sh`
+
+1. Run `set_db_env_vars $sops_encrypted_config_file` to decrypt and
+   export env vars to access the autograph database (this might take a
+   few seconds since it runs a few sops decrypt commands)
+
+1. Run `list_inactive_ees_csv` to query and print a list of inactive
+   EEs to delete
+
+1. Run `list_inactive_ees_csv | cut -d ',' -f 2 >
+   inactive_ee_key_labels.txt` to save a list of key labels to
+   delete. It should look something like this:
+
+   ```sh
+   $ head inactive_ee_key_labels.txt
+   aus-20181015205220
+   aus-20181105162523
+   ...
+   ```
+
+1. Run `set_cloudhsm_env_vars $sops_encrypted_config_file` to decrypt
+   and export env vars to access the CloudHSM cluster (this might take
+   a few seconds since it runs a few sops decrypt commands)
+
+1. Run `cat inactive_ee_key_labels.txt | ./find_ec_keys_by_label.sh >
+   inactive_ee_keys.csv` to find HSM key handles for the given
+   labels. (this might take a minute or two since it runs each
+   operation as a single key management command) Example output:
+
+   ```sh
+   $ cat inactive_ee_key_labels.txt | ./find_ec_keys_by_label.sh > inactive_ee_keys.csv
+   public key not found for normandy_cspki-20190520224541
+   private key not found for normandy_cspki-20190520224541
+   ...
+   INFO: success finished searching for EC keys with the provided labels
+   $ head inactive_ee_keys.csv
+   aus-20181015205220,123456
+   aus-20181015205220,123457
+   ...
+   ```
+
+   Keys deleted from earlier runs will not be found. This is expected.
+
+
+#### Delete the keys
+
+1. Run `./delete_keys_by_handle.sh < inactive_ee_keys.csv` to print
+   keys we will delete (but not delete them yet). Example output:
+
+   ```sh
+   $ ./delete_keys_by_handle.sh < inactive_ee_keys.csv
+   ...
+   got label aus-20181015205220 and handle 123456
+   123456
+   provided key label aus-20181015205220 matches label aus-20181015205220 for handle 123456
+   would delete: 123456 for label aus-20181015205220
+   ...
+   success! would delete: 42 keys
+   ```
+
+1. Inspect the output
+
+1. Run `DRY_RUN=0 ./delete_keys_by_handle.sh < inactive_ee_keys.csv`
+   to delete the keys

--- a/tools/cloudhsm-cleanup/delete_keys_by_handle.sh
+++ b/tools/cloudhsm-cleanup/delete_keys_by_handle.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -e
+
+CLOUDHSM_USER=${CLOUDHSM_USER:?}
+CLOUDHSM_PASSWORD=${CLOUDHSM_PASSWORD:?}
+CLOUDHSM_USER_TYPE=${CLOUDHSM_USER_TYPE:-"CU"}
+DRY_RUN=${DRY_RUN:-"1"}
+
+# read CSV lines of key label,handle from stdin
+# check stdin label matches key handle label attr
+# delete keys
+#
+# Defaults to printing keys to delete in dry run mode (set DRY_RUN=0 to delete keys)
+#
+# Requires env vars (use set_cloudhsm_env_vars to set them):
+#
+# CLOUDHSM_USER
+# CLOUDHSM_PASSWORD
+#
+# Accepts the optional env vars:
+#
+# CLOUDHSM_USER_TYPE
+# DRY_RUN
+#
+TMP=$(mktemp)
+
+keys_seen=0
+while IFS= read -r keyline; do
+    # truncate the tempfile
+    true > "$TMP"
+    echo
+
+    keylabel=$(echo "$keyline" | cut -d ',' -f 1)
+    keyhandle=$(echo "$keyline" | cut -d ',' -f 2)
+    echo "got label ${keylabel} and handle ${keyhandle}" >&2;
+
+    # get the key label for the handle
+    #
+    # 3 is OBJ_ATTR_LABEL
+    # https://docs.aws.amazon.com/cloudhsm/latest/userguide/key-attribute-table.html
+    #
+    /opt/cloudhsm/bin/key_mgmt_util singlecmd loginHSM -u "$CLOUDHSM_USER_TYPE" -s "$CLOUDHSM_USER" -p "$CLOUDHSM_PASSWORD" getAttribute -o "$keyhandle" -a 3 -out "$TMP" > /dev/null
+    keylabelattr="$(tail -n 1 "$TMP")"
+    echo "${keyhandle}"  >&2;
+
+    if [[ ! "$keylabel" = "$keylabelattr" ]]; then
+	echo "Aborting! provided key label ${keylabel} does not match label ${keylabelattr} for handle ${keyhandle}" >&2;
+	exit 1
+    else
+	echo "provided key label ${keylabel} matches label ${keylabelattr} for handle ${keyhandle}" >&2;
+    fi
+
+    if [[ "$DRY_RUN" = "0" ]]; then
+	echo "deleting: ${keyhandle} for label ${keylabel}"
+	/opt/cloudhsm/bin/key_mgmt_util singlecmd loginHSM -u "$CLOUDHSM_USER_TYPE" -s "$CLOUDHSM_USER" -p "$CLOUDHSM_PASSWORD" deleteKey -k "$keyhandle"
+    else
+	echo "would delete: ${keyhandle} for label ${keylabel}"
+    fi
+    ((keys_seen+=1))
+done
+rm "$TMP"
+
+if [[ "$DRY_RUN" = "0" ]]; then
+    echo "success! deleted: ${keys_seen} keys" >&2;
+else
+    echo "success! would delete: ${keys_seen} keys" >&2;
+fi

--- a/tools/cloudhsm-cleanup/find_ec_keys_by_label.sh
+++ b/tools/cloudhsm-cleanup/find_ec_keys_by_label.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -e
+
+CLOUDHSM_USER=${CLOUDHSM_USER:?}
+CLOUDHSM_PASSWORD=${CLOUDHSM_PASSWORD:?}
+CLOUDHSM_USER_TYPE=${CLOUDHSM_USER_TYPE:-"CU"}
+
+# read key labels from stdin
+# search for EC public and private keys matching the label
+# write a CSV of label,handle to stdout where the handle can be an empty string
+#
+# Requires env vars (use set_cloudhsm_env_vars to set them):
+#
+# CLOUDHSM_USER
+# CLOUDHSM_PASSWORD
+#
+# Accepts the optional env vars:
+#
+# CLOUDHSM_USER_TYPE
+#
+
+TMP=$(mktemp)
+
+while IFS= read -r keylabel; do
+    # truncate the tempfile
+    true > "$TMP"
+
+    # echo "checking for public EC keys with label: ${keylabel}" >&2;
+    # -t 3 searches for EC key types
+    # -c 2 searches for public keys (3 for private keys)
+    #
+    # https://docs.aws.amazon.com/cloudhsm/latest/userguide/key_mgmt_util-findKey.html
+    /opt/cloudhsm/bin/key_mgmt_util singlecmd loginHSM -u "$CLOUDHSM_USER_TYPE" -s "$CLOUDHSM_USER" -p "$CLOUDHSM_PASSWORD" findKey -c 2 -t 3 -l "$keylabel" > "$TMP"
+    grep -E "Total number of keys present: 1\s*$" "$TMP" > /dev/null || echo "INFO: public key not found for $keylabel it may have already been deleted" >&2;
+    # cut uses a tab delimiter by default
+    pubkey_handle=$(tr -d '\n' < "$TMP" | grep -o 'Handles of matching keys:\s*\([0-9]*\)' | cut -f 2)
+    # echo "found public EC key handle ${pubkey_handle} for label: ${keylabel}" >&2;
+
+    # truncate the tempfile
+    true > "$TMP"
+
+    # echo "checking for private EC keys with label: ${keylabel}" >&2;
+    /opt/cloudhsm/bin/key_mgmt_util singlecmd loginHSM -u "$CLOUDHSM_USER_TYPE" -s "$CLOUDHSM_USER" -p "$CLOUDHSM_PASSWORD" findKey -c 3 -t 3 -l "$keylabel" > "$TMP"
+    grep -E "Total number of keys present: 1$" "$TMP" > /dev/null || echo "INFO: private key not found for $keylabel it may have already been deleted" >&2;
+    # cut uses a tab delimiter by default
+    privkey_handle=$(tr -d '\n' < "$TMP" | grep -o 'Handles of matching keys:\s*\([0-9]*\)' | cut -f 2)
+    # echo "found private EC key handle ${privkey_handle} for label: ${keylabel}" >&2;
+
+    # write non-empty handles to stdout
+    if [[ ! "" = "$pubkey_handle" ]]; then
+	echo "${keylabel},${pubkey_handle}"
+    fi
+    if [[ ! "" = "$privkey_handle" ]]; then
+	echo "${keylabel},${privkey_handle}"
+    fi
+done
+rm "$TMP"
+echo "INFO: success finished searching for EC keys with the provided labels" >&2;

--- a/tools/cloudhsm-cleanup/hsm_cleanup_functions.sh
+++ b/tools/cloudhsm-cleanup/hsm_cleanup_functions.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# decrypt sops-encrypted autograph config at $1 and set env vars to
+# access the autograph DB
+function set_db_env_vars(){
+    DB_HOST="$(sudo sops --extract '["database"]["host"]' -d "$1" | cut -d ':' -f 1)"
+    DB_PORT="$(sudo sops --extract '["database"]["host"]' -d "$1" | cut -d ':' -f 2)"
+    DB_NAME="$(sudo sops --extract '["database"]["name"]' -d "$1")"
+    DB_USER="$(sudo sops --extract '["database"]["user"]' -d "$1")"
+    PGPASSWORD="$(sudo sops --extract '["database"]["password"]' -d "$1")"
+
+    export DB_HOST
+    export DB_PORT
+    export DB_NAME
+    export DB_USER
+    export PGPASSWORD
+}
+
+# decrypt sops-encrypted autograph config at $1 and set env vars to
+# access CloudHSM
+function set_cloudhsm_env_vars(){
+    CLOUDHSM_USER="$(sudo sops --extract '["hsm"]["pin"]' -d "$1" | cut -d ':' -f 1)"
+    CLOUDHSM_PASSWORD="$(sudo sops --extract '["hsm"]["pin"]' -d "$1" | cut -d ':' -f 2)"
+    CLOUDHSM_LABEL="$(sudo sops --extract '["hsm"]["tokenlabel"]' -d "$1")"
+
+    export CLOUDHSM_USER
+    export CLOUDHSM_PASSWORD
+    export CLOUDHSM_LABEL
+}
+
+# open a psql shell in the autograph DB using env vars from set_db_env_vars
+function db_shell(){
+    psql --host="$DB_HOST" \
+         --port="$DB_PORT" \
+         --username="$DB_USER" \
+         --dbname="$DB_NAME"
+}
+
+# list inactive DB end entities rows created more than 90 days ago
+# write them to stdout in CSV format row using env vars
+# from set_db_env_vars
+function list_inactive_ees_csv(){
+    psql --host="$DB_HOST" \
+         --port="$DB_PORT" \
+         --username="$DB_USER" \
+         --dbname="$DB_NAME" \
+         --command="COPY (SELECT id, label, hsm_handle, created_at FROM endentities WHERE is_current=FALSE AND created_at < (NOW()::DATE - 90) ORDER BY signer_id, created_at ASC) TO STDOUT CSV"
+}


### PR DESCRIPTION
refs: https://mozilla-hub.atlassian.net/browse/ITSEC-116

Adds scripts to help clean up old CloudHSM keys.

The scripts pass shellcheck without errors and earlier versions were tested in stage.

r? @hwine 