### PR TITLE
CI and dev fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,9 +86,9 @@ generate:
 # app-hsm -> monitor-hsm-lambda-emulator (app-hsm writes chains and updated config to shared /tmp volume)
 #
 build: generate
-	docker-compose build --no-cache --parallel app db
-	docker-compose build --no-cache --parallel app-hsm monitor
-	docker-compose build --no-cache --parallel monitor-lambda-emulator monitor-hsm-lambda-emulator
+	DOCKER_BUILDKIT=0 COMPOSE_DOCKER_CLI_BUILD=0 docker-compose build --no-cache --parallel app db
+	DOCKER_BUILDKIT=0 COMPOSE_DOCKER_CLI_BUILD=0 docker-compose build --no-cache --parallel app-hsm monitor
+	DOCKER_BUILDKIT=0 COMPOSE_DOCKER_CLI_BUILD=0 docker-compose build --no-cache --parallel monitor-lambda-emulator monitor-hsm-lambda-emulator
 
 integration-test:
 	./bin/run_integration_tests.sh

--- a/tools/autograph-client/integration_test_xpis.sh
+++ b/tools/autograph-client/integration_test_xpis.sh
@@ -12,9 +12,11 @@ SIGNER_ID_PREFIX=${SIGNER_ID_PREFIX:-""}
 SIGNER_ID=${SIGNER_ID_PREFIX}webextensions-rsa \
 	 TRUST_ROOTS=dev-webext-rsa-root.pem \
 	 TARGET="$AUTOGRAPH_URL" \
+	 CONFIG=${SIGNER_ID_PREFIX}webextensions-rsa \
          ./build_test_xpis.sh /app/src/autograph/signer/xpi/test/fixtures/ublock_origin-1.33.2-an+fx.xpi
 
 SIGNER_ID=${SIGNER_ID_PREFIX}extensions-ecdsa \
 	 TRUST_ROOTS=dev-ext-ecdsa-root.pem \
 	 TARGET="$AUTOGRAPH_URL" \
+	 CONFIG=${SIGNER_ID_PREFIX}extensions-ecdsa \
 	 ./build_test_xpis.sh /app/src/autograph/signer/xpi/test/fixtures/ublock_origin-1.33.2-an+fx.xpi


### PR DESCRIPTION
Changes:
* disable buildkit for docker desktop builds (broke newer docker-compose on OSX)
* distinguish XPIs by signer id in CI