### PR TITLE
signer: revert XPI EE validity to the interval UTC now and 87600h later

### DIFF
--- a/signer/xpi/x509.go
+++ b/signer/xpi/x509.go
@@ -108,8 +108,8 @@ func (s *XPISigner) makeTemplate(cn string) *x509.Certificate {
 			Province:           []string{"CA"},
 			Locality:           []string{"Mountain View"},
 		},
-		NotBefore:          EENotBefore,
-		NotAfter:           EENotBefore.Add(87600 * time.Hour), // ten year
+		NotBefore:          time.Now().UTC(),
+		NotAfter:           time.Now().UTC().Add(87600 * time.Hour), // roughly ten years later
 		SignatureAlgorithm: s.issuerCert.SignatureAlgorithm,
 		KeyUsage:           x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:        []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},

--- a/signer/xpi/x509_test.go
+++ b/signer/xpi/x509_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"testing"
+	"time"
 
 	"go.mozilla.org/cose"
 )
@@ -90,6 +91,25 @@ func TestMakeEndEntity(t *testing.T) {
 		}
 	})
 
+	t.Run("should set EE NotBefore to UTC now", func(t *testing.T) {
+		t.Parallel()
+
+		s := initSigner(t, 3)
+
+		testid := "foo"
+		cert, _, err := s.MakeEndEntity(testid, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		timeSinceNotBefore := time.Now().UTC().Sub(cert.NotBefore)
+		if timeSinceNotBefore.Seconds() <= 0 {
+			t.Fatalf("cert is not yet valid; got %f seconds since EE NotBefore", timeSinceNotBefore.Seconds())
+		}
+		// see GH #739 for details
+		if timeSinceNotBefore.Minutes() > 5 {
+			t.Fatalf("more than five minutes since cert; got %f seconds since EE NotBefore", timeSinceNotBefore.Seconds())
+		}
+	})
 }
 
 func TestGetIssuerRSAKeySize(t *testing.T) {

--- a/signer/xpi/xpi.go
+++ b/signer/xpi/xpi.go
@@ -56,14 +56,6 @@ const (
 	rsaKeyMinSize = 2048
 )
 
-var (
-	// EENotBefore is the NotBefore value used in generated
-	// EE/leaf certs. Fx ignores EE certs when it verifies addons,
-	// but we pin it to 2020-01-01 so we can use existing chain
-	// verification logic in tests and the monitor
-	EENotBefore = time.Date(2020, time.January, 1, 0, 0, 0, 0, time.UTC)
-)
-
 // An XPISigner is configured to issue detached PKCS7 and COSE
 // signatures for Firefox Add-ons of various types.
 type XPISigner struct {

--- a/tools/autograph-client/build_test_xpis.sh
+++ b/tools/autograph-client/build_test_xpis.sh
@@ -26,6 +26,11 @@ else
     COMMON_ARGS="-t $TARGET -f $INPUT_FILE -u $HAWK_USER -p $HAWK_SECRET -cn $CN -k $SIGNER_ID -r $TRUST_ROOTS -vt $VERIFICATION_TIME"
 fi
 
+VERIFY=${VERIFY:-"1"}
+if [ "$VERIFY" = "0" ]; then
+    COMMON_ARGS="$COMMON_ARGS -noverify"
+fi
+
 # only PKCS7 SHA1
 go run client.go $COMMON_ARGS -pk7digest sha1 -o ${OUTPUT_BASENAME}-SHA1.zip
 

--- a/tools/autograph-client/client.go
+++ b/tools/autograph-client/client.go
@@ -140,13 +140,13 @@ examples:
 	flag.Var(&algs, "c", "a COSE Signature algorithm to sign an XPI with can be used multiple times")
 	flag.StringVar(&pk7digest, "pk7digest", "", "an optional PK7 digest algorithm to use for XPI file signing, either 'sha1' (default) or 'sha256'.")
 	flag.StringVar(&rootPath, "r", "/path/to/root.pem", "Path to a PEM file of root certificates")
-	flag.StringVar(&verificationTimeInput, "vt", "", "Time to verify XPI signatures at in RFC3339 format. Defaults to time.Now().")
+	flag.StringVar(&verificationTimeInput, "vt", "", "Time to verify XPI signatures at in RFC3339 format. Defaults to at client invokation + 1 minute to account for time to transfer and sign the XPI")
 
 	flag.BoolVar(&debug, "D", false, "debug logs: show raw requests & responses")
 	flag.Parse()
 
 	if verificationTimeInput == "" {
-		verificationTime = time.Now()
+		verificationTime = time.Now().UTC().Add(time.Minute)
 		if debug {
 			fmt.Printf("Using default verification time: %q\n", verificationTime)
 		}

--- a/tools/autograph-client/integration_test_xpis.sh
+++ b/tools/autograph-client/integration_test_xpis.sh
@@ -25,5 +25,5 @@ SIGNER_ID=${SIGNER_ID_PREFIX}extensions-ecdsa-expired-chain \
 	 TRUST_ROOTS=dev-ext-ecdsa-expired-root.pem \
 	 TARGET="$AUTOGRAPH_URL" \
 	 CONFIG=${SIGNER_ID_PREFIX}extensions-ecdsa-expired-chain \
-	 VERIFICATION_TIME="2020-01-01T01:01:01Z" \
+	 VERIFY=0 \
 	 ./build_test_xpis.sh /app/src/autograph/signer/xpi/test/fixtures/ublock_origin-1.33.2-an+fx.xpi


### PR DESCRIPTION
fix #739

Changes:
* set XPI EE validity to UTC Now and ~10 years later and add a unit test since apparently that was untested. Fx uses the `notBefore` for a blocklist input, so it isn't completely ignored and wasn't safe to hardcode it as mentioned in https://bugzilla.mozilla.org/show_bug.cgi?id=1549018#c21. Fixes #739.
* add a `-noverify` option to the golang client used in integration tests (refs #163)
* disable verification for the expired chain in integration tests (we test that autograph signs XPIs with an expired chain but don't verify the result). Golang's [Certificate.Verify](https://pkg.go.dev/crypto/x509#Certificate.Verify) does not have an option to ignore the EE cert and match Fx/NSS behavior. We'd need to hack together our own version, which is out of scope for this PR.


NB: With this change and #722, it's possible to create an EE with validity that doesn't overlap the rest of an expired chain:

```
EE                              |<----->|
Inter       |<----->|
Root  |<----------->|
```

It that occurs it might break monitoring.