### PR TITLE
Fix 738 endpoint for keyid lookup

### DIFF
--- a/authorize.go
+++ b/authorize.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"net/http"
+	"regexp"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -23,6 +24,11 @@ type authorization struct {
 	Key     string
 	Signers []string
 }
+
+// authIDFormat is a regex for the format Authorization IDs must follow
+const authIDFormat = `^[a-zA-Z0-9-_]{1,255}$`
+
+var authIDFormatRegexp = regexp.MustCompile(authIDFormat)
 
 func abs(d time.Duration) time.Duration {
 	if d < 0 {

--- a/bin/run_integration_tests.sh
+++ b/bin/run_integration_tests.sh
@@ -50,6 +50,24 @@ docker-compose logs monitor-lambda-emulator
 docker-compose exec monitor-hsm-lambda-emulator "/usr/local/bin/test_monitor.sh"
 docker-compose logs monitor-hsm-lambda-emulator
 
+echo "checking read-only API"
+# user bob doesn't exist in the softhsm config
+docker-compose run \
+	       --rm \
+	       --user 0 \
+	       -e CHECK_BOB=1 \
+	       -e AUTOGRAPH_URL=http://app:8000 \
+	       --workdir /app/src/autograph/tools/autograph-client \
+	       --entrypoint ./integration_test_api.sh \
+	       app
+docker-compose run \
+	       --rm \
+	       --user 0 \
+	       -e AUTOGRAPH_URL=http://app-hsm:8001 \
+	       --workdir /app/src/autograph/tools/autograph-client \
+	       --entrypoint ./integration_test_api.sh \
+	       app-hsm
+
 echo "checking XPI signing"
 docker-compose run \
 	       --rm \

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -243,3 +243,50 @@ Content-Type: text/plain; charset=utf-8
 "build": "https://travis-ci.org/mozilla-services/autograph"
 }
 ```
+
+## /auths/:auth_id/keyids
+
+### Request
+
+Get the keyids an auth HAWK ID can sign with. Example:
+
+```bash
+GET /auths/alice/keyids
+Host: autograph.example.net
+Authorization: Hawk id="dh37fgj492je", ts="1353832234", nonce="j4h3g2", ext="some-app-ext-data", mac="6R4rV5iE+NPoym+WwjeHzjAGXUtLNIxmo1vpMofpLAE="
+```
+
+### Response
+
+400 Bad Request when the request includes a non-empty body
+401 Unauthorized when the Authorization header is missing or HAWK authorization fails
+403 Forbidden when the auth ID does not match the HAWK ID from the authorization header. An authorization does not have permission to get keyids for other signers.
+404 Not Found when the auth ID does not match the [auth ID format](https://github.com/mozilla-services/autograph/blob/main/authorize.go#L29)
+405 Method Not Allowed when the request method is not GET
+200 OK when the authorization is valid and path and auth IDs match. Example response body with Content-Type application/json:
+
+```json
+    [
+        "apk_cert_with_ecdsa_sha256",
+        "apk_cert_with_ecdsa_sha256_v3",
+        "appkey1",
+        "appkey2",
+        "dummyrsa",
+        "dummyrsapss",
+        "extensions-ecdsa",
+        "extensions-ecdsa-expired-chain",
+        "legacy_apk_with_rsa",
+        "normandy",
+        "pgpsubkey",
+        "randompgp",
+        "remote-settings",
+        "testapp-android",
+        "testapp-android-legacy",
+        "testapp-android-v3",
+        "testauthenticode",
+        "testmar",
+        "testmarecdsa",
+        "webextensions-rsa",
+        "webextensions-rsa-with-recommendation"
+    ]
+```

--- a/handlers.go
+++ b/handlers.go
@@ -18,6 +18,8 @@ import (
 	"path"
 	"time"
 
+	"github.com/gorilla/mux"
+
 	"github.com/mozilla-services/autograph/formats"
 	"github.com/mozilla-services/autograph/signer"
 	log "github.com/sirupsen/logrus"
@@ -371,4 +373,55 @@ func handleVersion(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	http.ServeContent(w, r, "version.json", stat.ModTime(), f)
+}
+
+// handleGetAuthKeyIDs returns the signer (keyID param for the API)
+// for the authenticated user
+func (a *autographer) handleGetAuthKeyIDs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		httpError(w, r, http.StatusMethodNotAllowed, "%s method not allowed; endpoint accepts GET only", r.Method)
+		return
+	}
+	if r.Body != nil {
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			httpError(w, r, http.StatusBadRequest, "failed to read request body: %s", err)
+			return
+		}
+		if len(body) > 0 {
+			httpError(w, r, http.StatusBadRequest, "endpoint received unexpected request body")
+			return
+		}
+	}
+
+	pathAuthID, ok := mux.Vars(r)["auth_id"]
+	if !ok {
+		httpError(w, r, http.StatusInternalServerError, "route is improperly configured")
+		return
+	}
+	if !authIDFormatRegexp.MatchString(pathAuthID) {
+		httpError(w, r, http.StatusBadRequest, "auth_id in URL path '%s' is invalid, it must match %s", pathAuthID, authIDFormat)
+		return
+	}
+	_, headerAuthID, err := a.authorizeHeader(r)
+	if err != nil {
+		httpError(w, r, http.StatusUnauthorized, "authorization verification failed: %v", err)
+		return
+	}
+
+	if headerAuthID != pathAuthID {
+		httpError(w, r, http.StatusForbidden, "Authorized user %q cannot request keyids for user %q", headerAuthID, pathAuthID)
+		return
+	}
+
+	signerIDsJSON, err := json.Marshal(a.authBackend.getSignerIDsForUser(pathAuthID))
+	if err != nil {
+		log.Errorf("handleGetAuthKeyIDs failed to marshal JSON with error: %s", err)
+		httpError(w, r, http.StatusInternalServerError, "error marshaling response JSON")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(signerIDsJSON)
 }

--- a/main.go
+++ b/main.go
@@ -213,6 +213,7 @@ func run(conf configuration, listen string, debug bool) {
 	router.HandleFunc("/sign/file", ag.handleSignature).Methods("POST")
 	router.HandleFunc("/sign/data", ag.handleSignature).Methods("POST")
 	router.HandleFunc("/sign/hash", ag.handleSignature).Methods("POST")
+	router.HandleFunc("/auths/{auth_id:[a-zA-Z0-9-_]{1,255}}/keyids", ag.handleGetAuthKeyIDs).Methods("GET")
 	if os.Getenv("AUTOGRAPH_PROFILE") == "1" {
 		err = setRuntimeConfig()
 		if err != nil {

--- a/memory_backend.go
+++ b/memory_backend.go
@@ -38,6 +38,9 @@ func newInMemoryAuthBackend() (backend *inMemoryBackend) {
 
 // addAuth adds an authorization to the auth map or errors
 func (b *inMemoryBackend) addAuth(auth *authorization) (err error) {
+	if !authIDFormatRegexp.MatchString(auth.ID) {
+		return fmt.Errorf("authorization id '%s' is invalid, it must match %s", auth.ID, authIDFormat)
+	}
 	_, getAuthErr := b.getAuthByID(auth.ID)
 	switch getAuthErr {
 	case nil:

--- a/tools/autograph-client/client.go
+++ b/tools/autograph-client/client.go
@@ -171,6 +171,8 @@ examples:
 		filebytes, err := ioutil.ReadFile(infile)
 		if err != nil {
 			log.Fatal(err)
+	cli := getHTTPClient()
+
 		}
 		data = base64.StdEncoding.EncodeToString(filebytes)
 	}
@@ -201,10 +203,6 @@ examples:
 	if err != nil {
 		log.Fatal(err)
 	}
-	tr := &http.Transport{
-		DisableKeepAlives: false,
-	}
-	cli := &http.Client{Transport: tr}
 
 	var roots *x509.CertPool
 	if rootPath != "/path/to/root.pem" {
@@ -377,6 +375,13 @@ examples:
 		}
 		time.Sleep(time.Second)
 	}
+}
+
+func getHTTPClient() http.Client {
+	tr := &http.Transport{
+		DisableKeepAlives: false,
+	}
+	return &http.Client{Transport: tr}
 }
 
 // parseVerificationTime parses an RFC3339 timestamp or exits

--- a/tools/autograph-client/client.go
+++ b/tools/autograph-client/client.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -64,17 +65,21 @@ func main() {
 	var (
 		userid, pass, data, hash, url, infile, outfile, outkeyfile, keyid, cn, pk7digest, rootPath, verificationTimeInput string
 		iter, maxworkers, sa                                                                                              int
-		debug, noVerify                                                                                                   bool
+		debug, listKeyIDs, noVerify                                                                                       bool
 		err                                                                                                               error
 		requests                                                                                                          []formats.SignatureRequest
 		algs                                                                                                              coseAlgs
 		verificationTime                                                                                                  time.Time
 	)
 	flag.Usage = func() {
-		fmt.Print("autograph-client - simple command line client to the autograph service\n\n")
+		fmt.Print("autograph-client - command line client to the autograph service\n\n")
 		flag.PrintDefaults()
 		fmt.Print(`
 examples:
+
+* pretty print keyids for a user to stdout
+	$ go run client.go -listkeyids -u alice
+
 * sign an APK, returns a signed APK
 	$ go run client.go -f signed.apk -o test.apk -k testapp-android
 	$ /opt/android-sdk/build-tools/27.0.3/apksigner verify -v test.apk
@@ -142,6 +147,7 @@ examples:
 	flag.StringVar(&rootPath, "r", "/path/to/root.pem", "Path to a PEM file of root certificates")
 	flag.StringVar(&verificationTimeInput, "vt", "", "Time to verify XPI signatures at in RFC3339 format. Defaults to at client invokation + 1 minute to account for time to transfer and sign the XPI")
 	flag.BoolVar(&noVerify, "noverify", false, "Skip verifying successful responses. Default false.")
+	flag.BoolVar(&listKeyIDs, "listkeyids", false, "List key IDs for the signer")
 
 	flag.BoolVar(&debug, "D", false, "debug logs: show raw requests & responses")
 	flag.Parse()
@@ -158,6 +164,12 @@ examples:
 		}
 	}
 
+	cli := getHTTPClient()
+	if listKeyIDs {
+		listKeyIDsForCurrentUser(cli, debug, url, userid, pass)
+		os.Exit(0)
+	}
+
 	if data != "base64(data)" {
 		log.Printf("signing data %q", data)
 		url = url + "/sign/data"
@@ -171,11 +183,10 @@ examples:
 		filebytes, err := ioutil.ReadFile(infile)
 		if err != nil {
 			log.Fatal(err)
-	cli := getHTTPClient()
-
 		}
 		data = base64.StdEncoding.EncodeToString(filebytes)
 	}
+
 	request := formats.SignatureRequest{
 		Input: data,
 		KeyID: keyid,
@@ -377,11 +388,58 @@ examples:
 	}
 }
 
-func getHTTPClient() http.Client {
+func getHTTPClient() *http.Client {
 	tr := &http.Transport{
 		DisableKeepAlives: false,
 	}
 	return &http.Client{Transport: tr}
+}
+
+func listKeyIDsForCurrentUser(cli *http.Client, debug bool, url, userid, pass string) {
+	url = url + "/auths/" + userid + "/keyids"
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Authorization", hawk.NewRequestAuth(req,
+		&hawk.Credentials{
+			ID:   userid,
+			Key:  pass,
+			Hash: sha256.New},
+		0).RequestHeader())
+	if debug {
+		fmt.Printf("DEBUG: sending request\nDEBUG: %+v\n", req)
+	}
+	resp, err := cli.Do(req)
+	if err != nil || resp == nil {
+		log.Fatal(err)
+	}
+	if debug {
+		fmt.Printf("DEBUG: received response\nDEBUG: %+v\n", resp)
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if debug {
+		fmt.Printf("DEBUG: %s\n", body)
+	}
+	if resp.StatusCode != http.StatusOK {
+		log.Fatalf("%s %s", resp.Status, body)
+	}
+	// pretty print output
+	var keyIDs []string
+	err = json.Unmarshal(body, &keyIDs)
+	if err != nil {
+		log.Fatalf("error unmarshaling JSON %q", err)
+	}
+	indentedJSON, err := json.MarshalIndent(keyIDs, "", "    ")
+	if err != nil {
+		log.Fatalf("error marshal indenting JSON %q", err)
+	}
+	fmt.Println(string(indentedJSON))
 }
 
 // parseVerificationTime parses an RFC3339 timestamp or exits

--- a/tools/autograph-client/integration_test_api.sh
+++ b/tools/autograph-client/integration_test_api.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+# CI script to check the /auths/:auth_id/keyids endpoint
+
+AUTOGRAPH_URL=${AUTOGRAPH_URL:?}
+CHECK_BOB=${CHECK_BOB:-"0"}
+
+# check alice has access to normandy
+go run client.go -t "$AUTOGRAPH_URL" -listkeyids -u alice | grep normandy
+
+if [ "$CHECK_BOB" = "1" ]; then
+    # but bob doesn't
+    go run client.go -t "$AUTOGRAPH_URL" -listkeyids -u bob -p 9vh6bhlc10y63ow2k4zke7k0c3l9hpr8mo96p92jmbfqngs9e7d | grep -v normandy
+    # bob should only have access to appkey2
+    go run client.go -t "$AUTOGRAPH_URL" -listkeyids -u bob -p 9vh6bhlc10y63ow2k4zke7k0c3l9hpr8mo96p92jmbfqngs9e7d | grep appkey2
+fi
+
+# invalid user and auth should return a 401 error
+go run client.go -t "$AUTOGRAPH_URL" -listkeyids -u nobody 2>&1 | grep 401


### PR DESCRIPTION
fix #737 using the first proposed approach

Changes:
* define a user/auth ID format (like the signer id format); validate users at boot; and refactor `autographer.addAuthorizations` tests in https://github.com/mozilla-services/autograph/pull/749/commits/97ce5b27d13bd98a195cefb99abdd04aefa63af8
* implement `/auths/:auth_id/keyids` more or less as proposed in #737; add support to the golang client and integration tests (handler tests don't exercise the mux router vars)