### PR TITLE
tools: monitor: improve error message when monitor request errors

### DIFF
--- a/tools/autograph-monitor/monitor.go
+++ b/tools/autograph-monitor/monitor.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -147,7 +148,11 @@ func monitor() (err error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		return fmt.Errorf("request failed with %s: %s", resp.Status, resp.Body)
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Printf("error reading failed monitor response body: %s", err)
+		}
+		return fmt.Errorf("monitor request failed with status %s and body: %s", resp.Status, body)
 	}
 
 	x5uClient := defaultX5UClient()


### PR DESCRIPTION
read error response body

fix ITSEC-103

functional tests:

- [x] error response logs the response body

```
AUTOGRAPH_URL=http://httpbin.org/status/500 AUTOGRAPH_KEY=invalid ./autograph-monitor 
2021/09/15 19:55:31 Retrieving monitoring data from http://httpbin.org/status/500
2021/09/15 19:55:31 Garbage collected in 12.348208ms
error: monitor request failed with status 400 BAD REQUEST and body: Invalid status code
```

instead of the response body pointer:

```
AUTOGRAPH_URL=http://httpbin.org/status/500 AUTOGRAPH_KEY=invalid ./autograph-monitor 
2021/09/15 20:44:04 Retrieving monitoring data from http://httpbin.org/status/500
2021/09/15 20:44:04 Garbage collected in 19.938792ms
error: request failed with 400 BAD REQUEST: &{%!s(*http.body=&{0xc000122ac8 <nil> <nil> true false {0 0} false false false <nil>}) {%!s(int32=0) %!s(uint32=0)} %!s(bool=false) <nil> %!s(func(error) error=0x6b6560) %!s(func() error=0x6b64e0)}
```