### PR TITLE
Update: Docker compose is a sub command now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
   unit-test:
     # based on the official golang image with more docker stuff
     docker:
-      - image: circleci/golang:1.16-buster
+      - image: cimg/go:1.16-buster
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -80,7 +80,7 @@ jobs:
   build-integrationtest-verify:
     # based on the official golang image with more docker stuff
     docker:
-      - image: circleci/golang:1.16-buster
+      - image: cimg/go:1.16-buster
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -176,14 +176,16 @@ workflows:
               only: /[0-9]\.[0-9]+\.[0-9]+/
             branches:
               only: main
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 1 * * *"
-          filters:
-            branches:
-              only: main
-    jobs:
-      - lint-vet-fmt
-      - unit-test
-      - build-integrationtest-verify
+##  # disable until tests green -- all the failed runs make good runs
+##  # hard to spot
+##  nightly:
+##    triggers:
+##      - schedule:
+##          cron: "0 1 * * *"
+##          filters:
+##            branches:
+##              only: main
+##    jobs:
+##      - lint-vet-fmt
+##      - unit-test
+##      - build-integrationtest-verify

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
   unit-test:
     # based on the official golang image with more docker stuff
     docker:
-      - image: cimg/go:1.16-buster
+      - image: cimg/go:1.16
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -80,7 +80,7 @@ jobs:
   build-integrationtest-verify:
     # based on the official golang image with more docker stuff
     docker:
-      - image: cimg/go:1.16-buster
+      - image: cimg/go:1.16
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,11 +71,11 @@ jobs:
       - run:
           name: build unit-test docker images
           command: |
-            docker-compose build --no-cache unit-test
+            docker compose build --no-cache unit-test
       - run:
           name: run unit-test docker image and report coverage
           command: |
-            docker-compose run unit-test
+            docker compose run unit-test
 
   build-integrationtest-verify:
     # based on the official golang image with more docker stuff

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,16 +107,17 @@ jobs:
       #
       # Use /go/src/app since we don't have permissions to make
       # directories in other locations
+      # CircleCI NextGen images moved this to $HOME/go/...
       - run:
           name: docker save built images
           no_output_timeout: 30m
           command: |
-            mkdir -p /go/src/app/cache
-            docker save "autograph-app" | gzip -c > /go/src/app/cache/docker.tgz
+            mkdir -p $HOME/go/src/app/cache
+            docker save "autograph-app" | gzip -c > $HOME/go/src/app/cache/docker.tgz
       - save_cache:
           key: v4-{{ .Branch }}-{{ epoch }}
           paths:
-            - /go/src/app/cache/docker.tgz
+            - $HOME/go/src/app/cache/docker.tgz
 
   deploy:
     docker:
@@ -127,7 +128,7 @@ jobs:
           key: v4-{{.Branch}}
       - run:
           name: Restore Docker image cache
-          command: gunzip -c /go/src/app/cache/docker.tgz | docker load
+          command: gunzip -c $HOME/go/src/app/cache/docker.tgz | docker load
 
       - run:
           name: Deploy to Dockerhub

--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,9 @@ gpg-test-clean:
 # app-hsm -> monitor-hsm-lambda-emulator (app-hsm writes chains and updated config to shared /tmp volume)
 #
 build: generate
-	DOCKER_BUILDKIT=0 COMPOSE_DOCKER_CLI_BUILD=0 docker-compose build --no-cache --parallel app db
-	DOCKER_BUILDKIT=0 COMPOSE_DOCKER_CLI_BUILD=0 docker-compose build --no-cache --parallel app-hsm monitor
-	DOCKER_BUILDKIT=0 COMPOSE_DOCKER_CLI_BUILD=0 docker-compose build --no-cache --parallel monitor-lambda-emulator monitor-hsm-lambda-emulator
+	DOCKER_BUILDKIT=0 COMPOSE_DOCKER_CLI_BUILD=0 docker compose build --no-cache --parallel app db
+	DOCKER_BUILDKIT=0 COMPOSE_DOCKER_CLI_BUILD=0 docker compose build --no-cache --parallel app-hsm monitor
+	DOCKER_BUILDKIT=0 COMPOSE_DOCKER_CLI_BUILD=0 docker compose build --no-cache --parallel monitor-lambda-emulator monitor-hsm-lambda-emulator
 
 integration-test:
 	./bin/run_integration_tests.sh

--- a/bin/run_integration_tests.sh
+++ b/bin/run_integration_tests.sh
@@ -4,14 +4,14 @@ set -e
 set -o pipefail
 
 # stop everything currently running
-docker-compose down -v
+docker compose down -v
 
 # wipe DB state from previous runs
-docker-compose stop db
-docker-compose rm -f db
+docker compose stop db
+docker compose rm -f db
 
 # start db and app servers
-docker-compose up -d --force-recreate db app app-hsm
+docker compose up -d --force-recreate db app app-hsm
 
 echo "waiting for autograph-app to start"
 while test "true" != "$(docker inspect -f {{.State.Running}} autograph-app)"; do
@@ -29,8 +29,8 @@ docker cp autograph-app-hsm:/tmp/normandy_dev_root_hash.txt .
 APP_HSM_NORMANDY_ROOT_HASH=$(grep '[0-9A-F]' normandy_dev_root_hash.txt | tr -d '\r\n')
 
 # start the monitor lambda emulators
-docker-compose up -d monitor-lambda-emulator
-AUTOGRAPH_ROOT_HASH=$APP_HSM_NORMANDY_ROOT_HASH docker-compose up -d monitor-hsm-lambda-emulator
+docker compose up -d monitor-lambda-emulator
+AUTOGRAPH_ROOT_HASH=$APP_HSM_NORMANDY_ROOT_HASH docker compose up -d monitor-hsm-lambda-emulator
 
 echo "waiting for monitor-lambda-emulator to start"
 while test "true" != "$(docker inspect -f {{.State.Running}} autograph-monitor-lambda-emulator)"; do
@@ -45,14 +45,14 @@ done
 
 echo "checking monitoring using hsm root hash:" "$APP_HSM_NORMANDY_ROOT_HASH"
 # exec in containers to workaround https://circleci.com/docs/2.0/building-docker-images/#accessing-services
-docker-compose exec monitor-lambda-emulator "/usr/local/bin/test_monitor.sh"
-docker-compose logs monitor-lambda-emulator
-docker-compose exec monitor-hsm-lambda-emulator "/usr/local/bin/test_monitor.sh"
-docker-compose logs monitor-hsm-lambda-emulator
+docker compose exec monitor-lambda-emulator "/usr/local/bin/test_monitor.sh"
+docker compose logs monitor-lambda-emulator
+docker compose exec monitor-hsm-lambda-emulator "/usr/local/bin/test_monitor.sh"
+docker compose logs monitor-hsm-lambda-emulator
 
 echo "checking read-only API"
 # user bob doesn't exist in the softhsm config
-docker-compose run \
+docker compose run \
 	       --rm \
 	       --user 0 \
 	       -e CHECK_BOB=1 \
@@ -60,7 +60,7 @@ docker-compose run \
 	       --workdir /app/src/autograph/tools/autograph-client \
 	       --entrypoint ./integration_test_api.sh \
 	       app
-docker-compose run \
+docker compose run \
 	       --rm \
 	       --user 0 \
 	       -e AUTOGRAPH_URL=http://app-hsm:8001 \
@@ -69,7 +69,7 @@ docker-compose run \
 	       app-hsm
 
 echo "checking gpg signing"
-docker-compose run \
+docker compose run \
 	       --rm \
 	       --user 0 \
 	       -e AUTOGRAPH_URL=http://app:8000 \
@@ -79,14 +79,14 @@ docker-compose run \
 # TODO(GH-785): add HSM support for GPG signing keys and test here
 
 echo "checking XPI signing"
-docker-compose run \
+docker compose run \
 	       --rm \
 	       --user 0 \
 	       -e AUTOGRAPH_URL=http://app:8000 \
 	       --workdir /app/src/autograph/tools/autograph-client \
 	       --entrypoint ./integration_test_xpis.sh \
 	       app
-docker-compose run \
+docker compose run \
 	       --rm \
 	       --user 0 \
 	       -e AUTOGRAPH_URL=http://app-hsm:8001 \
@@ -96,7 +96,7 @@ docker-compose run \
 	       app-hsm
 
 echo "checking APK signing"
-docker-compose run \
+docker compose run \
 	       --rm \
 	       --user 0 \
 	       -e TARGET=http://app:8000 \

--- a/database/README.md
+++ b/database/README.md
@@ -5,7 +5,7 @@ This directory contains:
 * a Dockerfile to setup a test database for CI and local development
 * key and cert files for the development docker DB root CA and server
 
-The key, CSR, and cert files were generated per the "To create a server certificate whose identity can be validated by clients, first create a certificate signing request (CSR) and a public/private key file:" section of https://www.postgresql.org/docs/11/ssl-tcp.html#SSL-CERTIFICATE-CREATION with the docker-compose CN of `db` i.e.
+The key, CSR, and cert files were generated per the "To create a server certificate whose identity can be validated by clients, first create a certificate signing request (CSR) and a public/private key file:" section of https://www.postgresql.org/docs/11/ssl-tcp.html#SSL-CERTIFICATE-CREATION with the docker compose CN of `db` i.e.
 
 ```console
 » openssl req -new -nodes -text -out root.csr -keyout root.key -subj "/CN=db" && chmod og-rwx root.key

--- a/tools/softhsm/Dockerfile
+++ b/tools/softhsm/Dockerfile
@@ -34,7 +34,7 @@ RUN cd /app/src/autograph/tools/softhsm/ && go run genkeys.go
 # make a pki in softhsm
 # then update the config
 # then write the generated config and new root hash to /tmp
-# docker-compose mounts /tmp for the monitor-hsm service
+# docker compose mounts /tmp for the monitor-hsm service
 RUN cd /app/src/autograph/tools/genpki/ && \
       go run genpki.go > /app/genpki.out && \
       cd /app/src/autograph/tools/configurator && \

--- a/tools/softhsm/autograph.softhsm.yaml
+++ b/tools/softhsm/autograph.softhsm.yaml
@@ -41,7 +41,7 @@ database:
 # The keys below are testing keys that do not grant any power
 #
 # NB: the softhsm Dockerfile generates and overwrites certs and keys
-# for the kinto and normandy signers for the app-hsm docker-compose
+# for the kinto and normandy signers for the app-hsm docker compose
 # service
 #
 signers:


### PR DESCRIPTION
New versions of Docker have 'compose' as a subcommand. The existing scripts used the older `docker-compose` executable, which has been removed.

`make integration-test` runs fine with the change.

Fixes #846