### PR TITLE
Allow Debian version special chars in unsigned filenames

### DIFF
--- a/signer/signer.go
+++ b/signer/signer.go
@@ -221,8 +221,10 @@ func isValidUnsignedFilename(filename string) error {
 	if !regexp.MustCompile(`[a-zA-Z0-9]$`).MatchString(filename) {
 		return fmt.Errorf("unsigned filename must end with an alphanumeric character")
 	}
+	// support debian version conventions as documented at:
+	//    https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
 	if !regexp.MustCompile(`^[-_\.+~a-zA-Z0-9]{1,256}$`).MatchString(filename) {
-		return fmt.Errorf(`unsigned filename must match ^[-_\.a-zA-Z0-9]{1,256}$`)
+		return fmt.Errorf(`unsigned filename must match ^[-_\.+~a-zA-Z0-9]{1,256}$`)
 	}
 	if regexp.MustCompile(`\.\.`).MatchString(filename) {
 		return fmt.Errorf("unsigned filename must not include ..")

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -215,10 +215,13 @@ type NamedSignedFile namedFile
 
 // isValidUnsignedFilename
 func isValidUnsignedFilename(filename string) error {
-	if !regexp.MustCompile(`^[a-zA-z0-9]`).MatchString(filename) {
+	if !regexp.MustCompile(`^[a-zA-Z0-9]`).MatchString(filename) {
 		return fmt.Errorf("unsigned filename must start with an alphanumeric character")
 	}
-	if !regexp.MustCompile(`^[-_\.a-zA-Z0-9]{1,256}$`).MatchString(filename) {
+	if !regexp.MustCompile(`[a-zA-Z0-9]$`).MatchString(filename) {
+		return fmt.Errorf("unsigned filename must end with an alphanumeric character")
+	}
+	if !regexp.MustCompile(`^[-_\.+~a-zA-Z0-9]{1,256}$`).MatchString(filename) {
 		return fmt.Errorf(`unsigned filename must match ^[-_\.a-zA-Z0-9]{1,256}$`)
 	}
 	if regexp.MustCompile(`\.\.`).MatchString(filename) {

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -269,7 +269,7 @@ ZkJ9hRz+l4ZVOsgNPHXPEi0AXWnDV6zrRQBpDYyiGhY=
 
 func TestAcceptedFilenames(t *testing.T) {
 	for _, testcase := range acceptedFileNames {
-		err := isValidUnsignedFilename(testcase);
+		err := isValidUnsignedFilename(testcase)
 		if err != nil {
 			t.Fatalf("failed to accept: %s reason: %v", testcase, err)
 		}
@@ -278,21 +278,21 @@ func TestAcceptedFilenames(t *testing.T) {
 
 func TestRejectedFilenames(t *testing.T) {
 	for _, testcase := range rejectedFileNames {
-		err := isValidUnsignedFilename(testcase);
+		err := isValidUnsignedFilename(testcase)
 		if err == nil {
 			t.Fatalf("failed to reject: %s", testcase)
 		}
 	}
 }
 
-var acceptedFileNames = []string {
+var acceptedFileNames = []string{
 	"simple.txt",
 	"example_1.2.3-456.dsc",
 	"complex-example123_4.5a.7~alpha1.buildinfo",
 	"complex+example456_6.a6.6~beta2+fix3.changes",
-};
+}
 
-var rejectedFileNames = []string {
+var rejectedFileNames = []string{
 	".dotfile",
 	"~tempfile",
 	"tempfile~",
@@ -305,4 +305,4 @@ var rejectedFileNames = []string {
 	"control^chars",
 	"control*chars",
 	"_non_alpha_start",
-};
+}

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -266,3 +266,43 @@ ZkJ9hRz+l4ZVOsgNPHXPEi0AXWnDV6zrRQBpDYyiGhY=
 -----END RSA PRIVATE KEY-----`,
 	}},
 }
+
+func TestAcceptedFilenames(t *testing.T) {
+	for _, testcase := range acceptedFileNames {
+		err := isValidUnsignedFilename(testcase);
+		if err != nil {
+			t.Fatalf("failed to accept: %s reason: %v", testcase, err)
+		}
+	}
+}
+
+func TestRejectedFilenames(t *testing.T) {
+	for _, testcase := range rejectedFileNames {
+		err := isValidUnsignedFilename(testcase);
+		if err == nil {
+			t.Fatalf("failed to reject: %s", testcase)
+		}
+	}
+}
+
+var acceptedFileNames = []string {
+	"simple.txt",
+	"example_1.2.3-456.dsc",
+	"complex-example123_4.5a.7~alpha1.buildinfo",
+	"complex+example456_6.a6.6~beta2+fix3.changes",
+};
+
+var rejectedFileNames = []string {
+	".dotfile",
+	"~tempfile",
+	"tempfile~",
+	"abcdef..xyz",
+	"control!chars",
+	"control@chars",
+	"control#chars",
+	"control$chars",
+	"control%%chars",
+	"control^chars",
+	"control*chars",
+	"_non_alpha_start",
+};


### PR DESCRIPTION
To full support Debian package signing, there are a few extra special characters that we may need to accept as valid filenames: `.` `-` `~` and `+` (full-stop, hyphen, tilde and plus). This patch should extend the `signer.isValidUnsignedFilename()` function to permit these characters, and adds some unit tests to make sure it works as expected.

Since the tilde character is sometimes used as a suffix by some text editors to denote backup files, I felt it was prudent to add an extra check to ensure that filenames also end with an alphanumeric character. I wouldn't expect this to cause issues, but I figured I should mention it as well in case anyone knows of a usecase that this might break.

I have tested this locally with `make integration-test` and it appears to pass.

Fixes: #849 