### PR TITLE
adding contentsignaturepki leaf cert CN overrides

### DIFF
--- a/signer/contentsignaturepki/contentsignature.go
+++ b/signer/contentsignaturepki/contentsignature.go
@@ -63,6 +63,7 @@ type ContentSigner struct {
 	chainUploadLocation         string
 	caCert                      string
 	db                          *database.Handler
+	subdomainOverride           string
 }
 
 // ecdsaAsn1Signature is a private struct to unmarshal asn1 signatures produced by crypto.Signer
@@ -83,6 +84,7 @@ func New(conf signer.Configuration) (s *ContentSigner, err error) {
 	s.chainUploadLocation = conf.ChainUploadLocation
 	s.caCert = conf.CaCert
 	s.db = conf.DB
+	s.subdomainOverride = conf.SubdomainOverride
 
 	if conf.Type != Type {
 		return nil, fmt.Errorf("contentsignaturepki %q: invalid type %q, must be %q", s.ID, conf.Type, Type)

--- a/signer/contentsignaturepki/contentsignature_test.go
+++ b/signer/contentsignaturepki/contentsignature_test.go
@@ -76,15 +76,21 @@ func TestSign(t *testing.T) {
 		if err != nil {
 			t.Fatalf("testcase %d failed to get X5U %q: %v", i, s.X5U, err)
 		}
-		key := certs[0].PublicKey.(*ecdsa.PublicKey)
+		leaf := certs[0]
+		key := leaf.PublicKey.(*ecdsa.PublicKey)
 		if !sig.(*verifier.ContentSignature).VerifyData([]byte(input), key) {
 			t.Fatalf("testcase %d failed to verify signature", i)
+		}
+
+		if leaf.Subject.CommonName != testcase.expectedCommonName {
+			t.Errorf("testcase %d expected common name %#v, got %#v", i, testcase.expectedCommonName, leaf.Subject.CommonName)
 		}
 	}
 }
 
 var PASSINGTESTCASES = []struct {
-	cfg signer.Configuration
+	cfg                signer.Configuration
+	expectedCommonName string
 }{
 	{cfg: signer.Configuration{
 		Type:                Type,
@@ -130,7 +136,9 @@ BAUwAwEB/zAKBggqhkjOPQQDAwNoADBlAjB3fOCz2SQvxNZ65juSotQNRvXhB4TZ
 nsbYLErV5grBhN+UxzmY9YwlOl6j6CoBiNkCMQCVBh9UBkWNkUfMUGImrCNDLvlw
 //Vb8kLBsJmLQjZNbXt+ikjYkWGqppp2pVwwgf4=
 -----END CERTIFICATE-----`,
-	}},
+	},
+		expectedCommonName: "testsigner0.content-signature.mozilla.org",
+	},
 	{cfg: signer.Configuration{
 		Type:                Type,
 		ID:                  "testsigner1",
@@ -172,7 +180,54 @@ CCsGAQUFBwMDMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwMDSAAwRQIgIBgf
 KkmH7TerRPn/517v/41o/sF9Hd9iGBilyWtVMggCIQClvRXiMM6DrabvybPGHWTt
 mpvOMOT3falDgXh0iOgdIA==
 -----END CERTIFICATE-----`,
-	}},
+	},
+		expectedCommonName: "testsigner1.content-signature.mozilla.org",
+	},
+	{cfg: signer.Configuration{
+		Type:                Type,
+		ID:                  "testsigner1",
+		SubdomainOverride:   "anothersigner1",
+		Mode:                P256ECDSA,
+		X5U:                 "file:///tmp/autograph_unit_tests/chains/",
+		ChainUploadLocation: "file:///tmp/autograph_unit_tests/chains/",
+		IssuerPrivKey: `
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIEABir6WMfkbG2ZyKKDCij1PlSBldaaJqPQ/9ioWvCM5oAoGCCqGSM49
+AwEHoUQDQgAED0x4GeyH3nxaCVQqPFbRkoBg1BJePxTSg1oaRWIgBbrMYaB/TKpL
+WoBQZFUwn11IFDP5y1B6Tt9U5DxQ3tgt+w==
+-----END EC PRIVATE KEY-----`,
+		IssuerCert: `
+-----BEGIN CERTIFICATE-----
+MIICIDCCAcWgAwIBAgIIFYW+N1jIJvAwCgYIKoZIzj0EAwMwXzELMAkGA1UEBhMC
+VVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQK
+EwdNb3ppbGxhMRkwFwYDVQQDExBjc3Jvb3QxNTUwODU0NzkxMB4XDTE4MTIyMTE2
+NTk1MVoXDTI5MDIyMjE2NTk1MVowYDELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNB
+MRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQKEwdNb3ppbGxhMRowGAYD
+VQQDExFjc2ludGVyMTU1MDg1NDc5MTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IA
+BA9MeBnsh958WglUKjxW0ZKAYNQSXj8U0oNaGkViIAW6zGGgf0yqS1qAUGRVMJ9d
+SBQz+ctQek7fVOQ8UN7YLfujajBoMA4GA1UdDwEB/wQEAwIBhjATBgNVHSUEDDAK
+BggrBgEFBQcDAzAPBgNVHRMBAf8EBTADAQH/MDAGA1UdHgEB/wQmMCSgIjAggh4u
+Y29udGVudC1zaWduYXR1cmUubW96aWxsYS5vcmcwCgYIKoZIzj0EAwMDSQAwRgIh
+AJYQbM1zDA9RkmNwEc4LafBwL98Z+aGy31z80HeC5Y8hAiEA4KEG+ZNinz5yZItW
+NYDcA5Hvd1xXeRQi6SWj6Z2qT7w=
+-----END CERTIFICATE-----`,
+		CaCert: `
+-----BEGIN CERTIFICATE-----
+MIIB7DCCAZKgAwIBAgIIFYW+N1i+RHgwCgYIKoZIzj0EAwMwXzELMAkGA1UEBhMC
+VVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQK
+EwdNb3ppbGxhMRkwFwYDVQQDExBjc3Jvb3QxNTUwODU0NzkxMB4XDTE4MTIyMDE2
+NTk1MVoXDTQ5MDIyMjE2NTk1MVowXzELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNB
+MRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQKEwdNb3ppbGxhMRkwFwYD
+VQQDExBjc3Jvb3QxNTUwODU0NzkxMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE
+SZakSnBD3qkp15bQ+qzcKCn2+OmoOJKVgrSezyrx7IHjtEbCYUz8Zp+HhKg3NXLY
+6ZMjO0zYnq3gTdAzH3amOqM4MDYwDgYDVR0PAQH/BAQDAgGGMBMGA1UdJQQMMAoG
+CCsGAQUFBwMDMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwMDSAAwRQIgIBgf
+KkmH7TerRPn/517v/41o/sF9Hd9iGBilyWtVMggCIQClvRXiMM6DrabvybPGHWTt
+mpvOMOT3falDgXh0iOgdIA==
+-----END CERTIFICATE-----`,
+	},
+		expectedCommonName: "anothersigner1.content-signature.mozilla.org",
+	},
 }
 
 func TestNewFailure(t *testing.T) {

--- a/signer/contentsignaturepki/x509.go
+++ b/signer/contentsignaturepki/x509.go
@@ -65,7 +65,7 @@ func (s *ContentSigner) makeAndUploadChain() (err error) {
 // returns the entire chain of certificate, its name (based on the ee cn &
 // expiration) and an error.
 func (s *ContentSigner) makeChain() (chain string, name string, err error) {
-	cn := s.ID + CSNameSpace
+	cn := s.domainForLeafCert()
 
 	// cert is backdated to allow for clock skew tolerance
 	notBefore := time.Now().UTC().Add(-s.clockSkewTolerance)
@@ -145,4 +145,12 @@ func (s *ContentSigner) makeChain() (chain string, name string, err error) {
 	chain = certPem.String() + s.IssuerCert + s.caCert
 	name = fmt.Sprintf("%s-%s.chain", cert.Subject.CommonName, cert.NotAfter.Format("2006-01-02-15-04-05"))
 	return
+}
+
+func (s *ContentSigner) domainForLeafCert() string {
+	subdomain := s.ID
+	if s.subdomainOverride != "" {
+		subdomain = s.subdomainOverride
+	}
+	return subdomain + CSNameSpace
 }

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -115,6 +115,11 @@ type Configuration struct {
 	// e.g. 0xA2B637F535A86009 for the gpg2 signer type
 	KeyID string `json:"keyid,omitempty"`
 
+	// SubdomainOverride is to override the subdomain of the leaf certificates
+	// created. This is mostly for contentsignaturepki. If this isn't set, the
+	// `KeyID` is used as the subdomain, instead.
+	SubdomainOverride string `json:"subdomain_override,omitempty"`
+
 	// Passphrase is the optional passphrase to use decrypt the
 	// gpg secret key for the gpg2 signer type
 	Passphrase string `json:"passphrase,omitempty"`


### PR DESCRIPTION
This adds the ability to override the common name
set in the Subject of the leaf certificates
generated by the contentsignaturepki type singer
configurations.

This is to allow for new certificates created with
the same key material but different singer
configurations to be validated by Firefox and
other clients as they were previously. This is an
important requirement for the add-on and content
signing root key succession plan as we're asking
the distribution services to use new signers (new
`keyids`) for the new keys, while keeping the old
common names in the end-user clients.

Fixes [bug 1886886](https://bugzilla.mozilla.org/show_bug.cgi?id=1886886)
