### PR TITLE
avoid destructive gnupg clean up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ generate:
 	go generate
 
 gpg-test-clean:
-	rm -rf ~/.gnupg /tmp/autograph_gpg2*
+	rm -rf /tmp/autograph_gpg2*
 	killall gpg-agent
 
 # image build order:

--- a/README.md
+++ b/README.md
@@ -25,15 +25,8 @@ This will download the latest build of autograph from DockerHub and run it with 
 
 #### Local Development with Docker
 
-|    |    |
-|----|----|
-| **WARNING!** | These tests may break or delete your gpg setup. |
-|    |    |
-
-If your are lucky, it will leave you alone. (It starts a number of `gpg-agent`
-processes, then does a `killall gpg-agent` to clean up.) However, I've lost my
-entire `~/.gnupg` setup. I _strongly_ recommend: `tar czf ~/gnupg.tgz ~/.gnupg`
-before starting.
+(This process will start a number of `gpg-agent` processes on your host machine,
+then does a `killall gpg-agent` to clean up.)
 
 After making any changes, please test locally by:
 ```bash


### PR DESCRIPTION
The deletion of `~/.gnupg` in the Makefile seems to
have been mooted by more careful use of gpg's
`--homedir` flag during the history of autograph.

Not being able to run the tests locally without
fear of blowing away your own gpg set up is not
great and slows down progress in working with
autograph.

If we find inconsistently failing tests due to
this change, we should apply more `--homedir` and
equivalent work to autograph and its tests.
