### PR TITLE
Trial fix of Circle CI brokeness

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,8 @@
         "issuerprivatekey",
         "pipx",
         "virtualenv"
-    ]
+    ],
+    "gopls": {
+        "ui.semanticTokens": true
+    }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,13 @@ RUN addgroup --gid 10001 app \
       --disabled-password app \
       && \
       echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/buster-backports.list && \
-      apt update && \
-      apt -y upgrade && \
       apt -y install libltdl-dev gpg libncurses5 devscripts && \
       apt -y install -t buster-backports apksigner && \
       apt-get clean
+
+      # removed upgrade to see if that changes behavior on circle ci
+      #apt update && \
+      #apt -y upgrade && \
 
 # fetch the RDS CA bundle
 # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.SSL


### PR DESCRIPTION
CircleCI nightlies started failing Saturday, with no changes, so assuming it's due to unpinned apt dependencies