### PR TITLE
Update deploy job to use cimg/deploy:2024.03.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
 
   deploy:
     docker:
-      - image: docker:18.06.3-ce
+      - image: cimg/deploy:2024.03.1
     steps:
       - setup_remote_docker
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,9 +104,6 @@ jobs:
       # save the built docker container to CircleCI's cache since
       # CircleCI Workflows do not have the same remote docker
       # instance.
-      #
-      # Use /go/src/app since we don't have permissions to make
-      # directories in other locations
       - run:
           name: docker save built images
           no_output_timeout: 30m


### PR DESCRIPTION
In my recent PR #897 to update the CircleCI environment, we needed to change the docker cache path because `/go/` is no longer writeable as a non-root user. Unfortunately, this seems to have caused the deploy job to fail due to differing project directories between the `docker:18.06.3-ce` image and the ones used by CircleCI.

To fix this, I think we can update the deployment docker image to a CircleCI one and it should all be good.