### PR TITLE
Fix monitor contentsignature checks

### DIFF
--- a/bin/test_monitor.sh
+++ b/bin/test_monitor.sh
@@ -4,6 +4,19 @@ set -e
 set -o pipefail
 
 # invoke a test monitor run in a lambda monitor
-
 MONITOR_ERROR=$(curl -w '\n' -X POST 'http://localhost:8080/2015-03-31/functions/function/invocations' -d '{}')
-test "$MONITOR_ERROR = null"
+
+# If the result was null - then we succeeded!
+if [ "${MONITOR_ERROR}" == "null" ]; then
+    exit 0
+fi
+
+# Otherwise - some kind of error occured
+MONITOR_ERROR_TYPE=$(echo "${MONITOR_ERROR}" | jq -r '.errorType')
+if [ "${MONITOR_ERROR_TYPE}" == "errorString" ]; then
+    echo "${MONITOR_ERROR}" | jq -r '.errorMessage' >&2
+else
+    echo "${MONITOR_ERROR}" | jq >&2
+fi
+exit 1
+

--- a/handlers_racing_test.go
+++ b/handlers_racing_test.go
@@ -168,7 +168,11 @@ func TestSignaturePass(t *testing.T) {
 					t.Fatalf("in test case %d on endpoint %q, error '%v' in response %d;\nrequest was: %+v\nresponse was: %+v failed to decode input",
 						i, testcase.endpoint, decodeErr, j, testcase.signaturerequests[j], response)
 				}
-				err = contentsignature.VerifyResponseHash(rawInput, response)
+				if req.URL.RequestURI() == "/sign/hash" {
+					err = contentsignature.VerifyResponseHash(rawInput, response)
+				} else {
+					err = contentsignature.VerifyResponse(rawInput, response)
+				}
 			case xpi.Type:
 				err = verifyXPISignature(testcase.signaturerequests[j].Input, response.Signature)
 			case apk2.Type:

--- a/handlers_racing_test.go
+++ b/handlers_racing_test.go
@@ -163,10 +163,10 @@ func TestSignaturePass(t *testing.T) {
 		for j, response := range responses {
 			switch response.Type {
 			case contentsignature.Type:
-				rawInput, err := base64.StdEncoding.DecodeString(testcase.signaturerequests[j].Input)
-				if err != nil {
+				rawInput, decodeErr := base64.StdEncoding.DecodeString(testcase.signaturerequests[j].Input)
+				if decodeErr != nil {
 					t.Fatalf("in test case %d on endpoint %q, error '%v' in response %d;\nrequest was: %+v\nresponse was: %+v failed to decode input",
-						i, testcase.endpoint, err, j, testcase.signaturerequests[j], response)
+						i, testcase.endpoint, decodeErr, j, testcase.signaturerequests[j], response)
 				}
 				err = contentsignature.VerifyResponseHash(rawInput, response)
 			case xpi.Type:

--- a/handlers_racing_test.go
+++ b/handlers_racing_test.go
@@ -163,10 +163,12 @@ func TestSignaturePass(t *testing.T) {
 		for j, response := range responses {
 			switch response.Type {
 			case contentsignature.Type:
-				err = verifyContentSignatureResponse(
-					testcase.signaturerequests[j].Input,
-					response,
-					testcase.endpoint)
+				rawInput, err := base64.StdEncoding.DecodeString(testcase.signaturerequests[j].Input)
+				if err != nil {
+					t.Fatalf("in test case %d on endpoint %q, error '%v' in response %d;\nrequest was: %+v\nresponse was: %+v failed to decode input",
+						i, testcase.endpoint, err, j, testcase.signaturerequests[j], response)
+				}
+				err = contentsignature.VerifyResponseHash(rawInput, response)
 			case xpi.Type:
 				err = verifyXPISignature(testcase.signaturerequests[j].Input, response.Signature)
 			case apk2.Type:

--- a/monitor_handler_racing_test.go
+++ b/monitor_handler_racing_test.go
@@ -58,10 +58,7 @@ func TestMonitorPass(t *testing.T) {
 
 		switch response.Type {
 		case contentsignature.Type:
-			err = verifyContentSignatureResponse(
-				base64.StdEncoding.EncodeToString(MonitoringInputData),
-				response,
-				"/__monitor__")
+			err = contentsignature.VerifyResponse(MonitoringInputData, response)
 			if err != nil {
 				t.Logf("%+v", response)
 				t.Fatalf("verification of monitoring response failed: %v", err)

--- a/tools/autograph-monitor/monitor.go
+++ b/tools/autograph-monitor/monitor.go
@@ -169,7 +169,12 @@ func monitor() (err error) {
 		switch response.Type {
 		case contentsignature.Type:
 			log.Printf("Verifying content signature from signer %q", response.SignerID)
-			err = verifyContentSignature(x5uClient, conf.notifier, conf.contentSignatureRootHash, contentSignatureIgnoredLeafCertCNs, response, []byte(inputdata))
+			if response.X5U == "" {
+				// The X5U is optional for contentsignature signers.
+				err = contentsignature.VerifyResponse([]byte(inputdata), response)
+			} else {
+				err = verifyContentSignature(x5uClient, conf.notifier, conf.contentSignatureRootHash, contentSignatureIgnoredLeafCertCNs, response, []byte(inputdata))
+			}
 		case contentsignaturepki.Type:
 			log.Printf("Verifying content signature pki from signer %q", response.SignerID)
 			err = verifyContentSignature(x5uClient, conf.notifier, conf.contentSignatureRootHash, contentSignatureIgnoredLeafCertCNs, response, []byte(inputdata))


### PR DESCRIPTION
It turns out that the monitor integration test has been failing for a while now because the `contentsignature` signer type is not required to provide an X5U for signature verification, but the monitor check is reusing the verification code from `contentsignaturepki` which does require an X5U and the public key comes from slightly different places in each case.

If you look a little closer at the monitor integration tests, you will find errors like this:
```
Verifying content signature from signer "appkey1"
Response from signer "appkey1" does not pass: content signature response is missing an X5U to fetch
Response was: {Ref:8pa9gsxl0nxk3vmthnxqgjx0r Type:contentsignature Mode:p384ecdsa SignerID:appkey1 PublicKey:MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE7oM/ewOhz6qtHyQhqJvT3SiefGPWqGwEUAZGVkuSIwvteVKrd8jnAjHYyCaYpIg9Vo10WnhXvm96L3KAbOE6Cyu3fMtKhZZIMf+Qqes9+66ae/NTeIWlDiGrjNeD+ClM Signature:nCTEFViv7rIioqm4fmD38-iyx38fL20ryNlZQGan4T2k83cCOG7TI9tufKzjpEGR7r0DNBZUsr8KrURccQA9qobqjOPBkbnzjztKqsYAZchfLrbLCjlcigW6LxFsIXzM SignedFile: SignedFiles:[] X5U: SignerOpts:<nil>}
Verifying content signature from signer "appkey2"
Response from signer "appkey2" does not pass: content signature response is missing an X5U to fetch
Response was: {Ref:27u8rhwzevdl020v7mr9xyd6ij Type:contentsignature Mode:p256ecdsa SignerID:appkey2 PublicKey:MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMdzAsqkWQiP8Fo89qTleJcuEjBtp2c6z16sC7BAS5KXvUGghURYq3utZw8En6Ik/4Om8c7EW/+EO+EkHShhgdA== Signature:4ys9GWOTXzoQjWNKObIY3B4PubtYSaVeCj1uW0ZMx8x45kQedtCHEX8N2vyN8DU4hggwYWcA7Gj1rFq7eXaU9Q SignedFile: SignedFiles:[] X5U: SignerOpts:<nil>}
```

To fix this, we need a to add a proper verification algorithm for `contentsignature` and use it in monitor when there's no X5U present. To do this, we add two new methods:
 - `contentsignature.VerifyResponse`: Accepts a `formats.SignatureResponse` from the `/sign/data` endpoint and performs a check of the ECDSA signature, and
 - `contentsignature.VerifyResponseHash`: Does the same thing, but checks the result of the `/sign/hash` endpoint.

Some food for thought: it is awkward that the `contentsignature` algorithm calculates its hashes differently in both the `/sign/hash` and `/sign/data` cases, which means that this is the only signature type where we need the context of the signing call to perform signature validation.

It would also be a good idea to check that when an X5U is present, the public key of the leaf/EE certificate matches the PublicKey returned in the signature.