### PR TITLE
migrate ioutil calls to io,os calls

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -9,7 +9,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	log "github.com/sirupsen/logrus"
@@ -30,7 +29,7 @@ func httpError(w http.ResponseWriter, r *http.Request, errorCode int, errorMessa
 	// request body is read before writing a response.
 	// https://github.com/golang/go/issues/15789
 	if r.Body != nil {
-		io.Copy(ioutil.Discard, r.Body)
+		io.Copy(io.Discard, r.Body)
 		r.Body.Close()
 	}
 	http.Error(w, msg, errorCode)

--- a/handlers.go
+++ b/handlers.go
@@ -12,7 +12,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path"
@@ -90,7 +90,7 @@ func (a *autographer) handleSignature(w http.ResponseWriter, r *http.Request) {
 		httpError(w, r, http.StatusUnauthorized, "authorization verification failed: %v", err)
 		return
 	}
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		httpError(w, r, http.StatusBadRequest, "failed to read request body: %s", err)
 		return
@@ -453,7 +453,7 @@ func (a *autographer) handleGetAuthKeyIDs(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if r.Body != nil {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			httpError(w, r, http.StatusBadRequest, "failed to read request body: %s", err)
 			return

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -16,7 +16,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -836,7 +836,7 @@ func verifyAPKSignature(signedAPK []byte) error {
 			if err != nil {
 				return err
 			}
-			sigdata, err = ioutil.ReadAll(rc)
+			sigdata, err = io.ReadAll(rc)
 			if err != nil {
 				return err
 			}
@@ -849,7 +849,7 @@ func verifyAPKSignature(signedAPK []byte) error {
 			if err != nil {
 				return err
 			}
-			rawsig, err := ioutil.ReadAll(rc)
+			rawsig, err := io.ReadAll(rc)
 			if err != nil {
 				return err
 			}

--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 	"crypto/sha256"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/signal"
@@ -254,7 +253,7 @@ func (c *configuration) loadFromFile(path string) error {
 		confSHA        [32]byte
 		err            error
 	)
-	data, err = ioutil.ReadFile(path)
+	data, err = os.ReadFile(path)
 	if err != nil {
 		return err
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -8,7 +8,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -197,7 +196,7 @@ authorizations:
 	for i, testcase := range testcases {
 		var conf configuration
 		// write conf file to /tmp and read it back
-		fd, err := ioutil.TempFile("", "autographtestconf")
+		fd, err := os.CreateTemp("", "autographtestconf")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -228,7 +227,7 @@ func TestDuplicateSigners(t *testing.T) {
 
 	var conf configuration
 	// write conf file to /tmp and read it back
-	fd, err := ioutil.TempFile("", "autographtestconf")
+	fd, err := os.CreateTemp("", "autographtestconf")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -283,7 +282,7 @@ func TestDuplicateAuthorization(t *testing.T) {
 
 	var conf configuration
 	// write conf file to /tmp and read it back
-	fd, err := ioutil.TempFile("", "autographtestconf")
+	fd, err := os.CreateTemp("", "autographtestconf")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -353,7 +352,7 @@ func TestUnknownSignerInAuthorization(t *testing.T) {
 
 	var conf configuration
 	// write conf file to /tmp and read it back
-	fd, err := ioutil.TempFile("", "autographtestconf")
+	fd, err := os.CreateTemp("", "autographtestconf")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/signer/apk2/apk2_test.go
+++ b/signer/apk2/apk2_test.go
@@ -1,12 +1,12 @@
 package apk2
 
 import (
-	"github.com/mozilla-services/autograph/signer"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/mozilla-services/autograph/signer"
 )
 
 func assertNewSignerWithConfOK(t *testing.T, conf signer.Configuration) *APK2Signer {
@@ -177,12 +177,12 @@ func TestSignFile(t *testing.T) {
 		t.Parallel()
 
 		// write the signature to a temp file
-		tmpApk, err := ioutil.TempFile("", "apk2_TestSignedApkFile")
+		tmpApk, err := os.CreateTemp("", "apk2_TestSignedApkFile")
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer os.Remove(tmpApk.Name())
-		err = ioutil.WriteFile(tmpApk.Name(), signedFile, 0755)
+		err = os.WriteFile(tmpApk.Name(), signedFile, 0755)
 		if err != nil {
 			t.Fatalf("error writing file %s: %q", tmpApk.Name(), err)
 		}

--- a/signer/contentsignaturepki/upload.go
+++ b/signer/contentsignaturepki/upload.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -63,7 +63,7 @@ func writeLocalFile(data, name string, target *url.URL) error {
 		}
 	}
 	// write the file into the target dir
-	return ioutil.WriteFile(target.Path+name, []byte(data), 0755)
+	return os.WriteFile(target.Path+name, []byte(data), 0755)
 }
 
 // buildHTTPClient returns the default HTTP.Client for fetching X5Us
@@ -95,7 +95,7 @@ func GetX5U(client *http.Client, x5u string) (body []byte, certs []*x509.Certifi
 		err = fmt.Errorf("failed to retrieve x5u from %s: %s", x5u, resp.Status)
 		return
 	}
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		err = fmt.Errorf("failed to parse x5u body: %w", err)
 		return

--- a/signer/gpg2/gpg2_test.go
+++ b/signer/gpg2/gpg2_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -81,7 +80,7 @@ func assertNewSignerWithConfErrs(t *testing.T, invalidConf signer.Configuration)
 // writes and imports the signer's public key in a new GPG keyring
 // then writes and verifies each clear signed file
 func assertClearSignedFilesVerify(t *testing.T, signer *GPG2Signer, testname string, signedFiles []signer.NamedSignedFile) {
-	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("autograph_gpg2_test_%s_", testname))
+	tmpDir, err := os.MkdirTemp("", fmt.Sprintf("autograph_gpg2_test_%s_", testname))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +88,7 @@ func assertClearSignedFilesVerify(t *testing.T, signer *GPG2Signer, testname str
 
 	// write the public key to a file
 	publicKeyPath := filepath.Join(tmpDir, "gpg2_publickey")
-	err = ioutil.WriteFile(publicKeyPath, []byte(signer.PublicKey), 0755)
+	err = os.WriteFile(publicKeyPath, []byte(signer.PublicKey), 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +110,7 @@ func assertClearSignedFilesVerify(t *testing.T, signer *GPG2Signer, testname str
 	// gpg --verify considers more than one signed file a detached sig
 	for _, signedFile := range signedFiles {
 		signedFilePath := filepath.Join(tmpDir, signedFile.Name)
-		err = ioutil.WriteFile(signedFilePath, signedFile.Bytes, 0755)
+		err = os.WriteFile(signedFilePath, signedFile.Bytes, 0755)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -323,36 +322,36 @@ func TestSignData(t *testing.T) {
 				t.Parallel()
 
 				// write the signature to a temp file
-				tmpSignatureFile, err := ioutil.TempFile("", fmt.Sprintf("gpg2_TestSignPGPAndVerifyWithGnuPG_signature_%s_", s.ID))
+				tmpSignatureFile, err := os.CreateTemp("", fmt.Sprintf("gpg2_TestSignPGPAndVerifyWithGnuPG_signature_%s_", s.ID))
 				if err != nil {
 					t.Fatal(err)
 				}
 				defer os.Remove(tmpSignatureFile.Name())
-				err = ioutil.WriteFile(tmpSignatureFile.Name(), []byte(sigstr), 0755)
+				err = os.WriteFile(tmpSignatureFile.Name(), []byte(sigstr), 0755)
 				if err != nil {
 					t.Fatalf("error writing file %s: %q", tmpSignatureFile.Name(), err)
 				}
 
 				// write the input to a temp file
-				tmpContentFile, err := ioutil.TempFile("", fmt.Sprintf("gpg2_TestSignPGPAndVerifyWithGnuPG_input_%s_", s.ID))
+				tmpContentFile, err := os.CreateTemp("", fmt.Sprintf("gpg2_TestSignPGPAndVerifyWithGnuPG_input_%s_", s.ID))
 				if err != nil {
 					t.Fatal(err)
 				}
 
 				defer os.Remove(tmpContentFile.Name())
-				err = ioutil.WriteFile(tmpContentFile.Name(), input, 0755)
+				err = os.WriteFile(tmpContentFile.Name(), input, 0755)
 				if err != nil {
 					t.Fatal(err)
 				}
 
 				// write the public key to a temp file
-				tmpPublicKeyFile, err := ioutil.TempFile("", fmt.Sprintf("gpg2_TestSignPGPAndVerifyWithGnuPG_publickey_%s_", s.ID))
+				tmpPublicKeyFile, err := os.CreateTemp("", fmt.Sprintf("gpg2_TestSignPGPAndVerifyWithGnuPG_publickey_%s_", s.ID))
 				if err != nil {
 					t.Fatal(err)
 				}
 				defer os.Remove(tmpPublicKeyFile.Name())
 				// fmt.Printf("loading %s\n", s.PublicKey)
-				err = ioutil.WriteFile(tmpPublicKeyFile.Name(), []byte(s.PublicKey), 0755)
+				err = os.WriteFile(tmpPublicKeyFile.Name(), []byte(s.PublicKey), 0755)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/signer/xpi/jar.go
+++ b/signer/xpi/jar.go
@@ -9,11 +9,11 @@ import (
 	"encoding/json"
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
 	"io"
-	"io/ioutil"
 	"strings"
 	"unicode/utf8"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // consts and vars for formatFilename
@@ -138,7 +138,7 @@ func makeJARManifest(input []byte) (manifest []byte, err error) {
 		if err != nil {
 			return manifest, err
 		}
-		data, err := ioutil.ReadAll(rc)
+		data, err := io.ReadAll(rc)
 		if err != nil {
 			return manifest, err
 		}
@@ -239,7 +239,7 @@ func repackJARWithMetafiles(input []byte, metafiles []Metafile) (output []byte, 
 		if err != nil {
 			return
 		}
-		data, err = ioutil.ReadAll(rc)
+		data, err = io.ReadAll(rc)
 		if err != nil {
 			return
 		}
@@ -365,7 +365,7 @@ func appendFileToZIP(input []byte, filepath string, filecontents []byte) (output
 		if err != nil {
 			return
 		}
-		data, err = ioutil.ReadAll(rc)
+		data, err = io.ReadAll(rc)
 		if err != nil {
 			return
 		}
@@ -437,7 +437,7 @@ func removeFileFromZIP(input []byte, filepath string) (output []byte, err error)
 		if err != nil {
 			return
 		}
-		data, err = ioutil.ReadAll(rc)
+		data, err = io.ReadAll(rc)
 		if err != nil {
 			return
 		}
@@ -471,7 +471,7 @@ func readFileFromZIP(signedXPI []byte, filename string) ([]byte, error) {
 				return nil, fmt.Errorf("error opening file %q in ZIP: %w", filename, err)
 			}
 			defer rc.Close()
-			data, err := ioutil.ReadAll(rc)
+			data, err := io.ReadAll(rc)
 			if err != nil {
 				return nil, fmt.Errorf("error reading file %q in ZIP: %w", filename, err)
 			}
@@ -502,7 +502,7 @@ func readXPIContentsToMap(signedXPI []byte) (map[string][]byte, error) {
 			return nil, fmt.Errorf("error opening file %q in ZIP: %w", f.Name, err)
 		}
 		defer rc.Close()
-		data, err := ioutil.ReadAll(rc)
+		data, err := io.ReadAll(rc)
 		if err != nil {
 			return nil, fmt.Errorf("error reading file %q in ZIP: %w", f.Name, err)
 		}

--- a/signer/xpi/jar_test.go
+++ b/signer/xpi/jar_test.go
@@ -4,7 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	_ "embed"
-	"io/ioutil"
+	"io"
 	"testing"
 )
 
@@ -147,7 +147,7 @@ func TestRepack(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer rc.Close()
-		data, err := ioutil.ReadAll(rc)
+		data, err := io.ReadAll(rc)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -211,7 +211,7 @@ func TestRepackEmptyCOSE(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer rc.Close()
-		data, err := ioutil.ReadAll(rc)
+		data, err := io.ReadAll(rc)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/signer/xpi/xpi_test.go
+++ b/signer/xpi/xpi_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -183,27 +182,27 @@ func TestSignDataAndVerifyWithOpenSSL(t *testing.T) {
 	pkcs7Sig := sig.(*Signature).String()
 
 	// write the signature to a temp file
-	tmpSignatureFile, err := ioutil.TempFile("", "TestSignDataAndVerifyWithOpenSSL_signature")
+	tmpSignatureFile, err := os.CreateTemp("", "TestSignDataAndVerifyWithOpenSSL_signature")
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = ioutil.WriteFile(tmpSignatureFile.Name(), []byte(pkcs7Sig), 0755)
+	err = os.WriteFile(tmpSignatureFile.Name(), []byte(pkcs7Sig), 0755)
 	if err != nil {
 		t.Fatalf("error writing file %s: %q", tmpSignatureFile.Name(), err)
 	}
 
 	// write the input to a temp file
-	tmpContentFile, err := ioutil.TempFile("", "TestSignDataAndVerifyWithOpenSSL_input")
+	tmpContentFile, err := os.CreateTemp("", "TestSignDataAndVerifyWithOpenSSL_input")
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = ioutil.WriteFile(tmpContentFile.Name(), input, 0755)
+	err = os.WriteFile(tmpContentFile.Name(), input, 0755)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// write the issuer cert to a temp file
-	tmpIssuerCertFile, err := ioutil.TempFile("", "TestSignDataAndVerifyWithOpenSSL_issuer")
+	tmpIssuerCertFile, err := os.CreateTemp("", "TestSignDataAndVerifyWithOpenSSL_issuer")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools/autograph-client/client.go
+++ b/tools/autograph-client/client.go
@@ -10,7 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"hash"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -192,7 +192,7 @@ examples:
 	} else if infile != "/path/to/file" {
 		log.Printf("signing file %q", infile)
 		url = url + "/sign/file"
-		filebytes, err := ioutil.ReadFile(infile)
+		filebytes, err := os.ReadFile(infile)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -201,7 +201,7 @@ examples:
 		log.Printf("signing files %q", flag.Args())
 		url = url + "/sign/files"
 		for _, inputFilename := range flag.Args() {
-			inputFileBytes, err := ioutil.ReadFile(inputFilename)
+			inputFileBytes, err := os.ReadFile(inputFilename)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -250,7 +250,7 @@ examples:
 	var roots *x509.CertPool
 	if rootPath != "/path/to/root.pem" {
 		roots = x509.NewCertPool()
-		rootContent, err := ioutil.ReadFile(rootPath)
+		rootContent, err := os.ReadFile(rootPath)
 		if err != nil {
 			log.Fatalf("failed to read roots from path %s: %s", rootPath, err)
 		}
@@ -290,7 +290,7 @@ examples:
 				fmt.Printf("DEBUG: received response\nDEBUG: %+v\n", resp)
 			}
 			defer resp.Body.Close()
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -407,14 +407,14 @@ examples:
 					}
 				}
 				if outfile != "" {
-					err = ioutil.WriteFile(outfile, sigData, 0644)
+					err = os.WriteFile(outfile, sigData, 0644)
 					if err != nil {
 						log.Fatal(err)
 					}
 					log.Println("response written to", outfile)
 				}
 				if outkeyfile != "" {
-					err = ioutil.WriteFile(outkeyfile, []byte(response.PublicKey), 0644)
+					err = os.WriteFile(outkeyfile, []byte(response.PublicKey), 0644)
 					if err != nil {
 						log.Fatal(err)
 					}
@@ -426,7 +426,7 @@ examples:
 					if err != nil {
 						log.Fatal(err)
 					}
-					err = ioutil.WriteFile(signedOutputFilename, signedFileBytes, 0644)
+					err = os.WriteFile(signedOutputFilename, signedFileBytes, 0644)
 					if err != nil {
 						log.Fatal(err)
 					}
@@ -475,7 +475,7 @@ func listKeyIDsForCurrentUser(cli *http.Client, debug bool, url, userid, pass st
 		fmt.Printf("DEBUG: received response\nDEBUG: %+v\n", resp)
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/tools/genpki/genpki.go
+++ b/tools/genpki/genpki.go
@@ -11,9 +11,9 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/big"
+	"os"
 	"time"
 
 	"github.com/ThalesIgnite/crypto11"
@@ -150,7 +150,7 @@ func main() {
 		log.Fatal(fmt.Errorf("failed to verify intermediate chain to root: %w"), err)
 	}
 
-	rootTmpfile, err := ioutil.TempFile("", "csrootcert")
+	rootTmpfile, err := os.CreateTemp("", "csrootcert")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -161,7 +161,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	interTmpfile, err := ioutil.TempFile("", "csintercert")
+	interTmpfile, err := os.CreateTemp("", "csintercert")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -185,7 +185,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		rootPrivTmpfile, err := ioutil.TempFile("", "csrootkey")
+		rootPrivTmpfile, err := os.CreateTemp("", "csrootkey")
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -206,7 +206,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		interPrivTmpfile, err := ioutil.TempFile("", "csinterkey")
+		interPrivTmpfile, err := os.CreateTemp("", "csinterkey")
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/tools/make-hsm-ee/make-hsm-ee.go
+++ b/tools/make-hsm-ee/make-hsm-ee.go
@@ -9,9 +9,9 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/big"
+	"os"
 	"time"
 
 	"github.com/ThalesIgnite/crypto11"
@@ -52,7 +52,7 @@ func main() {
 		usage()
 	}
 
-	issuerCertBytes, err := ioutil.ReadFile(issuerCertPath)
+	issuerCertBytes, err := os.ReadFile(issuerCertPath)
 	if err != nil {
 		log.Fatalf("error reading issuer cert: %s", err.Error())
 	}
@@ -124,7 +124,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = ioutil.WriteFile(outputBasename+".crt", eePem.Bytes(), 0644)
+	err = os.WriteFile(outputBasename+".crt", eePem.Bytes(), 0644)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -143,7 +143,7 @@ func main() {
 		log.Fatal(err)
 	}
 	msgBody := fmt.Sprintf("%s%s\n", secp384r1ECParams, eePrivPem.Bytes())
-	err = ioutil.WriteFile(outputBasename+".key", []byte(msgBody), 0644)
+	err = os.WriteFile(outputBasename+".key", []byte(msgBody), 0644)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
The Go 1.19 and nearby versions marked these calls as deprecated. Clean
them up with their documented replacements.

Ran these commands to fix it up:

```
$ gofmt -w -r 'ioutil.TempFile -> os.CreateTemp' $(find . -type f -name '*.go' | grep -v "/vendor/")
$ gofmt -w -r 'ioutil.ReadAll -> io.ReadAll' $(find . -type f -name '*.go' | grep -v "/vendor/")
$ gofmt -w -r 'ioutil.WriteFile -> os.WriteFile' $(find . -type f -name '*.go' | grep -v "/vendor/")
$ gofmt -w -r 'ioutil.TempDir -> os.MkdirTemp' $(find . -type f -name '*.go' | grep -v "/vendor/")
```

Then removing the `ioutil` import from the files that no longer use it.

Oh, also ha to revert some gofmt changes in `verifier/contentsignature`
that I'll ship separately.
