### PR TITLE
remove golint from build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,6 @@ jobs:
             make check-no-crypto11-in-signers
             make show-lints
       - run:
-          name: run golint
-          command: |
-            make install-golint lint
-            make show-lints
-            make -C tools/autograph-monitor lint
-            make -C verifier/contentsignature lint
-      - run:
           name: run gofmt
           command: |
             make -s fmt-diff | tee fmt.diff
@@ -38,7 +31,7 @@ jobs:
           command: |
             make vet
             make -C tools/autograph-monitor vet
-            make -C verifier/contentsignature vet 
+            make -C verifier/contentsignature vet
       - run:
           name: run staticcheck
           command: |

--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,13 @@ PACKAGE_NAMES := github.com/mozilla-services/autograph github.com/mozilla-servic
 # The GOPATH isn't always on the path.
 GOPATH := $(shell go env GOPATH)
 
-all: generate test vet lint staticcheck install
+all: generate test vet staticcheck install
 
 # update the vendored version of the wait-for-it.sh script
 install-wait-for-it:
 	curl -o bin/wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
 	sha256sum -c bin/wait-for-it.sh.sha256
 	chmod +x bin/wait-for-it.sh
-
-install-golint:
-	go install golang.org/x/lint/golint@v0.0.0-20190409202823-959b441ac422
 
 install-goveralls:
 	go install github.com/mattn/goveralls@v0.0.11
@@ -37,17 +34,13 @@ vendor:
 tag: all
 	git tag -s $(TAGVER) -a -m "$(TAGMSG)"
 
-lint:
-	$(GOPATH)/bin/golint $(PACKAGE_NAMES) | tee /tmp/autograph-golint.txt
-	test 0 -eq $$(grep -c -Pv 'stutters|suggestions' /tmp/autograph-golint.txt)
-
 # refs: https://github.com/mozilla-services/autograph/issues/247
 check-no-crypto11-in-signers:
 	test 0 -eq $(shell grep -Ri crypto11 signer/*/ | tee /tmp/autograph-crypto11-check.txt | wc -l)
 
 show-lints:
-	-cat /tmp/autograph-golint.txt /tmp/autograph-crypto11-check.txt /tmp/autograph-staticcheck.txt
-	-rm -f /tmp/autograph-golint.txt /tmp/autograph-crypto11-check.txt /tmp/autograph-staticcheck.txt
+	-cat /tmp/autograph-crypto11-check.txt /tmp/autograph-staticcheck.txt
+	-rm -f /tmp/autograph-crypto11-check.txt /tmp/autograph-staticcheck.txt
 
 vet:
 	go vet $(PACKAGE_NAMES)


### PR DESCRIPTION
This removes golint from the circleci config and the Makefile.

golint has been deprecated in favor of the vet and staticcheck tools.
See https://github.com/golang/lint?tab=readme-ov-file#readme and
https://github.com/golang/go/issues/38968
