### PR TITLE
remove unneeded grep of staticcheck output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,6 @@ race:
 
 staticcheck:
 	$(GOPATH)/bin/staticcheck $(PACKAGE_NAMES) | tee /tmp/autograph-staticcheck.txt
-	# ignore errors in pkgs
-	# ignore SA1019 for DSA being deprecated refs: GH #667
-	test 0 -eq $$(grep -c -Pv '^/go/pkg/mod/|SA1019' /tmp/autograph-staticcheck.txt)
 
 test:
 	go test -v -coverprofile coverage.out -covermode=count -count=1 $(PACKAGE_NAMES)


### PR DESCRIPTION
This grep was a hack to avoid fixing a deprecated API for DSA. The grep
command fails on macOS because `-P` doesn't exist on the default macOS
grep.

Fortunately, the use of the deprecated API was corrected in
https://github.com/mozilla-services/autograph/pull/770 (original ticket:
https://github.com/mozilla-services/autograph/issues/667), so we can
just drop it whole cloth.

In the future, I believe we'll want to use staticcheck's built-in ways
of ignoring certain lints, anyway:
https://staticcheck.io/docs/configuration/#ignoring-problems
