### PR TITLE
run gofmt on verifier/contentsignature

### DIFF
--- a/verifier/contentsignature/signature.go
+++ b/verifier/contentsignature/signature.go
@@ -9,7 +9,6 @@
 // in Firefox Desktop or [the rust application services
 // component](https://github.com/mozilla/application-services/) in
 // other Mozilla products.
-//
 package contentsignature // import "github.com/mozilla-services/autograph/verifier/contentsignature"
 
 import (

--- a/verifier/contentsignature/verifier.go
+++ b/verifier/contentsignature/verifier.go
@@ -17,7 +17,6 @@ import (
 // cert. It does not validate the certificates or the chain.
 //
 // It returns the slice of three certs or an empty slice and an error.
-//
 func ParseChain(chain []byte) (certs []*x509.Certificate, err error) {
 	block, rest := pem.Decode(chain)
 	if block == nil || block.Type != "CERTIFICATE" {
@@ -101,7 +100,6 @@ func verifyRoot(rootHash string, cert *x509.Certificate) error {
 // 1) signed by their parent/issuer/the next cert in the chain or all verifyRoot checks for the root
 // 2) valid for the current time i.e. cert NotBefore < current time < cert NotAfter
 // 3) the chain follows name constraints and extended key usage as checked by x509 Certificate.Verify
-//
 func VerifyChain(rootHash string, certs []*x509.Certificate, currentTime time.Time) error {
 	if len(certs) != 3 {
 		return fmt.Errorf("can only verify 3 certificate chain, got %d certs", len(certs))
@@ -172,7 +170,6 @@ func VerifyChain(rootHash string, certs []*x509.Certificate, currentTime time.Ti
 // then verifies the cert chain of trust maps to the signed data.
 //
 // It returns an error if it fails or nil on success.
-//
 func Verify(input, certChain []byte, signature, rootHash string) error {
 	certs, err := ParseChain(certChain)
 	if err != nil {

--- a/verifier/contentsignature/verifier_test.go
+++ b/verifier/contentsignature/verifier_test.go
@@ -583,7 +583,7 @@ wNuvFqc=
 // NB: these certs do no exactly match the result of parsing
 // ExpiredEndEntityChain
 var ExpiredEndEntityChainCerts = []*x509.Certificate{
-	&x509.Certificate{
+	{
 		Subject: pkix.Name{
 			CommonName:         "normandy.content-signature.mozilla.org",
 			Organization:       []string{"Mozilla Corporation"},
@@ -598,7 +598,7 @@ var ExpiredEndEntityChainCerts = []*x509.Certificate{
 		DNSNames:  []string{"normandy.content-signature.mozilla.org"},
 		KeyUsage:  x509.KeyUsageDigitalSignature,
 	},
-	&x509.Certificate{
+	{
 		Subject: pkix.Name{
 			CommonName:         "Content Signing Intermediate",
 			Organization:       []string{"Mozilla Corporation"},
@@ -614,7 +614,7 @@ var ExpiredEndEntityChainCerts = []*x509.Certificate{
 		KeyUsage:            x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
 		PermittedDNSDomains: []string{".content-signature.mozilla.org", "content-signature.mozilla.org"},
 	},
-	&x509.Certificate{
+	{
 		Subject: pkix.Name{
 			CommonName:         "root-ca-production-amo",
 			Organization:       []string{"Mozilla Corporation"},
@@ -734,7 +734,7 @@ wNuvFqc=
 // NB: these certs do no exactly match the result of parsing
 // WronglyOrderedChain
 var WronglyOrderedChainCerts = []*x509.Certificate{
-	&x509.Certificate{
+	{
 		Subject: pkix.Name{
 			CommonName:         "Content Signing Intermediate/emailAddress=foxsec@mozilla.com",
 			Organization:       []string{"Mozilla Corporation"},
@@ -750,7 +750,7 @@ var WronglyOrderedChainCerts = []*x509.Certificate{
 		KeyUsage:            x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
 		PermittedDNSDomains: []string{".content-signature.mozilla.org", "content-signature.mozilla.org"},
 	},
-	&x509.Certificate{
+	{
 		Subject: pkix.Name{
 			CommonName:         "normandy.content-signature.mozilla.org",
 			Organization:       []string{"Mozilla Corporation"},
@@ -765,7 +765,7 @@ var WronglyOrderedChainCerts = []*x509.Certificate{
 		DNSNames:  []string{"normandy.content-signature.mozilla.org"},
 		KeyUsage:  x509.KeyUsageDigitalSignature,
 	},
-	&x509.Certificate{
+	{
 		Subject: pkix.Name{
 			CommonName:         "root-ca-production-amo",
 			Organization:       []string{"Mozilla Corporation"},
@@ -911,7 +911,7 @@ Gbste+8S5QCMhh00g5vR9QF8EaFqdxCdSxrsA4GmpCa5UQl8jtCnpp2DLKXuOh72
 // NB: these certs do no exactly match the result of parsing
 // NormandyDevChain2021
 var NormandyDevChain2021Certs = []*x509.Certificate{
-	&x509.Certificate{
+	{
 		Subject: pkix.Name{
 			CommonName:         "normandy.content-signature.mozilla.org",
 			Organization:       []string{"Mozilla Corporation"},
@@ -926,7 +926,7 @@ var NormandyDevChain2021Certs = []*x509.Certificate{
 		DNSNames:  []string{"normandy.content-signature.mozilla.org"},
 		KeyUsage:  x509.KeyUsageDigitalSignature,
 	},
-	&x509.Certificate{
+	{
 		Subject: pkix.Name{
 			CommonName:         "Devzilla Signing Services Intermediate 1",
 			Organization:       []string{"Allizom"},
@@ -941,7 +941,7 @@ var NormandyDevChain2021Certs = []*x509.Certificate{
 		IsCA:      true,
 		DNSNames:  nil,
 	},
-	&x509.Certificate{
+	{
 		Subject: pkix.Name{
 			CommonName:         "dev.content-signature.root.ca",
 			Organization:       []string{"Content Signature Dev Signing"},
@@ -1002,10 +1002,10 @@ func Test_ParseChain(t *testing.T) {
 			wantErrStr: []string{"failed to PEM decode EE/leaf certificate from chain"},
 		},
 		{
-			name:       "EE bad PEM content fails",
-			chain:      []byte(badPEMContent),
-			wantCerts:  []*x509.Certificate{},
-			wantErr:    true,
+			name:      "EE bad PEM content fails",
+			chain:     []byte(badPEMContent),
+			wantCerts: []*x509.Certificate{},
+			wantErr:   true,
 			wantErrStr: []string{
 				"error parsing EE/leaf certificate from chain: asn1: structure error: tags don't match",
 				"error parsing EE/leaf certificate from chain: x509: malformed tbs certificate",
@@ -1019,10 +1019,10 @@ func Test_ParseChain(t *testing.T) {
 			wantErrStr: []string{"failed to PEM decode intermediate certificate from chain"},
 		},
 		{
-			name:       "inter bad PEM content fails",
-			chain:      []byte(firefoxPkiStageRoot + "\n" + badPEMContent),
-			wantCerts:  []*x509.Certificate{},
-			wantErr:    true,
+			name:      "inter bad PEM content fails",
+			chain:     []byte(firefoxPkiStageRoot + "\n" + badPEMContent),
+			wantCerts: []*x509.Certificate{},
+			wantErr:   true,
 			wantErrStr: []string{
 				"failed to parse intermediate certificate from chain: asn1: structure error: tags don't match",
 				"failed to parse intermediate certificate from chain: x509: malformed tbs certificate",
@@ -1036,10 +1036,10 @@ func Test_ParseChain(t *testing.T) {
 			wantErrStr: []string{"failed to PEM decode root certificate from chain"},
 		},
 		{
-			name:       "inter bad PEM content fails",
-			chain:      []byte(firefoxPkiStageRoot + "\n" + firefoxPkiStageRoot + "\n" + badPEMContent),
-			wantCerts:  []*x509.Certificate{},
-			wantErr:    true,
+			name:      "inter bad PEM content fails",
+			chain:     []byte(firefoxPkiStageRoot + "\n" + firefoxPkiStageRoot + "\n" + badPEMContent),
+			wantCerts: []*x509.Certificate{},
+			wantErr:   true,
 			wantErrStr: []string{
 				"failed to parse root certificate from chain: asn1: structure error: tags don't match",
 				"failed to parse root certificate from chain: x509: malformed tbs certificate",


### PR DESCRIPTION
This is the output of running `gofmt -s -w ./verifier/contentsignature`.

Found these changes lurking around when fixing up the ioutil
deprecations in #911
