### PR TITLE
AUT-105: Add GitHub Workflows for building, integration and unit testing.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -117,4 +117,4 @@ jobs:
 
       - name: Running ${{ matrix.testcase }}
         shell: bash
-        run: docker compose run ${{ matrix.testcase }}
+        run: docker compose -f tools/autograph-client/integration-tests.yml run ${{ matrix.testcase }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
- 
+
       - name: Build images
         shell: bash
         run: make generate build
@@ -53,7 +53,7 @@ jobs:
     env:
       DBNAME: autograph
       PGPASSWORD: myautographdbpassword
-    
+
     services:
       database:
         image: postgres:11
@@ -72,7 +72,7 @@ jobs:
         with:
           name: autograph-images-${{ github.sha }}
           path: docker-cache/
-      
+
       - name: Initialize database
         shell: bash
         run: psql -h localhost -p 5432 -U postgres --no-password -f database/schema.sql ${{ env.DBNAME }}
@@ -84,12 +84,10 @@ jobs:
       - name: Run Tests
         shell: bash
         env:
-          AUTOGRAPH_DB_DSN: host=localhost user=myautographdbuser dbname=${{ env.DBNAME }} password=${{ env.PGPASSWORD }} sslmode=disable
-          AUTOGRAPH_DB_HOST: localhost
+          AUTOGRAPH_DB_DSN: postgres://myautographdbuser:${{ env.PGPASSWORD }}@localhost/${{ env.DBNAME }}?sslmode=disable
         run: |
           docker run \
             --env AUTOGRAPH_DB_DSN \
-            --env AUTOGRAPH_DB_HOST \
             --env RACE_TEST=0 \
             --workdir /app/src/autograph \
             --net=host \
@@ -113,12 +111,11 @@ jobs:
         with:
           name: autograph-images-${{ github.sha }}
           path: docker-cache/
-      
+
       - name: Load images
         shell: bash
         run: gunzip -c docker-cache/autograph-images.tgz | docker load
-      
-      # FIXME: This could be done so much better with a matrix job.
+
       - name: Running ${{ matrix.testcase }}
         shell: bash
         run: docker compose run ${{ matrix.testcase }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,19 +41,51 @@ jobs:
     runs-on: ubuntu-22.04
     needs:
       - build
+    env:
+      DBNAME: autograph
+      PGPASSWORD: myautographdbpassword
+    
+    services:
+      database:
+        image: postgres:11
+        env:
+          POSTGRES_DB: ${{ env.DBNAME }}
+          POSTGRES_PASSWORD: ${{ env.PGPASSWORD }}
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+
     steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           name: autograph-images-${{ github.sha }}
           path: docker-cache/
       
+      - name: Initialize database
+        shell: bash
+        run: psql -h localhost -p 5432 -U postgres --no-password -f database/schema.sql ${{ env.DBNAME }}
+
       - name: Load images
         shell: bash
         run: gunzip -c docker-cache/autograph-images.tgz | docker load
 
       - name: Run Tests
         shell: bash
-        run: docker compose run unit-test
+        env:
+          AUTOGRAPH_DB_DSN: host=localhost user=myautographdbuser dbname=${{ env.DBNAME }} password=${{ env.PGPASSWORD }} sslmode=disable
+          AUTOGRAPH_DB_HOST: localhost
+        run: |
+          docker run \
+            --env AUTOGRAPH_DB_DSN \
+            --env AUTOGRAPH_DB_HOST \
+            --env RACE_TEST=0 \
+            --workdir /app/src/autograph \
+            --net=host \
+            --user 0 \
+            autograph-app ./bin/run_unit_tests.sh
 
   integration-tests:
     runs-on: ubuntu-22.04

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,37 @@
+name: Tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+# Restrict tests to the most recent commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Docker Images
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+ 
+      - name: Build images
+        shell: bash
+        run: make generate build
+
+      - name: Save images
+        shell: bash
+        run: |
+            mkdir -p docker-cache
+            docker save "autograph-app" | gzip -c > docker-cache/autograph-app.tgz
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: autograph-app-${{ github.sha }}
+          compression-level: 0
+          path: docker-cache/autograph-app.tgz

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,7 +30,7 @@ jobs:
         shell: bash
         run: |
             mkdir -p docker-cache
-            docker save autograph-app autograph-app-hsm | gzip -c > docker-cache/autograph-images.tgz
+            docker save -o docker-cache/autograph-images.tar autograph-app autograph-app-hsm
 
       - name: Enumerate tests
         id: enum-tests
@@ -42,7 +42,6 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: autograph-images-${{ github.sha }}
-          compression-level: 0
           path: docker-cache/
 
   unit-tests:
@@ -79,7 +78,7 @@ jobs:
 
       - name: Load images
         shell: bash
-        run: gunzip -c docker-cache/autograph-images.tgz | docker load
+        run: docker load -i docker-cache/autograph-images.tar
 
       - name: Run Tests
         shell: bash
@@ -114,7 +113,7 @@ jobs:
 
       - name: Load images
         shell: bash
-        run: gunzip -c docker-cache/autograph-images.tgz | docker load
+        run: docker load -i docker-cache/autograph-images.tar
 
       - name: Running ${{ matrix.testcase }}
         shell: bash

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,6 +16,8 @@ jobs:
   build:
     name: Build Docker Images
     runs-on: ubuntu-22.04
+    outputs:
+      testcases: ${{ steps.enum-tests.outputs.testcases }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
@@ -29,6 +31,13 @@ jobs:
         run: |
             mkdir -p docker-cache
             docker save autograph-app autograph-app-hsm | gzip -c > docker-cache/autograph-images.tgz
+
+      - name: Enumerate tests
+        id: enum-tests
+        shell: bash
+        run: |
+            echo -n "testcases=" >> $GITHUB_OUTPUT
+            yq -o=json '.services | keys' tools/autograph-client/integration-tests.yml | jq -c >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v4
         with:
@@ -88,10 +97,14 @@ jobs:
             autograph-app ./bin/run_unit_tests.sh
 
   integration-tests:
+    name: Run Integration Tests
     runs-on: ubuntu-22.04
     needs:
       - build
-    name: Run Integration Tests
+    strategy:
+      fail-fast: false # Don't cancel other jobs if a test fails
+      matrix:
+        testcase: ${{ fromJSON(needs.build.outputs.testcases) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
@@ -106,6 +119,6 @@ jobs:
         run: gunzip -c docker-cache/autograph-images.tgz | docker load
       
       # FIXME: This could be done so much better with a matrix job.
-      - name: Run Tests
+      - name: Running ${{ matrix.testcase }}
         shell: bash
-        run: ./bin/run_integration_tests.sh
+        run: docker compose run ${{ matrix.testcase }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,10 +28,52 @@ jobs:
         shell: bash
         run: |
             mkdir -p docker-cache
-            docker save "autograph-app" | gzip -c > docker-cache/autograph-app.tgz
+            docker save autograph-app autograph-app-hsm | gzip -c > docker-cache/autograph-images.tgz
 
       - uses: actions/upload-artifact@v4
         with:
-          name: autograph-app-${{ github.sha }}
+          name: autograph-images-${{ github.sha }}
           compression-level: 0
-          path: docker-cache/autograph-app.tgz
+          path: docker-cache/
+
+  unit-tests:
+    name: Run Unit Tests
+    runs-on: ubuntu-22.04
+    needs:
+      - build
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: autograph-images-${{ github.sha }}
+          path: docker-cache/
+      
+      - name: Load images
+        shell: bash
+        run: gunzip -c docker-cache/autograph-images.tgz | docker load
+
+      - name: Run Tests
+        shell: bash
+        run: docker compose run unit-test
+
+  integration-tests:
+    runs-on: ubuntu-22.04
+    needs:
+      - build
+    name: Run Integration Tests
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: autograph-images-${{ github.sha }}
+          path: docker-cache/
+      
+      - name: Load images
+        shell: bash
+        run: gunzip -c docker-cache/autograph-images.tgz | docker load
+      
+      # FIXME: This could be done so much better with a matrix job.
+      - name: Run Tests
+        shell: bash
+        run: ./bin/run_integration_tests.sh

--- a/bin/run_integration_tests.sh
+++ b/bin/run_integration_tests.sh
@@ -31,17 +31,17 @@ APP_HSM_NORMANDY_ROOT_HASH=$(grep '[0-9A-F]' normandy_dev_root_hash.txt | tr -d 
 # start the monitor lambda emulators
 echo "checking autograph monitors"
 docker compose run \
-			--rm \
-      		-e AUTOGRAPH_URL=http://app:8000/ \
-			--entrypoint /usr/local/bin/lambda-selftest-entrypoint.sh \
-			monitor-lambda-emulator /go/bin/autograph-monitor
+	       --rm \
+	       -e AUTOGRAPH_URL=http://app:8000/ \
+	       --entrypoint /usr/local/bin/lambda-selftest-entrypoint.sh \
+	       monitor-lambda-emulator /go/bin/autograph-monitor
 
 docker compose run \
-			--rm \
-      		-e AUTOGRAPH_URL=http://autograph-app-hsm:8001/ \
-			-e AUTOGRAPH_ROOT_HASH=$APP_HSM_NORMANDY_ROOT_HASH \
-			--entrypoint /usr/local/bin/lambda-selftest-entrypoint.sh \
-			monitor-hsm-lambda-emulator /go/bin/autograph-monitor
+	       --rm \
+	       -e AUTOGRAPH_URL=http://autograph-app-hsm:8001/ \
+	       -e AUTOGRAPH_ROOT_HASH=$APP_HSM_NORMANDY_ROOT_HASH \
+	       --entrypoint /usr/local/bin/lambda-selftest-entrypoint.sh \
+	       monitor-hsm-lambda-emulator /go/bin/autograph-monitor
 
 echo "checking read-only API"
 # user bob doesn't exist in the softhsm config
@@ -93,7 +93,7 @@ docker compose run \
 	       --rm \
 	       --user 0 \
 	       -e TARGET=http://app:8000 \
-               -e VERIFY=1 \
+	       -e VERIFY=1 \
 	       --workdir /app/src/autograph/tools/autograph-client \
 	       --entrypoint ./build_test_apks.sh \
 	       app

--- a/bin/run_integration_tests.sh
+++ b/bin/run_integration_tests.sh
@@ -29,26 +29,19 @@ docker cp autograph-app-hsm:/tmp/normandy_dev_root_hash.txt .
 APP_HSM_NORMANDY_ROOT_HASH=$(grep '[0-9A-F]' normandy_dev_root_hash.txt | tr -d '\r\n')
 
 # start the monitor lambda emulators
-docker compose up -d monitor-lambda-emulator
-AUTOGRAPH_ROOT_HASH=$APP_HSM_NORMANDY_ROOT_HASH docker compose up -d monitor-hsm-lambda-emulator
+echo "checking autograph monitors"
+docker compose run \
+			--rm \
+      		-e AUTOGRAPH_URL=http://app:8000/ \
+			--entrypoint /usr/local/bin/lambda-selftest-entrypoint.sh \
+			monitor-lambda-emulator /go/bin/autograph-monitor
 
-echo "waiting for monitor-lambda-emulator to start"
-while test "true" != "$(docker inspect -f {{.State.Running}} autograph-monitor-lambda-emulator)"; do
-  echo -n "."
-  sleep 1 # wait before checking again
-done
-echo "waiting for monitor-hsm-lambda-emulator to start"
-while test "true" != "$(docker inspect -f {{.State.Running}} autograph-monitor-hsm-lambda-emulator)"; do
-  echo -n "."
-  sleep 1 # wait before checking again
-done
-
-echo "checking monitoring using hsm root hash:" "$APP_HSM_NORMANDY_ROOT_HASH"
-# exec in containers to workaround https://circleci.com/docs/2.0/building-docker-images/#accessing-services
-docker compose exec monitor-lambda-emulator "/usr/local/bin/test_monitor.sh"
-docker compose logs monitor-lambda-emulator
-docker compose exec monitor-hsm-lambda-emulator "/usr/local/bin/test_monitor.sh"
-docker compose logs monitor-hsm-lambda-emulator
+docker compose run \
+			--rm \
+      		-e AUTOGRAPH_URL=http://autograph-app-hsm:8001/ \
+			-e AUTOGRAPH_ROOT_HASH=$APP_HSM_NORMANDY_ROOT_HASH \
+			--entrypoint /usr/local/bin/lambda-selftest-entrypoint.sh \
+			monitor-hsm-lambda-emulator /go/bin/autograph-monitor
 
 echo "checking read-only API"
 # user bob doesn't exist in the softhsm config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,10 +66,7 @@ services:
   monitor:
     container_name: autograph-monitor
     image: autograph-app
-    command:
-      [
-        "/go/bin/autograph-monitor",
-      ]
+    command: ["/go/bin/autograph-monitor"]
 
   monitor-lambda-emulator:
     container_name: autograph-monitor-lambda-emulator
@@ -83,6 +80,7 @@ services:
       # set a non-empty value to use the lambda handler
       - LAMBDA_TASK_ROOT=/usr/local/bin/
       - AUTOGRAPH_ROOT_HASH
+    command: ["/go/bin/autograph-monitor"]
     ports:
       - "9000:8080"
     links:
@@ -104,6 +102,7 @@ services:
       # set a non-empty value to use the lambda handler
       - LAMBDA_TASK_ROOT=/usr/local/bin/
       - AUTOGRAPH_ROOT_HASH
+    command: ["/go/bin/autograph-monitor"]
     ports:
       - "9001:8080"
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 volumes:
   apptmpdir:
   hsmtmpdir:
-include:
-  - tools/autograph-client/integration-tests.yml
 services:
   db:
     container_name: autograph-db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 volumes:
   apptmpdir:
   hsmtmpdir:
+include:
+  - tools/autograph-client/integration-tests.yml
 services:
   db:
     container_name: autograph-db

--- a/tools/autograph-client/integration-tests.yml
+++ b/tools/autograph-client/integration-tests.yml
@@ -1,0 +1,56 @@
+services:
+  test-api-app:
+    container_name: test-api-app
+    image: autograph-app
+    user: "0"
+    links:
+      - app
+    depends_on:
+      - app
+    environment:
+      - CHECK_BOB=1
+      - AUTOGRAPH_URL=http://app:8000
+    working_dir: "/app/src/autograph/tools/autograph-client"
+    command: [ "./integration_test_api.sh" ]
+
+  test-api-hsm:
+    container_name: test-api-hsm
+    image: autograph-app
+    user: "0"
+    links:
+      - app-hsm
+    depends_on:
+      - app-hsm
+    environment:
+      - AUTOGRAPH_URL=http://app-hsm:8001
+    working_dir: "/app/src/autograph/tools/autograph-client"
+    command: [ "./integration_test_api.sh" ]
+
+  test-gpg-signing:
+    container_name: test-gpg-signing
+    extends:
+      service: test-api-app
+    command: [ "./integration_test_gpg2_signer.sh" ]
+
+  test-xpi-signing:
+    container_name: test-xpi-signing
+    extends:
+      service: test-api-app
+    command: [ "./integration_test_xpis.sh" ]
+
+  test-xpi-signing-hsm:
+    container_name: test-xpi-signing-hsm
+    extends:
+      service: test-api-hsm
+    environment:
+      - SIGNER_ID_PREFIX=hsm-
+    command: [ "./integration_test_xpis.sh" ]
+
+  test-apk-signing:
+    container_name: test-apk-signing
+    extends:
+      service: test-api-app
+    environment:
+      - TARGET=http://app:8000
+      - VERIFY=1
+    command: [ "./build_test_apks.sh" ]

--- a/tools/autograph-client/integration-tests.yml
+++ b/tools/autograph-client/integration-tests.yml
@@ -7,6 +7,7 @@ services:
       - app
     depends_on:
       - app
+    entrypoint: ./test-entrypoint.sh
     environment:
       - CHECK_BOB=1
       - AUTOGRAPH_URL=http://app:8000
@@ -21,6 +22,7 @@ services:
       - app-hsm
     depends_on:
       - app-hsm
+    entrypoint: ./test-entrypoint.sh
     environment:
       - AUTOGRAPH_URL=http://app-hsm:8001
     working_dir: "/app/src/autograph/tools/autograph-client"

--- a/tools/autograph-client/integration-tests.yml
+++ b/tools/autograph-client/integration-tests.yml
@@ -58,3 +58,13 @@ services:
       - TARGET=http://app:8000
       - VERIFY=1
     command: [ "./build_test_apks.sh" ]
+
+  test-monitor-app:
+    container_name: test-monitor-app
+    extends:
+      file: ../../docker-compose.yml
+      service: monitor-lambda-emulator
+    entrypoint: [ "/usr/local/bin/lambda-selftest-entrypoint.sh" ]
+
+  # TODO: Add a monitor test for the HSM lambda - tricky because we need
+  # a way to dynamically grab the root hash from the HSM.

--- a/tools/autograph-client/integration-tests.yml
+++ b/tools/autograph-client/integration-tests.yml
@@ -1,3 +1,5 @@
+include:
+  - ../../docker-compose.yml
 services:
   test-api-app:
     container_name: test-api-app

--- a/tools/autograph-client/test-entrypoint.sh
+++ b/tools/autograph-client/test-entrypoint.sh
@@ -20,4 +20,4 @@ fi
 
 # Run the test
 set -e
-/bin/bash -c "$@"
+exec "$@"

--- a/tools/autograph-client/test-entrypoint.sh
+++ b/tools/autograph-client/test-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+
+# Wait for the heartbeat
+RESULT=$(curl --silent \
+              --connect-timeout 5 \
+              --max-time 10 \
+              --retry-connrefused \
+              --retry 5 \
+              --retry-delay 5 \
+              --retry-max-time 60 \
+              "${AUTOGRAPH_URL}/__heartbeat__")
+RETCODE=$?
+if [ $RETCODE -ne 0 ]; then
+    echo "Failed to reach autograph heartbeat" >&2
+    exit $RETCODE
+else
+    echo "Autograph is running: ${RESULT}"
+    echo "Starting test"
+fi
+
+# Run the test
+set -e
+/bin/bash -c "$@"

--- a/tools/autograph-monitor/Dockerfile.lambda-emulator
+++ b/tools/autograph-monitor/Dockerfile.lambda-emulator
@@ -2,11 +2,13 @@ FROM autograph-app
 
 USER root
 
-RUN cp /app/src/autograph/bin/test_monitor.sh /usr/local/bin/test_monitor.sh
 RUN curl -Lo /usr/local/bin/aws-lambda-rie \
     https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/latest/download/aws-lambda-rie \
     && \
-    chmod +x /usr/local/bin/aws-lambda-rie /usr/local/bin/test_monitor.sh
+    chmod +x /usr/local/bin/aws-lambda-rie
+
+COPY lambda-selftest-entrypoint.sh /usr/local/bin/lambda-selftest-entrypoint.sh
 
 USER app
-CMD ["/usr/local/bin/aws-lambda-rie", "/go/bin/autograph-monitor"]
+ENTRYPOINT ["/usr/local/bin/aws-lambda-rie"]
+CMD ["/go/bin/autograph-monitor"]

--- a/tools/autograph-monitor/lambda-selftest-entrypoint.sh
+++ b/tools/autograph-monitor/lambda-selftest-entrypoint.sh
@@ -3,8 +3,17 @@
 set -e
 set -o pipefail
 
+# Fork to start the AWS runtime emulator
+/usr/local/bin/aws-lambda-rie "$@" &
+AWS_RUNTIME_PID=$!
+cleanup() {
+    kill -TERM $AWS_RUNTIME_PID
+    wait $AWS_RUNTIME_PID
+}
+trap cleanup EXIT SIGINT SIGTERM
+
 # invoke a test monitor run in a lambda monitor
-MONITOR_ERROR=$(curl -w '\n' -X POST 'http://localhost:8080/2015-03-31/functions/function/invocations' -d '{}')
+MONITOR_ERROR=$(curl -s -w '\n' -X POST 'http://localhost:8080/2015-03-31/functions/function/invocations' -d '{}')
 
 # If the result was null - then we succeeded!
 if [ "${MONITOR_ERROR}" == "null" ]; then
@@ -19,4 +28,3 @@ else
     echo "${MONITOR_ERROR}" | jq >&2
 fi
 exit 1
-


### PR DESCRIPTION
This attempts to add a Github workflow to build the docker images then run the unit and integration tests. While github seems to build slower than CircleCI, we make up for it by running the integration tests in parallel with a matrix job.

In order to get the monitor tests working, we had to cherry-pick PR #908 onto this branch to clean up the handoff of the root hash between autograph and the lambda emulator.

This makes no attempt to deploy the image as we will need Dockerhub credentials to do that, and it would be better suited for a followup PR.

For a quick high-level tour of how this works:
- We create a new docker compose file `tools/autograph-client/integration-tests.yml` which extends the top level compose file, and adds a service for each integration test. This allows each test to define which container it runs on, the dependencies and how to run the test.
- Use Docker entrypoints for the tests to resolve startup timing between containers (IMO, this is a bug in Docker compose, but it's above my paygrade to fix that).
- Write a github action to build the docker containers and upload it as an artifact.
- Parse the integration test YAML to enumerate the test jobs.
- Use a matrix job to download the container and run the tests in parallel.