### PR TITLE
fix: speed up integration test times & cleanup

### DIFF
--- a/bin/run_integration_tests.sh
+++ b/bin/run_integration_tests.sh
@@ -52,14 +52,16 @@ docker compose run \
 	       -e AUTOGRAPH_URL=http://app:8000 \
 	       --workdir /app/src/autograph/tools/autograph-client \
 	       --entrypoint ./integration_test_api.sh \
-	       app
+	       app &
 docker compose run \
 	       --rm \
 	       --user 0 \
 	       -e AUTOGRAPH_URL=http://app-hsm:8001 \
 	       --workdir /app/src/autograph/tools/autograph-client \
 	       --entrypoint ./integration_test_api.sh \
-	       app-hsm
+	       app-hsm &
+
+wait
 
 echo "checking gpg signing"
 docker compose run \
@@ -78,7 +80,7 @@ docker compose run \
 	       -e AUTOGRAPH_URL=http://app:8000 \
 	       --workdir /app/src/autograph/tools/autograph-client \
 	       --entrypoint ./integration_test_xpis.sh \
-	       app
+	       app &
 docker compose run \
 	       --rm \
 	       --user 0 \
@@ -86,7 +88,9 @@ docker compose run \
 	       -e SIGNER_ID_PREFIX="hsm-" \
 	       --workdir /app/src/autograph/tools/autograph-client \
 	       --entrypoint ./integration_test_xpis.sh \
-	       app-hsm
+	       app-hsm &
+
+wait
 
 echo "checking APK signing"
 docker compose run \

--- a/bin/run_integration_tests.sh
+++ b/bin/run_integration_tests.sh
@@ -98,3 +98,6 @@ docker compose run \
 	       --entrypoint ./build_test_apks.sh \
 	       app
 # TODO(GH-381): add HSM support for APK signing keys and test here
+
+echo "cleaning up"
+rm normandy_dev_root_hash.txt

--- a/tools/autograph-client/build_test_apks.sh
+++ b/tools/autograph-client/build_test_apks.sh
@@ -18,27 +18,30 @@ HAWK_SECRET=${HAWK_SECRET:-fs5wgcer9qj819kfptdlp8gm227ewxnzvsuj9ztycsx08hfhzu}
 TARGET=${TARGET:-'http://127.0.0.1:8000'}
 
 # Sign Fennec Beta
-go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f fennec-beta.apk -o fennec-legacy-sha1.resigned.apk -k legacy_apk_with_rsa -pk7digest sha1
+go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f fennec-beta.apk -o fennec-legacy-sha1.resigned.apk -k legacy_apk_with_rsa -pk7digest sha1 &
 
 # Sign with ECDSA
-go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f focus-latest.apk -o focus-ecdsa.v2.resigned.apk -k apk_cert_with_ecdsa_sha256
+go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f focus-latest.apk -o focus-ecdsa.v2.resigned.apk -k apk_cert_with_ecdsa_sha256 &
 
 # Sign with RSA
-go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f focus-latest.apk -o focus-rsa.v2.resigned.apk -k testapp-android
+go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f focus-latest.apk -o focus-rsa.v2.resigned.apk -k testapp-android &
 
 # Sign Aligned APK with ECDSA
-go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f ../../signer/apk2/aligned-two-files.apk -o aligned-two-files.ecdsa.v2.signed.apk -k apk_cert_with_ecdsa_sha256
+go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f ../../signer/apk2/aligned-two-files.apk -o aligned-two-files.ecdsa.v2.signed.apk -k apk_cert_with_ecdsa_sha256 &
 
 # Sign Aligned APK with RSA
-go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f ../../signer/apk2/aligned-two-files.apk -o aligned-two-files.rsa.signed.apk -k testapp-android-legacy
+go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f ../../signer/apk2/aligned-two-files.apk -o aligned-two-files.rsa.signed.apk -k testapp-android-legacy &
 
 # Sign aligned APK with v3 sigs using RSA and ECDSA keys
-go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f ../../signer/apk2/aligned-two-files.apk -o aligned-two-files.rsa.v2.v3.signed.apk -k testapp-android-v3
-go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f ../../signer/apk2/aligned-two-files.apk -o aligned-two-files.ecdsa.v2.v3.signed.apk -k apk_cert_with_ecdsa_sha256_v3
+go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f ../../signer/apk2/aligned-two-files.apk -o aligned-two-files.rsa.v2.v3.signed.apk -k testapp-android-v3 &
+go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f ../../signer/apk2/aligned-two-files.apk -o aligned-two-files.ecdsa.v2.v3.signed.apk -k apk_cert_with_ecdsa_sha256_v3 &
 
 # Resign v2 sigs with v3 sigs using RSA and ECDSA keys
-go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f focus-rsa.v2.resigned.apk -o focus-rsa.v2.v3.resigned.apk -k testapp-android-v3
-go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f focus-ecdsa.v2.resigned.apk -o focus-ecdsa.v2.v3.resigned.apk -k apk_cert_with_ecdsa_sha256_v3
+go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f focus-rsa.v2.resigned.apk -o focus-rsa.v2.v3.resigned.apk -k testapp-android-v3 &
+go run client.go -t $TARGET -u $HAWK_USER -p $HAWK_SECRET -f focus-ecdsa.v2.resigned.apk -o focus-ecdsa.v2.v3.resigned.apk -k apk_cert_with_ecdsa_sha256_v3 &
+
+# Wait for all the signing to be done
+wait
 
 VERIFY=${VERIFY:-"0"}
 if [ "$VERIFY" = "1" ]; then

--- a/tools/autograph-client/build_test_xpis.sh
+++ b/tools/autograph-client/build_test_xpis.sh
@@ -32,41 +32,47 @@ if [ "$VERIFY" = "0" ]; then
     COMMON_ARGS="$COMMON_ARGS -noverify"
 fi
 
+# These tests don't interfere with each other, so they are backgrounded
+# and waited on after all are launched.
+
 # only PKCS7 SHA1
-go run client.go $COMMON_ARGS -pk7digest sha1 -o ${OUTPUT_BASENAME}-SHA1.zip
+go run client.go $COMMON_ARGS -pk7digest sha1 -o ${OUTPUT_BASENAME}-SHA1.zip &
 
 # PKCS7 SHA1 with COSE ES256
-go run client.go $COMMON_ARGS -pk7digest sha1 -o ${OUTPUT_BASENAME}-SHA1-ES256.zip -c ES256
+go run client.go $COMMON_ARGS -pk7digest sha1 -o ${OUTPUT_BASENAME}-SHA1-ES256.zip -c ES256 &
 
 # PKCS7 SHA1 with COSE ES512
-go run client.go $COMMON_ARGS -pk7digest sha1 -o ${OUTPUT_BASENAME}-SHA1-ES256.zip -c ES512
+go run client.go $COMMON_ARGS -pk7digest sha1 -o ${OUTPUT_BASENAME}-SHA1-ES256.zip -c ES512 &
 
 # PKCS7 SHA1 with COSE PS256
-go run client.go $COMMON_ARGS -pk7digest sha1 -o ${OUTPUT_BASENAME}-SHA1-PS256.zip -c PS256
+go run client.go $COMMON_ARGS -pk7digest sha1 -o ${OUTPUT_BASENAME}-SHA1-PS256.zip -c PS256 &
 
 # PKCS7 SHA1 with COSE ES256 ES384 ES512 (multiple recognized)
-go run client.go $COMMON_ARGS -pk7digest sha1 -o ${OUTPUT_BASENAME}-SHA1-ES256-ES384-ES512.zip -c ES256 -c ES384 -c ES512
+go run client.go $COMMON_ARGS -pk7digest sha1 -o ${OUTPUT_BASENAME}-SHA1-ES256-ES384-ES512.zip -c ES256 -c ES384 -c ES512 &
 
 # PKCS7 SHA1 with COSE ES256 PS256 (multiple one Fx recognizes ES256 and another unrecognized PS256)
-go run client.go $COMMON_ARGS -pk7digest sha1  -o ${OUTPUT_BASENAME}-SHA1-ES256-PS256.zip -c ES256 -c PS256
+go run client.go $COMMON_ARGS -pk7digest sha1  -o ${OUTPUT_BASENAME}-SHA1-ES256-PS256.zip -c ES256 -c PS256 &
 
 
 # only PKCS7 SHA256
-go run client.go $COMMON_ARGS -pk7digest sha256 -o ${OUTPUT_BASENAME}-SHA256.zip
+go run client.go $COMMON_ARGS -pk7digest sha256 -o ${OUTPUT_BASENAME}-SHA256.zip &
 
 # PKCS7 SHA256 with COSE ES256
-go run client.go $COMMON_ARGS -pk7digest sha256 -o ${OUTPUT_BASENAME}-SHA256-ES256.zip -c ES256
+go run client.go $COMMON_ARGS -pk7digest sha256 -o ${OUTPUT_BASENAME}-SHA256-ES256.zip -c ES256 &
 
 # PKCS7 SHA256 with COSE ES512
-go run client.go $COMMON_ARGS -pk7digest sha256 -o ${OUTPUT_BASENAME}-SHA256-ES256.zip -c ES512
+go run client.go $COMMON_ARGS -pk7digest sha256 -o ${OUTPUT_BASENAME}-SHA256-ES256.zip -c ES512 &
 
 # PKCS7 SHA256 with COSE PS256
-go run client.go $COMMON_ARGS -pk7digest sha256 -o ${OUTPUT_BASENAME}-SHA256-PS256.zip -c PS256
+go run client.go $COMMON_ARGS -pk7digest sha256 -o ${OUTPUT_BASENAME}-SHA256-PS256.zip -c PS256 &
 
 # PKCS7 SHA256 with COSE ES256 ES384 ES512 (multiple recognized)
-go run client.go $COMMON_ARGS -pk7digest sha256 -o ${OUTPUT_BASENAME}-SHA256-ES256-ES384-ES512.zip -c ES256 -c ES384 -c ES512
+go run client.go $COMMON_ARGS -pk7digest sha256 -o ${OUTPUT_BASENAME}-SHA256-ES256-ES384-ES512.zip -c ES256 -c ES384 -c ES512 &
 
 # PKCS7 SHA256 with COSE ES256 PS256 (multiple one Fx recognizes ES256 and another unrecognized PS256)
-go run client.go $COMMON_ARGS -pk7digest sha256 -o ${OUTPUT_BASENAME}-SHA256-ES256-PS256.zip -c ES256 -c PS256
+go run client.go $COMMON_ARGS -pk7digest sha256 -o ${OUTPUT_BASENAME}-SHA256-ES256-PS256.zip -c ES256 -c PS256 &
+
+# Wait for tests to complete
+wait
 
 tar cvzf ${OUTPUT_BASENAME}.tgz ${OUTPUT_BASENAME}*.zip


### PR DESCRIPTION
We could probably eke more out of this by rearchitecting how they run, but this covers the low hanging fruit that stuck out to me. On my local machine, it takes integration tests from ~5m to ~1m30s.

In CI it looks like it took the CircleCI integration test from ~12min to ~7min, but only made small gains in the already parallelized integration tests for various signers.

This is mostly a quick hack. Feel free to reject it if it's undesirable for any reason.