### PR TITLE
create working CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,3 @@
-*       @g-k, @kkleemola, @pwnbus
+* @mozilla-services/autograph-devs @mozilla-services/autograph-mergers
 
-# the AMO team should review changes that impact Addon signing
-signer/xpi/	@willdurand
-
-# TODO: check with Mathieu
-# signer/contentsignature	@leplatrem
-# signer/contentsignaturepki	@leplatrem
+signer/xpi/ @mozilla-services/autograph-devs @mozilla-services/autograph-mergers @mozilla/addons-engineering


### PR DESCRIPTION
We would like to have code reviewers automatically alerted and assigned
when PRs are posted to autograph codebases. This is the next step
towards that for the autograph repo. One this merge, we'll enable the
automatic assignation in the GitHub repo settings (one day, we'll have
terraform for those settings, I hope).

Autograph is going to use the @mozilla-services/autograph-devs GitHub
team to provide automatic assignation of code reviewers in autograph.
These folks are expected to provide timely reviews of code coming into
autograph. See the autograph code review Confluence page for more.

As a back up and in order to provide some escape valves, we also have a
@mozilla-services/autograph-mergers. This team is folks who are trusted
to merge code but can't provide timely reviews like our SREs. This may
not be a team that we keep around in the future, but given our current
team size and volatility, it's a good back up.

Finally, the `addons.mozilla.org` teams has previously requested alerts
when code is changed in `signer/xpi`. We provide that here using the
same GitHub team as the one used in the mozilla/addons-server
CODEOWNERS.

Updates AUT-18
