### PR TITLE
adjust AMO team in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 * @mozilla-services/autograph-devs @mozilla-services/autograph-mergers
 
-signer/xpi/ @mozilla-services/autograph-devs @mozilla-services/autograph-mergers @mozilla/addons-engineering
+signer/xpi/ @mozilla-services/autograph-devs @mozilla-services/autograph-mergers @mozilla-services/addons-engineering


### PR DESCRIPTION
I'm pretty sure this is what we want. The team that [the original PR referenced](https://github.com/mozilla-services/autograph/pull/922) is in https://github.com/mozilla/addons-server/blob/master/.github/CODEOWNERS which is 5 years out of date.