### PR TITLE
finish off Go 1.22 upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,9 @@ version: 2.1
 jobs:
   lint-vet-fmt:
     docker:
-      - image: debian:bookworm
+      - image: cimg/go:1.22
     steps:
-      - run:
-          name: install dependencies
-          command: |
-            apt-get update
-            apt-get install -y golang build-essential git ca-certificates libltdl-dev
+      # TODO(AUT-158): this linting always succeeds even if there are errors, and future correct linting may need correct cgo compliation
       - checkout
       - run:
           name: check crypto11 not used in signers
@@ -38,7 +34,7 @@ jobs:
           command: |
             make vet
             make -C tools/autograph-monitor vet
-            make -C verifier/contentsignature vet 
+            make -C verifier/contentsignature vet
       - run:
           name: run staticcheck
           command: |
@@ -50,7 +46,7 @@ jobs:
   unit-test:
     # based on the official golang image with more docker stuff
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/go:1.22
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -80,7 +76,7 @@ jobs:
   build-integrationtest-verify:
     # based on the official golang image with more docker stuff
     docker:
-      - image: cimg/go:1.19
+      - image: cimg/go:1.22
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mozilla-services/autograph
 
-go 1.22
+go 1.22.5
 
 require (
 	github.com/DataDog/datadog-go v3.7.2+incompatible
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-lambda-go v1.27.0
 	github.com/aws/aws-sdk-go v1.42.15
 	github.com/golang/mock v1.6.0
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/lib/pq v1.10.4
@@ -40,7 +41,6 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
 	github.com/golang/protobuf v1.3.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
 	github.com/goware/prefixer v0.0.0-20160118172347-395022866408 // indirect
 	github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c // indirect


### PR DESCRIPTION
This patch cleans up some stragglers in the CircleCI config that were
still running on 1.19.

We also change `go.mod` to include the patch portion of the Go version.
Including `x.y.z`, not just `x.y` is what the Go 1.22 tooling (and, I
believe 1.21) does and expects. If we don't include the patch version,
various third party tools like GitHub's CodeQL can break (see
https://github.com/github/codeql/issues/15647 for the last time I ran
into this). This go.mod version change is actually what led me to the
other missing CircleCI version bumps as changing go.mod broke those
CircleCI jobs.

Along the way, we remove some dependency installations from the linting
CircleCI job. While future linting maybe need these dependencies, the
current ones do not.

I've made AUT-158 to consolidate our go linting stuff and avoid some of
these problems. Some (not all) of the rationale for AUT-158 will be
mooted by a move to GitHub Actions.

Along the way, I also ran `go mod tidy` which correctly noted that the
the google/uuid dep is now a direct dep. Hilariously, this is the change
I did first.

do less work in the lint-vet-fmt job
