### PR TITLE
bump go.mod go version to 1.22.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mozilla-services/autograph
 
-go 1.22.5
+go 1.22.1
 
 require (
 	github.com/DataDog/datadog-go v3.7.2+incompatible


### PR DESCRIPTION
This change is to speed up our build and CI.

Our current debian dpkg package install for Go installs Go 1.21.1. When
that version sees a Go 1.22.x version greater than itself, it downloads
and installs that newer version. This takes a lot of time and happens
across many of our CI jobs and docker image builds.

This downgrade will have no impact on our security posture
(its just for dep version selection) and our dependencies won't be
setting their minimum go version this high for a while.

It might be better for us to just install on a docker image that has the
right Go version installed and allows us to keep up to date in those
other dpkgs without doing `apt-get update`s (by having a cache of the
package info regularly updated and published as new docker image tags
and our dependabot can detect those).
