### PR TITLE
Fetch autograph logs in Github actions integration tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -123,7 +123,7 @@ jobs:
         shell: bash
         if: ${{ always() }}
         run: |
-          if echo "${{ matrix.testcase }}" | grep -q hsm;
+          if echo "${{ matrix.testcase }}" | grep -q hsm; then
             docker compose logs app-hsm
           else
             docker compose logs app

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -118,3 +118,13 @@ jobs:
       - name: Running ${{ matrix.testcase }}
         shell: bash
         run: docker compose -f tools/autograph-client/integration-tests.yml run ${{ matrix.testcase }}
+
+      - name: Fetching autograph logs
+        shell: bash
+        if: ${{ always() }}
+        run: |
+          if echo "${{ matrix.testcase }}" | grep -q hsm;
+            docker compose logs app-hsm
+          else
+            docker compose logs app
+          fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -124,7 +124,7 @@ jobs:
         if: ${{ always() }}
         run: |
           if echo "${{ matrix.testcase }}" | grep -q hsm; then
-            docker compose logs app-hsm
+            docker compose -f tools/autograph-client/integration-tests.yml logs app-hsm
           else
-            docker compose logs app
+            docker compose -f tools/autograph-client/integration-tests.yml logs app
           fi


### PR DESCRIPTION
This should add a step after an integration test runs that outputs the logs from the autograph container to the github workflow console. This should better allow us to investigate the cause of a failure. Note that the use of `if: ${{ always() }}` should cause this step to be run even if the preceeding steps result in a failure.