### PR TITLE
AUT-151: Deploy to Google Artifact Registry from Github Actions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,5 +1,6 @@
 name: Deploy
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,7 +24,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ vars.DOCKERHUB_REPO }}
+          images: ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY}}/autograph
           tags: |
             type=semver,pattern={{raw}}
             type=raw,value=latest,enable={{is_default_branch}}
@@ -33,11 +33,18 @@ jobs:
         shell: bash
         run: make generate
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
+      - id: gcp-auth
+        uses: google-github-actions/auth@v2
         with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          token_format: 'access_token'
+          service_account: artifact-writer@${{ env.GCP_PROJECT_ID}}.iam.gserviceaccount.com
+          workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GAR_LOCATION }}-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,10 +8,10 @@ on:
       - '[0-9]+.[0-9a-z]+.[0-9a-z]+'
 
 jobs:
-  dockerhub:
-    name: Dockerhub
+  docker:
+    name: Docker Images
     runs-on: ubuntu-22.04
-    environment: dockerhub
+    environment: build
     steps:
       - name: Clone repository
         uses: actions/checkout@v4

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,7 +25,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY}}/autograph
+          images: ${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GAR_REPOSITORY}}/autograph
           tags: |
             type=semver,pattern={{raw}}
             type=raw,value=latest,enable={{is_default_branch}}
@@ -38,12 +38,12 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           token_format: 'access_token'
-          service_account: artifact-writer@${{ env.GCP_PROJECT_ID}}.iam.gserviceaccount.com
+          service_account: artifact-writer@${{ vars.GCP_PROJECT_ID}}.iam.gserviceaccount.com
           workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
 
       - uses: docker/login-action@v3
         with:
-          registry: ${{ env.GAR_LOCATION }}-docker.pkg.dev
+          registry: ${{ vars.GAR_LOCATION }}-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.gcp-auth.outputs.access_token }}
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,47 @@
+name: Deploy
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '[0-9]+.[0-9a-z]+.[0-9a-z]+'
+
+jobs:
+  dockerhub:
+    name: Dockerhub
+    runs-on: ubuntu-22.04
+    environment: dockerhub
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ vars.DOCKERHUB_REPO }}
+          tags: |
+            type=semver,pattern={{raw}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Generate version.json
+        shell: bash
+        run: make generate
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          sbom: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          context: .

--- a/version.sh
+++ b/version.sh
@@ -13,11 +13,18 @@ if [ -n "$CIRCLE_SHA1" ]; then
         "$CIRCLE_PROJECT_USERNAME" \
         "$CIRCLE_PROJECT_REPONAME" \
         "$CIRCLE_BUILD_URL" > version.json
+elif [ -n "$GITHUB_SHA" ]; then
+    # We are running in Github Actions.
+    printf '{"commit":"%s","version":"%s","source":"%s","build":"%s"}\n' \
+        "$GITHUB_SHA" \
+        "$GITHUB_REF_NAME" \
+        "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
+        "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > version.json
 elif [ -d .git ]; then
     # Try pulling info from git directly.
     printf '{"commit":"%s","version":"%s","source":"%s","build":"%s"}\n' \
         "$(git rev-parse HEAD)" \
-        "$(git describe --tags)" \
+        "$(git describe --tags --always)" \
         "$(git remote get-url origin)" \
         "" > version.json
 elif [ ! -f version.json ]; then


### PR DESCRIPTION
This implements a github workflow which can push docker images to a registry using Docker's official `docker/build-push-action@v6`. This should push the built images to the google Google Artifact registry, but we should also be able to push to Dockerhub too simply by changing the `docker/login-action@v3` to target a different registry.

For this workflow to run successfully, we need to provide the following variables and secrets to the Github project:
 - `env.GAR_LOCATION`: The Google Artifact Registry location. (eg: `us`)
 - `env.GCP_PROJECT_ID`: The GCP Project identifier. (eg: `moz-fx-autograph-prod`)
 - `env.GAR_REPOSITORY`: The Google Artifact Registry repository to which the image should be pushed (eg: `autograph-prod`)

We also need to configure a service account and provide the identifiers necessary for workload identity federation to auth with GCP as per the [google-github-actions/auth](https://github.com/google-github-actions/auth) Github action.

The build and deployment step has been tested against a personal Dockerhub repository using my personal fork [here](https://github.com/oskirby/autograph/actions/runs/9999772262/job/27641314740) which results in an image being pushed to https://hub.docker.com/r/nkirby/autograph-debug.