### PR TITLE
run unit tests once when enabling race detector

### DIFF
--- a/bin/run_unit_tests.sh
+++ b/bin/run_unit_tests.sh
@@ -13,15 +13,13 @@ REPORT_COVERAGE=${CI:-""}
 if [ "$REPORT_COVERAGE" = "true" ]; then
     make install-goveralls
 fi
-# run app unit tests
-make test
-# run monitor unit tests
-make -C tools/autograph-monitor test
 
 if [ "$RACE_TEST" = "1" ]; then
     make race
     make -C tools/autograph-monitor race
-    make -C verifier/contentsignature race
+else
+    make test
+    make -C tools/autograph-monitor test
 fi
 
 if [ "$REPORT_COVERAGE" = "true" ]; then


### PR DESCRIPTION
Previously, running

```
docker compose build unit-test && docker compose \
run -e RACE_TEST=1 unit-test
```

would run the tests once without the race
detector and then again with the race detector.

Found this while discussing how to handle AUT-162 with Ben Hearsum.

Along the way, remove the duplicate running of
`verifier/contentsignature` (it's already in PACKAGE_NAMES in the
top-level Makefile).

I'm not sure we want all this infrastructure for running unit tests, but
I'm not going to be the one to turn off coverage calculations. (Assuming
they still are working correctly, which I'm realizing I've not checked
in on since joining the project.)

Updates AUT-188
Updates AUT-189
