### PR TITLE
move tools/autograph-monitor into top-level make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-PACKAGE_NAMES := github.com/mozilla-services/autograph github.com/mozilla-services/autograph/database github.com/mozilla-services/autograph/formats github.com/mozilla-services/autograph/signer github.com/mozilla-services/autograph/signer/apk2 github.com/mozilla-services/autograph/signer/contentsignature github.com/mozilla-services/autograph/signer/contentsignaturepki github.com/mozilla-services/autograph/signer/genericrsa github.com/mozilla-services/autograph/signer/gpg2 github.com/mozilla-services/autograph/signer/mar github.com/mozilla-services/autograph/signer/xpi github.com/mozilla-services/autograph/verifier/contentsignature
+PACKAGE_NAMES := github.com/mozilla-services/autograph github.com/mozilla-services/autograph/database github.com/mozilla-services/autograph/formats github.com/mozilla-services/autograph/signer github.com/mozilla-services/autograph/signer/apk2 github.com/mozilla-services/autograph/signer/contentsignature github.com/mozilla-services/autograph/signer/contentsignaturepki github.com/mozilla-services/autograph/signer/genericrsa github.com/mozilla-services/autograph/signer/gpg2 github.com/mozilla-services/autograph/signer/mar github.com/mozilla-services/autograph/signer/xpi github.com/mozilla-services/autograph/verifier/contentsignature github.com/mozilla-services/autograph/tools/autograph-monitor
 
 # The GOPATH isn't always on the path.
 GOPATH := $(shell go env GOPATH)
@@ -53,11 +53,11 @@ vet:
 	go vet $(PACKAGE_NAMES)
 
 fmt-diff:
-	gofmt -d *.go database/ signer/ tools/autograph-client/ $(shell ls tools/autograph-monitor/*.go) tools/softhsm/ tools/hawk-token-maker/ tools/make-hsm-ee/ tools/makecsr/ tools/genpki/
+	gofmt -d *.go database/ signer/ tools/autograph-client/ tools/autograph-monitor tools/softhsm/ tools/hawk-token-maker/ tools/make-hsm-ee/ tools/makecsr/ tools/genpki/
 
 fmt-fix:
 	go fmt $(PACKAGE_NAMES)
-	gofmt -w tools/autograph-client/ $(shell ls tools/autograph-monitor/*.go) tools/softhsm/ tools/hawk-token-maker/ tools/make-hsm-ee/ tools/makecsr/ tools/genpki/
+	gofmt -w tools/autograph-client/ tools/softhsm/ tools/hawk-token-maker/ tools/make-hsm-ee/ tools/makecsr/ tools/genpki/
 
 benchmarkxpi:
 	go test -run=XXX -benchtime=15s -bench=. -v -cpuprofile cpu.out github.com/mozilla-services/autograph/signer/xpi ;\

--- a/bin/run_unit_tests.sh
+++ b/bin/run_unit_tests.sh
@@ -3,7 +3,6 @@
 set -e
 set -o pipefail
 
-
 # run unit tests inside an app container
 # and report coverage from CI
 #
@@ -16,18 +15,12 @@ fi
 
 if [ "$RACE_TEST" = "1" ]; then
     make race
-    make -C tools/autograph-monitor race
 else
     make test
-    make -C tools/autograph-monitor test
 fi
 
 if [ "$REPORT_COVERAGE" = "true" ]; then
-    cp coverage.out combined-coverage.out
-    # skip 'mode: count' on the first line
-    tail -n +2 tools/autograph-monitor/monitor-coverage.out >> combined-coverage.out
-
     # report coverage
     # ignore failures while coveralls is down for maintenance
-    $(go env GOPATH)/bin/goveralls -coverprofile=combined-coverage.out -service circle-ci || true
+    $(go env GOPATH)/bin/goveralls -coverprofile=coverage.out -service circle-ci || true
 fi

--- a/tools/autograph-monitor/contentsignaturepki_test.go
+++ b/tools/autograph-monitor/contentsignaturepki_test.go
@@ -199,7 +199,7 @@ func Test_verifyContentSignature(t *testing.T) {
 
 	// TODO: replace type with pointer to a notifier
 	// implementation when another is added
-	var typedNilNotifier Notifier = nil
+	var typedNilNotifier Notifier
 
 	type args struct {
 		x5uClient    *http.Client
@@ -479,7 +479,7 @@ func Test_verifyContentSignature(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		var notifier Notifier = tt.args.notifier
+		notifier := tt.args.notifier
 		if tt.useMockNotifier {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()


### PR DESCRIPTION
This is review feedback from a previous patch.
https://github.com/mozilla-services/autograph/pull/941#discussion_r1705636141

This patches moves tools/autograph-monitor is `PACKAGE_NAMES` in the
top-level Makefile and removes the separated make calls.

This might mess up the coverage calculations we were previously doing,
but I'm not sure we've been getting much value out of those. We can fix
them up later if we do.

This also tries to clean up some unusual ways the autograph-monitor is
referenced in the rest of the Makefile. I'm not sure what that was
about. Perhaps, at some point, the original authors had code files in
that directory with different `package`s in them?
