### PR TITLE
AUT-162: fix flakey gpg tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -445,7 +445,8 @@ func (a *autographer) addSigners(signerConfs []signer.Configuration) error {
 				return fmt.Errorf("failed to add signer %q: %w", signerConf.ID, err)
 			}
 		case gpg2.Type:
-			s, err = gpg2.New(signerConf)
+			tmpDirPrefix := fmt.Sprintf("autograph_%s_%s_%s_", signerConf.Type, signerConf.KeyID, signerConf.Mode)
+			s, err = gpg2.New(signerConf, tmpDirPrefix)
 			if err != nil {
 				return fmt.Errorf("failed to add signer %q: %w", signerConf.ID, err)
 			}

--- a/signer/gpg2/gpg2_test.go
+++ b/signer/gpg2/gpg2_test.go
@@ -356,13 +356,17 @@ func TestSignData(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				defer os.Remove("/tmp/autograph_test_gpg2_keyring.gpg")
-				defer os.Remove("/tmp/autograph_test_gpg2_secring.gpg")
-				defer os.Remove("/tmp/autograph_test_gpg2_keyring.gpg~")
+				tmpKeyringDir, err := os.MkdirTemp("", "keyring")
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer os.RemoveAll(tmpKeyringDir)
+
+				tmpKeyring := filepath.Join(tmpKeyringDir, "keyring.gpg")
 
 				// call gnupg to create a new keyring, load the key in it
 				gnupgCreateKeyring := exec.Command("gpg", "--no-default-keyring",
-					"--keyring", "/tmp/autograph_test_gpg2_keyring.gpg",
+					"--keyring", tmpKeyring,
 					"--import", tmpPublicKeyFile.Name())
 				out, err := gnupgCreateKeyring.CombinedOutput()
 				if err != nil {
@@ -371,7 +375,7 @@ func TestSignData(t *testing.T) {
 
 				// verify the signature
 				gnupgVerifySig := exec.Command("gpg", "--no-default-keyring",
-					"--keyring", "/tmp/autograph_test_gpg2_keyring.gpg",
+					"--keyring", tmpKeyring,
 					"--verify", tmpSignatureFile.Name(), tmpContentFile.Name())
 				out, err = gnupgVerifySig.CombinedOutput()
 				if err != nil {


### PR DESCRIPTION
As expected, these are easily fixed by using distinct keychains for each test.

This PR will initially be opened with an additional commit that makes these tests fail more or less 100% of the time. I will then follow-up with another commit with the fix showing that it works. Finally, I will update the PR with just the fix, and provide links to the first two test runs for comparison.

Test run prior to fix
=======
Test run - failed: https://app.circleci.com/pipelines/github/mozilla-services/autograph/2507/workflows/4b597895-de8c-4262-893c-83b94d75b5ca/jobs/12143
Log excerpt:
```
panic: Fail in goroutine after TestSignData has completed [recovered]
	panic: Fail in goroutine after TestSignData has completed
	panic: Fail in goroutine after TestSignData has completed

goroutine 1662 [running]:
testing.tRunner.func1.1()
	/usr/lib/go-1.22/src/testing/testing.go:1608 +0x92
panic({0x605f00?, 0xc0009365d0?})
	/usr/lib/go-1.22/src/runtime/panic.go:770 +0x132
testing.(*common).Fail(0xc0000cad00)
	/usr/lib/go-1.22/src/testing/testing.go:952 +0xd4
testing.(*common).Fail(0xc0001876c0)
	/usr/lib/go-1.22/src/testing/testing.go:946 +0x3c
testing.(*common).Fail(0xc0004edba0)
	/usr/lib/go-1.22/src/testing/testing.go:946 +0x3c
testing.tRunner.func1.2({0x605f00, 0xc0009365c0})
	/usr/lib/go-1.22/src/testing/testing.go:1615 +0x49
testing.tRunner.func1()
	/usr/lib/go-1.22/src/testing/testing.go:1634 +0x377
panic({0x605f00?, 0xc0009365c0?})
	/usr/lib/go-1.22/src/runtime/panic.go:770 +0x132
testing.(*common).Fail(0xc0000cad00)
	/usr/lib/go-1.22/src/testing/testing.go:952 +0xd4
testing.(*common).Fail(0xc0001876c0)
	/usr/lib/go-1.22/src/testing/testing.go:946 +0x3c
testing.(*common).Fail(0xc0004edba0)
	/usr/lib/go-1.22/src/testing/testing.go:946 +0x3c
testing.(*common).FailNow(0xc0004edba0)
	/usr/lib/go-1.22/src/testing/testing.go:981 +0x26
testing.(*common).Fatalf(0xc0004edba0, {0x65ed6b?, 0x400?}, {0xc00028ef00?, 0x700?, 0x0?})
	/usr/lib/go-1.22/src/testing/testing.go:1089 +0x5e
github.com/mozilla-services/autograph/signer/gpg2.TestSignData.func1.1.2(0xc0004edba0)
	/app/src/autograph/signer/gpg2/gpg2_test.go:381 +0x8db
testing.tRunner(0xc0004edba0, 0xc00010a880)
	/usr/lib/go-1.22/src/testing/testing.go:1689 +0xfb
created by testing.(*T).Run in goroutine 466
	/usr/lib/go-1.22/src/testing/testing.go:1742 +0x390
FAIL	github.com/mozilla-services/autograph/signer/gpg2	8.808s
```

Test run with fix
=======
Test run - passed: https://app.circleci.com/pipelines/github/mozilla-services/autograph/2508/workflows/157fa0db-fda1-49f2-85ed-a5778197388c/jobs/12145