### PR TITLE
AUT-151: Add permissions to github deployment job

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,6 +12,9 @@ jobs:
     name: Docker Images
     runs-on: ubuntu-22.04
     environment: build
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Clone repository
         uses: actions/checkout@v4


### PR DESCRIPTION
In PR #940 we added a github workflow to deploy docker images to the Google Artifact Registry, but we forgot to add the necessary permissions to the job in order to properly authenticate with Google. Hopefully this adds them and gets it working.