### PR TITLE
add golangci-lint no reviews plox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,8 @@ version: 2.1
 jobs:
   lint-vet-fmt:
     docker:
+      # If you adjust this version, also adjust the GOLANGCI_LINT_VERSION in the
+      # Makefile
       - image: golangci/golangci-lint:v1.60.1-alpine
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,40 +8,10 @@ version: 2.1
 jobs:
   lint-vet-fmt:
     docker:
-      - image: cimg/go:1.22
+      - image: golangci/golangci-lint:v1.60.1-alpine
     steps:
-      # TODO(AUT-158): this linting always succeeds even if there are errors, and future correct linting may need correct cgo compliation
       - checkout
-      - run:
-          name: check crypto11 not used in signers
-          command: |
-            make check-no-crypto11-in-signers
-            make show-lints
-      - run:
-          name: run golint
-          command: |
-            make install-golint lint
-            make show-lints
-            make -C tools/autograph-monitor lint
-            make -C verifier/contentsignature lint
-      - run:
-          name: run gofmt
-          command: |
-            make -s fmt-diff | tee fmt.diff
-            test -z "$(cat fmt.diff)"
-      - run:
-          name: run go vet
-          command: |
-            make vet
-            make -C tools/autograph-monitor vet
-            make -C verifier/contentsignature vet
-      - run:
-          name: run staticcheck
-          command: |
-            make install-staticcheck staticcheck
-            make show-lints
-            make -C tools/autograph-monitor staticcheck
-            make -C verifier/contentsignature staticcheck
+      - run: golangci-lint run
 
   unit-test:
     # based on the official golang image with more docker stuff

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,11 +55,17 @@ jobs:
       # Optional: allow write access to checks to allow the action to annotate code in the PR.
       checks: write
     steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
       - name: golangci-lint
-        # If you bump this, check if the new version contains a new
-        # golangci-lint version we should bump as GOLANGCI_LINT_VERSION in the
-        # Makefile
         uses: golangci/golangci-lint-action@v6.1.0
+        with:
+          # If you bump this, also bump GOLANGCI_LINT_VERSION in the
+          # Makefile
+          version: v1.60.1
+          args: --timeout 5m
 
   unit-tests:
     name: Run Unit Tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,6 +47,13 @@ jobs:
   lint:
     name: Linting
     runs-on: ubuntu-22.04
+    permissions:
+      # Required: allow read access to the content for analysis.
+      contents: read
+      # Optional: allow read access to pull request. Use with `only-new-issues` option.
+      pull-requests: read
+      # Optional: allow write access to checks to allow the action to annotate code in the PR.
+      checks: write
     steps:
       - name: golangci-lint
         # If you bump this, check if the new version contains a new

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,6 +44,16 @@ jobs:
           name: autograph-images-${{ github.sha }}
           path: docker-cache/
 
+  lint:
+    name: Linting
+    runs-on: ubuntu-22.04
+    steps:
+      - name: golangci-lint
+        # If you bump this, check if the new version contains a new
+        # golangci-lint version we should bump as GOLANGCI_LINT_VERSION in the
+        # Makefile
+        uses: golangci/golangci-lint-action@v6.1.0
+
   unit-tests:
     name: Run Unit Tests
     runs-on: ubuntu-22.04

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,9 @@
-linters-settings:
-  errcheck:
-    check-type-assertions: true
-    check-blank: true
-    disable-default-exclusions: false
-    exclude-functions:
-      - (*database/sql.Tx).Rollback
+linters:
+  disable-all: true
+  enable:
+    # - errcheck # FIXME make ticket to enable this
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,9 @@ linters:
   disable-all: true
   enable:
     - depguard
-    # - errcheck # FIXME make ticket to enable this
+    # TODO(AUT-202): errcheck is too handy to leave out but requires more churn
+    # at time of writing
+    # - errcheck
     - gosimple
     - govet
     - ineffassign

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,8 @@ linters:
 linters-settings:
   depguard:
     rules:
-      foobar:
+      # refs: https://github.com/mozilla-services/autograph/issues/247
+      no-crypto11-in-signer-submodules:
         list-mode: lax
 
         files:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+linters-settings:
+  errcheck:
+    check-type-assertions: true
+    check-blank: true
+    disable-default-exclusions: false
+    exclude-functions:
+      - (*database/sql.Tx).Rollback

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,6 @@ linters-settings:
 
         deny:
           - pkg: "github.com/ThalesIgnite/crypto11"
-            desc: "No PKCS#11 work allowed in signer submodules (so, crypto11 is banned there)"
+            desc: "Only indirect PKCS#11 work allowed in signer submodules (so, crypto11 is banned there)"
           - pkg: "github.com/ThalesGroup/crypto11" # ThalesGroup is the more modern version
-            desc: "No PKCS#11 work allowed in signer submodules (so, crypto11 is banned there)"
+            desc: "Only indirect PKCS#11 work allowed in signer submodules (so, crypto11 is banned there)"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,25 @@
 linters:
   disable-all: true
   enable:
+    - depguard
     # - errcheck # FIXME make ticket to enable this
     - gosimple
     - govet
     - ineffassign
     - staticcheck
     - unused
+
+linters-settings:
+  depguard:
+    rules:
+      foobar:
+        list-mode: lax
+
+        files:
+          - "**/signer/**/*.go"
+
+        deny:
+          - pkg: "github.com/ThalesIgnite/crypto11"
+            desc: "No PKCS#11 work allowed in signer submodules (so, crypto11 is banned there)"
+          - pkg: "github.com/ThalesGroup/crypto11" # ThalesGroup is the more modern version
+            desc: "No PKCS#11 work allowed in signer submodules (so, crypto11 is banned there)"

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ PACKAGE_NAMES := github.com/mozilla-services/autograph github.com/mozilla-servic
 # The GOPATH isn't always on the path.
 GOPATH := $(shell go env GOPATH)
 
+# If you bump this version for golangci-lint, also check if the version of the
+# golangci-lint GitHub Action needs to be bumped in .github/workflows.
 GOLANGCI_LINT_VERSION := v1.60.1
 
 all: generate test vet lint staticcheck install

--- a/Makefile
+++ b/Makefile
@@ -22,19 +22,10 @@ install-wait-for-it:
 good-lint:
 	docker run --rm -v $(PWD):/app -v ~/.cache/golangci-lint/v1.60.1:/root/.cache -w /app golangci/golangci-lint:v1.60.1 golangci-lint run -v
 
-install-golint:
-	go install golang.org/x/lint/golint@v0.0.0-20190409202823-959b441ac422
-
-install-goveralls:
-	go install github.com/mattn/goveralls@v0.0.11
-
-install-staticcheck:
-	go install honnef.co/go/tools/cmd/staticcheck@v0.4.7
-
 install-go-mod-upgrade:
 	go get github.com/oligot/go-mod-upgrade
 
-install-dev-deps: install-golint install-staticcheck install-goveralls install-go-mod-upgrade
+install-dev-deps: install-goveralls install-go-mod-upgrade
 
 install:
 	go install github.com/mozilla-services/autograph
@@ -44,18 +35,6 @@ vendor:
 
 tag: all
 	git tag -s $(TAGVER) -a -m "$(TAGMSG)"
-
-lint:
-	$(GOPATH)/bin/golint $(PACKAGE_NAMES) | tee /tmp/autograph-golint.txt
-	test 0 -eq $$(grep -c -Pv 'stutters|suggestions' /tmp/autograph-golint.txt)
-
-# refs: https://github.com/mozilla-services/autograph/issues/247
-check-no-crypto11-in-signers:
-	test 0 -eq $(shell grep -Ri crypto11 signer/*/ | tee /tmp/autograph-crypto11-check.txt | wc -l)
-
-show-lints:
-	-cat /tmp/autograph-golint.txt /tmp/autograph-crypto11-check.txt /tmp/autograph-staticcheck.txt
-	-rm -f /tmp/autograph-golint.txt /tmp/autograph-crypto11-check.txt /tmp/autograph-staticcheck.txt
 
 vet:
 	go vet $(PACKAGE_NAMES)
@@ -75,12 +54,6 @@ showbenchmarkxpi:
 
 race:
 	go test -race -covermode=atomic -count=1 $(PACKAGE_NAMES)
-
-staticcheck:
-	$(GOPATH)/bin/staticcheck $(PACKAGE_NAMES) | tee /tmp/autograph-staticcheck.txt
-	# ignore errors in pkgs
-	# ignore SA1019 for DSA being deprecated refs: GH #667
-	test 0 -eq $$(grep -c -Pv '^/go/pkg/mod/|SA1019' /tmp/autograph-staticcheck.txt)
 
 test:
 	go test -v -coverprofile coverage.out -covermode=count -count=1 $(PACKAGE_NAMES)

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ PACKAGE_NAMES := github.com/mozilla-services/autograph github.com/mozilla-servic
 # The GOPATH isn't always on the path.
 GOPATH := $(shell go env GOPATH)
 
+GOLANGCI_LINT_VERSION := v1.60.1
+
 all: generate test vet lint staticcheck install
 
 # update the vendored version of the wait-for-it.sh script
@@ -13,6 +15,10 @@ install-wait-for-it:
 	curl -o bin/wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
 	sha256sum -c bin/wait-for-it.sh.sha256
 	chmod +x bin/wait-for-it.sh
+
+# FIXME
+good-lint:
+	docker run --rm -v $(PWD):/app -v ~/.cache/golangci-lint/v1.60.1:/root/.cache -w /app golangci/golangci-lint:v1.60.1 golangci-lint run -v
 
 install-golint:
 	go install golang.org/x/lint/golint@v0.0.0-20190409202823-959b441ac422

--- a/handlers.go
+++ b/handlers.go
@@ -129,10 +129,10 @@ func (a *autographer) handleSignature(w http.ResponseWriter, r *http.Request) {
 	for i, sigreq := range sigreqs {
 		if r.URL.RequestURI() == "/sign/files" {
 			if sigreq.Input != "" {
-				httpError(w, r, http.StatusBadRequest, fmt.Sprintf("input should be empty in sign files signature request %d", i))
+				httpError(w, r, http.StatusBadRequest, "input should be empty in sign files signature request %d", i)
 			}
 			if sigreq.Files == nil {
-				httpError(w, r, http.StatusBadRequest, fmt.Sprintf("missing Files in sign files signature request %d", i))
+				httpError(w, r, http.StatusBadRequest, "missing Files in sign files signature request %d", i)
 			}
 			if len(sigreq.Files) < MinNamedFiles {
 				httpError(w, r, http.StatusBadRequest, "Did not receive enough files to sign. Need at least %d", MinNamedFiles)
@@ -142,7 +142,7 @@ func (a *autographer) handleSignature(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		} else if sigreq.Input == "" {
-			httpError(w, r, http.StatusBadRequest, fmt.Sprintf("missing input in signature request %d", i))
+			httpError(w, r, http.StatusBadRequest, "missing input in signature request %d", i)
 		}
 	}
 	if a.debug {

--- a/main_racing_test.go
+++ b/main_racing_test.go
@@ -12,10 +12,8 @@ import (
 func TestLogLevelParsing(t *testing.T) {
 	t.Parallel()
 
-	var (
-		debug = false
-		fatal = false
-	)
+	var debug, fatal bool
+
 	_, _, debug = parseArgsAndLoadConfig([]string{"-l", "debug"})
 	if !(debug == true && log.GetLevel() == log.DebugLevel) {
 		t.Errorf("failed to set debug flag for debug log level")

--- a/monitor_handler.go
+++ b/monitor_handler.go
@@ -34,7 +34,8 @@ func (m *monitor) handleMonitor(w http.ResponseWriter, r *http.Request) {
 
 	for _, errstr := range m.sigerrstrs {
 		if errstr != "" {
-			httpError(w, r, http.StatusInternalServerError, errstr)
+			// "%s" is a go vet false positive correction
+			httpError(w, r, http.StatusInternalServerError, "%s", errstr)
 			return
 		}
 	}

--- a/signer/contentsignaturepki/upload.go
+++ b/signer/contentsignaturepki/upload.go
@@ -48,7 +48,7 @@ func (s *ContentSigner) upload(data, name string) error {
 	case "file":
 		return writeLocalFile(data, name, parsedURL)
 	default:
-		return fmt.Errorf("unsupported upload scheme " + parsedURL.Scheme)
+		return fmt.Errorf("unsupported upload scheme %#v", parsedURL.Scheme)
 	}
 }
 

--- a/signer/mar/mar.go
+++ b/signer/mar/mar.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/ThalesIgnite/crypto11"
 	"github.com/mozilla-services/autograph/signer"
 
 	margo "go.mozilla.org/mar"
@@ -17,7 +18,8 @@ import (
 
 const (
 	// Type of this signer is "mar"
-	Type = "mar"
+	Type  = "mar"
+	FIXME = crypto11.CKM_NCIPHER
 )
 
 // MARSigner holds the configuration of the signer

--- a/signer/mar/mar.go
+++ b/signer/mar/mar.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/ThalesIgnite/crypto11"
 	"github.com/mozilla-services/autograph/signer"
 
 	margo "go.mozilla.org/mar"
@@ -18,8 +17,7 @@ import (
 
 const (
 	// Type of this signer is "mar"
-	Type  = "mar"
-	FIXME = crypto11.CKM_NCIPHER
+	Type = "mar"
 )
 
 // MARSigner holds the configuration of the signer

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -15,6 +15,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"regexp"
@@ -372,7 +373,7 @@ func ParsePrivateKey(keyPEMBlock []byte) (key crypto.PrivateKey, err error) {
 	}
 	savedErr = append(savedErr, "ecdsa: "+err.Error())
 
-	return nil, fmt.Errorf("failed to parse private key, make sure to use PKCS1 for RSA and PKCS8 for ECDSA. errors: " + strings.Join(savedErr, ";;; "))
+	return nil, errors.New("failed to parse private key, make sure to use PKCS1 for RSA and PKCS8 for ECDSA. errors: " + strings.Join(savedErr, ";;; "))
 }
 
 func removePrivateKeyNewlines(confPrivateKey string) string {

--- a/tools/autograph-client/client.go
+++ b/tools/autograph-client/client.go
@@ -538,10 +538,8 @@ func verifyContentSignature(input []byte, resp formats.SignatureResponse, endpoi
 	}
 	if endpoint == "/sign/data" {
 		return sig.VerifyData(input, pubKey)
-	} else {
-		return sig.VerifyHash(input, pubKey)
 	}
-	return true
+	return sig.VerifyHash(input, pubKey)
 }
 
 func verifyXPI(input []byte, req formats.SignatureRequest, resp formats.SignatureResponse, reqType requestType, roots *x509.CertPool, verificationTime time.Time) bool {

--- a/tools/autograph-monitor/monitor.go
+++ b/tools/autograph-monitor/monitor.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -214,7 +215,7 @@ func monitor() (err error) {
 		for i, fail := range failures {
 			failure += fmt.Sprintf("\n%d. %s", i+1, fail.Error())
 		}
-		return fmt.Errorf(failure)
+		return errors.New(failure)
 	}
 	log.Println("All signature responses passed, monitoring OK")
 	return

--- a/tools/genpki/genpki.go
+++ b/tools/genpki/genpki.go
@@ -143,11 +143,11 @@ func main() {
 	}
 	inter, err := x509.ParseCertificate(interCertBytes)
 	if err != nil {
-		log.Fatal(fmt.Errorf("failed to parse intermediate certificate: %w"), err)
+		log.Fatal("failed to parse intermediate certificate: %w", err)
 	}
 	_, err = inter.Verify(opts)
 	if err != nil {
-		log.Fatal(fmt.Errorf("failed to verify intermediate chain to root: %w"), err)
+		log.Fatal("failed to verify intermediate chain to root: %w", err)
 	}
 
 	rootTmpfile, err := os.CreateTemp("", "csrootcert")

--- a/tools/softhsm/testdupkeys.go
+++ b/tools/softhsm/testdupkeys.go
@@ -49,9 +49,9 @@ func main() {
 	// now try to make a key with the same label after the routine are done
 	ecdsakey, err := crypto11.GenerateECDSAKeyPairOnSlot(slots[0], []byte(keyName), []byte(keyName), elliptic.P384())
 	if err != nil {
-		log.Printf("failed to make key %s in main thread: %v", keyName, i, err)
+		log.Printf("failed to make key %s in main thread: %v", keyName, err)
 	} else {
-		log.Printf("main thread made ECDSA Key named %q: %+v %+v", i, keyName, ecdsakey, ecdsakey.Public().(*ecdsa.PublicKey).Params())
+		log.Printf("main thread made ECDSA Key named %q: %+v %+v", keyName, ecdsakey, ecdsakey.Public().(*ecdsa.PublicKey).Params())
 	}
 }
 


### PR DESCRIPTION
- **move various tools to avoid main func collisions**
- **boo**
- **add golangci config**
- **just remove errcheck for now**
- **FIXME but nice tool run**
- **correct govet errors in genpki**
- **fix autograph-client unreachable code error from govet**
- **correct 'non-constant format string' govet error in handlers**
- **fix "ineffectual assignment to debug" in main_racing_test.go from ineffassign linter**
- **fix "non-constant format string in call to fmt.Errorf" from govet in autograph-monitor**
- **govet printf fixes**
- **GHA port, comments about versions**
- **add depguard to replace check-no-crypto11-in-signers in Makefile**
- **better name and comment**
