### PR TITLE
consolidate linting and add it to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,40 +8,12 @@ version: 2.1
 jobs:
   lint-vet-fmt:
     docker:
-      - image: cimg/go:1.22
+      # If you adjust this version, also adjust the GOLANGCI_LINT_VERSION in the
+      # Makefile
+      - image: golangci/golangci-lint:v1.60.1-alpine
     steps:
-      # TODO(AUT-158): this linting always succeeds even if there are errors, and future correct linting may need correct cgo compliation
       - checkout
-      - run:
-          name: check crypto11 not used in signers
-          command: |
-            make check-no-crypto11-in-signers
-            make show-lints
-      - run:
-          name: run golint
-          command: |
-            make install-golint lint
-            make show-lints
-            make -C tools/autograph-monitor lint
-            make -C verifier/contentsignature lint
-      - run:
-          name: run gofmt
-          command: |
-            make -s fmt-diff | tee fmt.diff
-            test -z "$(cat fmt.diff)"
-      - run:
-          name: run go vet
-          command: |
-            make vet
-            make -C tools/autograph-monitor vet
-            make -C verifier/contentsignature vet
-      - run:
-          name: run staticcheck
-          command: |
-            make install-staticcheck staticcheck
-            make show-lints
-            make -C tools/autograph-monitor staticcheck
-            make -C verifier/contentsignature staticcheck
+      - run: golangci-lint run
 
   unit-test:
     # based on the official golang image with more docker stuff

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version-file: './go.mod'
       - name: golangci-lint
         # If you bump this version, double check that we shouldn't also bump
         # GOLANGCI_LINT_VERSION in the Makefile. (The version here is for the

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,6 +44,30 @@ jobs:
           name: autograph-images-${{ github.sha }}
           path: docker-cache/
 
+  lint:
+    name: Linting
+    runs-on: ubuntu-22.04
+    permissions:
+      # Required: allow read access to the content for analysis.
+      contents: read
+      # Optional: allow read access to pull request. Use with `only-new-issues` option.
+      pull-requests: read
+      # Optional: allow write access to checks to allow the action to annotate code in the PR.
+      checks: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        # If you bump this version, double check that we shouldn't also bump
+        # GOLANGCI_LINT_VERSION in the Makefile. (The version here is for the
+        # GitHub Action and the one in the Makefile is for the actual version of
+        # golangci-lint.)
+        uses: golangci/golangci-lint-action@v6.1.0
+        with:
+          args: --timeout 5m
+
   unit-tests:
     name: Run Unit Tests
     runs-on: ubuntu-22.04

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,33 @@
+linters:
+  disable-all: true
+  enable:
+    - depguard
+    # TODO(AUT-202): errcheck is too handy to leave out but requires more churn
+    # at time of writing
+    # - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+
+linters-settings:
+  depguard:
+    rules:
+      # The first reason for this is to minimize how often we're having to deal
+      # with many different kinds of key types when the generic forms of the
+      # keys work fine. The second is that it makes sure our code can handle
+      # keys sourced from differing places.
+      #
+      # refs: https://github.com/mozilla-services/autograph/issues/247
+      no-crypto11-in-signer-submodules:
+        list-mode: lax
+
+        files:
+          - "**/signer/**/*.go"
+
+        deny:
+          - pkg: "github.com/ThalesIgnite/crypto11"
+            desc: "Only indirect PKCS#11 work allowed in signer submodules (so, crypto11 is banned there)"
+          - pkg: "github.com/ThalesGroup/crypto11" # ThalesGroup is the more modern version
+            desc: "Only indirect PKCS#11 work allowed in signer submodules (so, crypto11 is banned there)"

--- a/handlers.go
+++ b/handlers.go
@@ -129,10 +129,10 @@ func (a *autographer) handleSignature(w http.ResponseWriter, r *http.Request) {
 	for i, sigreq := range sigreqs {
 		if r.URL.RequestURI() == "/sign/files" {
 			if sigreq.Input != "" {
-				httpError(w, r, http.StatusBadRequest, fmt.Sprintf("input should be empty in sign files signature request %d", i))
+				httpError(w, r, http.StatusBadRequest, "input should be empty in sign files signature request %d", i)
 			}
 			if sigreq.Files == nil {
-				httpError(w, r, http.StatusBadRequest, fmt.Sprintf("missing Files in sign files signature request %d", i))
+				httpError(w, r, http.StatusBadRequest, "missing Files in sign files signature request %d", i)
 			}
 			if len(sigreq.Files) < MinNamedFiles {
 				httpError(w, r, http.StatusBadRequest, "Did not receive enough files to sign. Need at least %d", MinNamedFiles)
@@ -142,7 +142,7 @@ func (a *autographer) handleSignature(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		} else if sigreq.Input == "" {
-			httpError(w, r, http.StatusBadRequest, fmt.Sprintf("missing input in signature request %d", i))
+			httpError(w, r, http.StatusBadRequest, "missing input in signature request %d", i)
 		}
 	}
 	if a.debug {

--- a/main_racing_test.go
+++ b/main_racing_test.go
@@ -12,10 +12,8 @@ import (
 func TestLogLevelParsing(t *testing.T) {
 	t.Parallel()
 
-	var (
-		debug = false
-		fatal = false
-	)
+	var debug, fatal bool
+
 	_, _, debug = parseArgsAndLoadConfig([]string{"-l", "debug"})
 	if !(debug == true && log.GetLevel() == log.DebugLevel) {
 		t.Errorf("failed to set debug flag for debug log level")

--- a/monitor_handler.go
+++ b/monitor_handler.go
@@ -34,7 +34,6 @@ func (m *monitor) handleMonitor(w http.ResponseWriter, r *http.Request) {
 
 	for _, errstr := range m.sigerrstrs {
 		if errstr != "" {
-			// "%s" is a go vet false positive correction
 			httpError(w, r, http.StatusInternalServerError, "%s", errstr)
 			return
 		}

--- a/monitor_handler.go
+++ b/monitor_handler.go
@@ -34,7 +34,8 @@ func (m *monitor) handleMonitor(w http.ResponseWriter, r *http.Request) {
 
 	for _, errstr := range m.sigerrstrs {
 		if errstr != "" {
-			httpError(w, r, http.StatusInternalServerError, errstr)
+			// "%s" is a go vet false positive correction
+			httpError(w, r, http.StatusInternalServerError, "%s", errstr)
 			return
 		}
 	}

--- a/signer/contentsignaturepki/upload.go
+++ b/signer/contentsignaturepki/upload.go
@@ -48,7 +48,7 @@ func (s *ContentSigner) upload(data, name string) error {
 	case "file":
 		return writeLocalFile(data, name, parsedURL)
 	default:
-		return fmt.Errorf("unsupported upload scheme " + parsedURL.Scheme)
+		return fmt.Errorf("unsupported upload scheme %#v", parsedURL.Scheme)
 	}
 }
 

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -15,6 +15,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"regexp"
@@ -372,7 +373,7 @@ func ParsePrivateKey(keyPEMBlock []byte) (key crypto.PrivateKey, err error) {
 	}
 	savedErr = append(savedErr, "ecdsa: "+err.Error())
 
-	return nil, fmt.Errorf("failed to parse private key, make sure to use PKCS1 for RSA and PKCS8 for ECDSA. errors: " + strings.Join(savedErr, ";;; "))
+	return nil, errors.New("failed to parse private key, make sure to use PKCS1 for RSA and PKCS8 for ECDSA. errors: " + strings.Join(savedErr, ";;; "))
 }
 
 func removePrivateKeyNewlines(confPrivateKey string) string {

--- a/tools/autograph-client/client.go
+++ b/tools/autograph-client/client.go
@@ -538,10 +538,8 @@ func verifyContentSignature(input []byte, resp formats.SignatureResponse, endpoi
 	}
 	if endpoint == "/sign/data" {
 		return sig.VerifyData(input, pubKey)
-	} else {
-		return sig.VerifyHash(input, pubKey)
 	}
-	return true
+	return sig.VerifyHash(input, pubKey)
 }
 
 func verifyXPI(input []byte, req formats.SignatureRequest, resp formats.SignatureResponse, reqType requestType, roots *x509.CertPool, verificationTime time.Time) bool {

--- a/tools/autograph-monitor/monitor.go
+++ b/tools/autograph-monitor/monitor.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -214,7 +215,7 @@ func monitor() (err error) {
 		for i, fail := range failures {
 			failure += fmt.Sprintf("\n%d. %s", i+1, fail.Error())
 		}
-		return fmt.Errorf(failure)
+		return errors.New(failure)
 	}
 	log.Println("All signature responses passed, monitoring OK")
 	return

--- a/tools/genpki/genpki.go
+++ b/tools/genpki/genpki.go
@@ -143,11 +143,11 @@ func main() {
 	}
 	inter, err := x509.ParseCertificate(interCertBytes)
 	if err != nil {
-		log.Fatal(fmt.Errorf("failed to parse intermediate certificate: %w"), err)
+		log.Fatal("failed to parse intermediate certificate: %w", err)
 	}
 	_, err = inter.Verify(opts)
 	if err != nil {
-		log.Fatal(fmt.Errorf("failed to verify intermediate chain to root: %w"), err)
+		log.Fatal("failed to verify intermediate chain to root: %w", err)
 	}
 
 	rootTmpfile, err := os.CreateTemp("", "csrootcert")

--- a/tools/softhsm/testdupkeys.go
+++ b/tools/softhsm/testdupkeys.go
@@ -49,9 +49,9 @@ func main() {
 	// now try to make a key with the same label after the routine are done
 	ecdsakey, err := crypto11.GenerateECDSAKeyPairOnSlot(slots[0], []byte(keyName), []byte(keyName), elliptic.P384())
 	if err != nil {
-		log.Printf("failed to make key %s in main thread: %v", keyName, i, err)
+		log.Printf("failed to make key %s in main thread: %v", keyName, err)
 	} else {
-		log.Printf("main thread made ECDSA Key named %q: %+v %+v", i, keyName, ecdsakey, ecdsakey.Public().(*ecdsa.PublicKey).Params())
+		log.Printf("main thread made ECDSA Key named %q: %+v %+v", keyName, ecdsakey, ecdsakey.Public().(*ecdsa.PublicKey).Params())
 	}
 }
 


### PR DESCRIPTION
This consolidates our linting tools into the golangci-lint tool. It also
removes the unsupported, archived golint tool.

Docs about golangci-lint can be found here: https://golangci-lint.run/

Specifics about how to configure specific linters and what they are can
be found at https://golangci-lint.run/usage/linters/

The new GitHub Action integration also will annotate the PR its run on
with the violations it fails instead of just printing them out to the
console. This means we'll get nice lil UI things directly next to the
code in a PR that's causing the linter violation. This is the Action
maintained by the golangci-lint maintainers.

The default configuration of `golangci-lint` includes `errcheck` which
is very handy but was going to cause a significant amount of churn here.
I've made AUT-202 for us to turn it on later.

We use `depguard` to replace the `check-no-crypto11-in-signers` target.
It's a lil funky (I don't like the "**/" prefix that's required and
could cause false positives if we ever gain another `signer` package
name) but it's nice to have it in place for future checks like it. Plus,
it won't have the previous kind of false positives of the old grep.

`staticcheck` is still run in golangci-lint by default and we make sure
it remains enabled. No change there.

Along the way, pick up some new lint errors that the previous linting
missed.

One is that the `main.httpError` func is Sprintf-like, and `go vet`'s
`printf` checks were being violated in a few places. Same deal with some
uses of `fmt.Errorf` without any additional arguments. Some `log.Printf`
calls had the wrong number of arguments for the format string they were
given. One of the `main.httpError` calls is false positive-y and gets a
useless `"%s"` because we have no "zero arguments" function equivalent,
but it's fine.

Our immediate update of the `debug` variable in `main_racing_test.go`
meant the new `ineffassign` linter was unhappy. It's slightly false
positive-y because I suspect it was folks just trying to be clear about
what the zero value of a bool is, but the new code for that is shorter
and more typical Go.

`go vet` ("`govet`" in golangci-lint parlance) also had an "unreachable
code" trigger in the autograph-client codebase. A nice simplification
made it go away.

`golangci-lint` got a 5 minute timeout (`--timeout`) in the GitHub
Actions. That time was chosen arbitrarily, and 5 minutes would be a long
time to wait for a linting check to finish. We could definitely shorten
it and maybe should.

Also, the Makefile gains the ability to install `golangci-lint`, because
I don't have a better pattern for how folks should install it right now.

Updates AUT-158
Updates AUT-197
