### PR TITLE
AUT-151: Add push to Dockerhub from Deploy workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,34 +83,6 @@ jobs:
           paths:
             - docker-cache/
 
-  deploy:
-    docker:
-      - image: cimg/deploy:2024.03.1
-    steps:
-      - setup_remote_docker
-      - restore_cache:
-          key: v4-{{.Branch}}
-      - run:
-          name: Restore Docker image cache
-          command: gunzip -c docker-cache/autograph-app.tgz | docker load
-
-      - run:
-          name: Deploy to Dockerhub
-          command: |
-            # deploy main
-            if [ "${CIRCLE_BRANCH}" == "main" ]; then
-              docker login -u $DOCKER_USER -p $DOCKER_PASS
-              docker tag autograph-app ${DOCKERHUB_REPO}:latest
-              docker push ${DOCKERHUB_REPO}:latest
-            elif  [ ! -z "${CIRCLE_TAG}" ]; then
-            # deploy a release tag...
-              docker login -u $DOCKER_USER -p $DOCKER_PASS
-              echo "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
-              docker tag autograph-app "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
-              docker images
-              docker push "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
-            fi
-
 workflows:
   version: 2
   check-code-quality:
@@ -132,15 +104,6 @@ workflows:
             tags:
               only: /.*/
 
-      - deploy:
-          requires:
-            - build-integrationtest-verify
-          filters:
-            tags:
-              # only upload the docker container on semver tags
-              only: /[0-9]\.[0-9]+\.[0-9]+/
-            branches:
-              only: main
   nightly:
     triggers:
       - schedule:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,7 +28,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GAR_REPOSITORY}}/autograph
+          images: |
+            ${{ vars.DOCKERHUB_REPO }}
+            ${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/${{ vars.GAR_REPOSITORY}}/autograph
           tags: |
             type=semver,pattern={{raw}}
             type=raw,value=latest,enable={{is_default_branch}}
@@ -44,11 +46,18 @@ jobs:
           service_account: artifact-writer@${{ vars.GCP_PROJECT_ID}}.iam.gserviceaccount.com
           workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
 
-      - uses: docker/login-action@v3
+      - name: Login to Google Artifact Registry
+        uses: docker/login-action@v3
         with:
           registry: ${{ vars.GAR_LOCATION }}-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.gcp-auth.outputs.access_token }}
+
+      - name: Login to Dockerhub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
In the last pull request (#940) we added a deployment job to push container images to the Google Artifact Registry and it seems to be working okay-ish. However, we still need to add a push to Dockerhub too to get the container image over to our AWS instances as well. However, that work was blocked on an update to https://github.com/mozilla-services/cloudops-deployment/pull/4994

Once that work lands in cloudops-deployment, and the workers have been configured with a Github API token, then this PR should contain the remaining work to switch over to github for the build and deployment, as well as the deprecation of CircleCI as the builder.

This job expects the following variables and secrets in the `build` environment:
- `vars.DOCKERHUB_REPO`: The repository on Dockerhub to which the image should be pushed.
- `vars.DOCKERHUB_USERNAME`: The username of the account that will login to Dockerhub.
- `secrets.DOCKERHUB_PASSWORD`: The password (or personal access token) used to authenticate with Dockerhub.

This is probably something we need to do in one atomic commit so that CircleCI and Github don't both try to and push to Dockerhub.