### PR TITLE
AUT-151: Remove tags from deployment job fetch

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
I think this is a vestigial config from an earlier attempt to roll our own tags, and they are no longer necessary now that we are using the docker/metadata-action step. Furthermore, we seem to be failing to checkout on a github tag event, which is preventing us from shipping release artifacts.

For example, see the failed deployment [workflow](https://github.com/mozilla-services/autograph/actions/runs/10513023082) for `7.1.23`. Which fails as follows:
```
   /usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules --depth=1 origin +08048d638646e63257387761af5a74a006f4db3b:refs/tags/7.1.23
  Error: fatal: Cannot fetch both 08048d638646e63257387761af5a74a006f4db3b and refs/tags/7.1.23 to refs/tags/7.1.23
  The process '/usr/bin/git' failed with exit code 128
  Waiting 18 seconds before trying again
```