### PR TITLE
aggregate http.api metrics as agg.http.api

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,11 +210,11 @@ func run(conf configuration, listen string, debug bool) {
 	router.HandleFunc("/__lbheartbeat__", statsMiddleware(handleLBHeartbeat, "http.nonapi.lbheartbeat", stats)).Methods("GET")
 	router.HandleFunc("/__version__", statsMiddleware(handleVersion, "http.nonapi.version", stats)).Methods("GET")
 	router.HandleFunc("/__monitor__", statsMiddleware(monitor.handleMonitor, "http.nonapi.monitor", stats)).Methods("GET")
-	router.HandleFunc("/sign/files", statsMiddleware(ag.handleSignature, "http.api.sign/files", stats)).Methods("POST")
-	router.HandleFunc("/sign/file", statsMiddleware(ag.handleSignature, "http.api.sign/file", stats)).Methods("POST")
-	router.HandleFunc("/sign/data", statsMiddleware(ag.handleSignature, "http.api.sign/data", stats)).Methods("POST")
-	router.HandleFunc("/sign/hash", statsMiddleware(ag.handleSignature, "http.api.sign/hash", stats)).Methods("POST")
-	router.HandleFunc("/auths/{auth_id:[a-zA-Z0-9-_]{1,255}}/keyids", statsMiddleware(ag.handleGetAuthKeyIDs, "http.api.getauthkeyids", stats)).Methods("GET")
+	router.HandleFunc("/sign/files", apiStatsMiddleware(ag.handleSignature, "http.api.sign/files", stats)).Methods("POST")
+	router.HandleFunc("/sign/file", apiStatsMiddleware(ag.handleSignature, "http.api.sign/file", stats)).Methods("POST")
+	router.HandleFunc("/sign/data", apiStatsMiddleware(ag.handleSignature, "http.api.sign/data", stats)).Methods("POST")
+	router.HandleFunc("/sign/hash", apiStatsMiddleware(ag.handleSignature, "http.api.sign/hash", stats)).Methods("POST")
+	router.HandleFunc("/auths/{auth_id:[a-zA-Z0-9-_]{1,255}}/keyids", apiStatsMiddleware(ag.handleGetAuthKeyIDs, "http.api.getauthkeyids", stats)).Methods("GET")
 	if os.Getenv("AUTOGRAPH_PROFILE") == "1" {
 		err = setRuntimeConfig()
 		if err != nil {


### PR DESCRIPTION
Our observability infrastructure in AWS is bad. We're running a
combination of Grafana and InfluxDB versions that don't allow us to
easily sum over globbed metrics. This makes it difficult to write
availability metrics (a.k.a. succcess rates).

Until we've dropped support for the AWS deployment, we need to add
aggregate metrics across the API request paths to make it trivial to
calculate our availability.

This change allows us to emit "agg.http.api" namespaced metrics that are
roll-ups of all of the other "http.api" request and response metrics.

See #933 for prior work

Updates AUT-150
