### PR TITLE
add integration matrix result job for PR checks

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -126,3 +126,26 @@ jobs:
           else
             docker compose -f tools/autograph-client/integration-tests.yml logs app
           fi
+
+  # A hack around matrix jobs not reporting their status up through the job that
+  # created them. See
+  # https://github.com/orgs/community/discussions/26822#discussioncomment-8285141
+  # and
+  # https://github.com/orgs/community/discussions/26822#discussioncomment-3305794
+  integration-tests-results:
+    if: ${{ always() }}
+    name: Check Integration Test Results (See the individual Run Integration Tests jobs for details)
+    runs-on: ubuntu-22.04
+    needs:
+      - integration-tests
+    steps:
+      - name: See the individual Run Integration Tests jobs for details
+        run:
+          exit 1
+          # see https://stackoverflow.com/a/67532120/4907315
+        if: >-
+          ${{
+              contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+            || contains(needs.*.result, 'skipped')
+          }}


### PR DESCRIPTION
It's annoying to have each individual "Run Integration Tests" matrix job
in the branch protection settings. If we ever need to add or remove one
of those, we'd have to grab a GitHub admin user (`autograph-admins`) to
adjust the protection settings (or, if SRE is allowed to infra-as-code
GitHub, write a separate PR).

Instead, we can add this new integration-test-results job that `needs`
the results of `Run Integration Tests` and, after this merges, we can
add it to the branch protection settings instead of the individual
integration test jobs.

See
https://github.com/orgs/community/discussions/26822#discussioncomment-8285141
and
https://github.com/orgs/community/discussions/26822#discussioncomment-3305794

Updates AUT-151
