### PR TITLE
roll up HTTP success and status code group metrics

### DIFF
--- a/stats_test.go
+++ b/stats_test.go
@@ -15,6 +15,8 @@ func TestStatsResponseWriterWritesResponseMetricOnce(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockStats := mockstatsd.NewMockClientInterface(ctrl)
+	mockStats.EXPECT().Incr("myhandler.response.status.4xx", []string(nil), 1.0).Times(1)
+	mockStats.EXPECT().Incr("myhandler.response.success", []string(nil), 1.0).Times(1)
 	mockStats.EXPECT().Incr("myhandler.response.status.400", []string(nil), 1.0).Times(1)
 
 	recorder := httptest.NewRecorder()
@@ -34,6 +36,8 @@ func TestStatsResponseWriterWritesToHeaderOnWrite(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockStats := mockstatsd.NewMockClientInterface(ctrl)
+	mockStats.EXPECT().Incr("myhandler.response.status.2xx", []string(nil), 1.0).Times(1)
+	mockStats.EXPECT().Incr("myhandler.response.success", []string(nil), 1.0).Times(1)
 	mockStats.EXPECT().Incr("myhandler.response.status.200", []string(nil), 1.0).Times(1)
 
 	recorder := httptest.NewRecorder()
@@ -49,7 +53,9 @@ func TestWrappingStatsResponseWriteWritesAllMetrics(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockStats := mockstatsd.NewMockClientInterface(ctrl)
+	mockStats.EXPECT().Incr("inner.response.status.5xx", []string(nil), 1.0).Times(1)
 	mockStats.EXPECT().Incr("inner.response.status.500", []string(nil), 1.0).Times(1)
+	mockStats.EXPECT().Incr("wrapper.response.status.5xx", []string(nil), 1.0).Times(1)
 	mockStats.EXPECT().Incr("wrapper.response.status.500", []string(nil), 1.0).Times(1)
 
 	recorder := httptest.NewRecorder()


### PR DESCRIPTION
Following up on #955, I missed that our observability system would also
make it too hard to roll up the various status codes into sums.

So, we add some per-hundred status code metrics, and a
`response.success` metric that includes both 2xx and 4xx responses. The
4xx count as success because (as the [HTTP docs
say](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status)) 4xx
status codes are client errors. Counting someone's system accidentally
using the wrong credentials shouldn't against our success rate.
