### PR TITLE
add missing entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,19 @@ tools/sign-addon/venv/*
 
 vendor/go.mozilla.org/cose/samples/*
 version.json
+.vscode/
+
+./autograph
+tools/autograph-client/autograph-client
+tools/autograph-monitor/autograph-monitor
+tools/genpki/genpki
+tools/hawk-token-maker/hawk-token-maker
+tools/make-hsm-ee/make-hsm-ee
+tools/makecsr/makecsr
+tools/makecsr/make-ev-csr/make-ev-csr
+tools/softhsm/softhsm
+tools/softhsm/genkeys/genkeys
+tools/softhsm/genrsa/genrsa
 
 # Python dev stuff
 **/.venv*


### PR DESCRIPTION
Now that the .vscode directory is deleted, we can ignore it.

And running `go build .` will get you binaries in these `tools`
directories, so we should ignore those binary files.
