### PR TITLE
allow missing trailing slashes in chainUploadLocation

### DIFF
--- a/signer/contentsignaturepki/contentsignature.go
+++ b/signer/contentsignaturepki/contentsignature.go
@@ -10,6 +10,7 @@ import (
 	"hash"
 	"io"
 	"math/big"
+	"net/http"
 	"time"
 
 	"github.com/mozilla-services/autograph/database"
@@ -185,7 +186,7 @@ func (s *ContentSigner) initEE(conf signer.Configuration) error {
 	default:
 		return fmt.Errorf("contentsignaturepki %q: failed to find suitable end-entity: %w", s.ID, err)
 	}
-	_, _, err = GetX5U(buildHTTPClient(), s.X5U)
+	_, _, err = GetX5U(http.DefaultClient, s.X5U)
 	if err != nil {
 		return fmt.Errorf("contentsignaturepki %q: failed to verify x5u: %w", s.ID, err)
 	}

--- a/signer/contentsignaturepki/contentsignature_test.go
+++ b/signer/contentsignaturepki/contentsignature_test.go
@@ -9,6 +9,7 @@ package contentsignaturepki
 import (
 	"crypto/ecdsa"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -19,73 +20,75 @@ import (
 func TestSign(t *testing.T) {
 	input := []byte("foobarbaz1234abcd")
 	for i, testcase := range PASSINGTESTCASES {
-		// initialize a signer
-		s, err := New(testcase.cfg)
-		if err != nil {
-			t.Fatalf("testcase %d signer initialization failed with: %v", i, err)
-		}
-		if s.Type != testcase.cfg.Type {
-			t.Fatalf("testcase %d signer type %q does not match configuration %q", i, s.Type, testcase.cfg.Type)
-		}
-		if s.ID != testcase.cfg.ID {
-			t.Fatalf("testcase %d signer id %q does not match configuration %q", i, s.ID, testcase.cfg.ID)
-		}
-		if s.PrivateKey != testcase.cfg.PrivateKey {
-			t.Fatalf("testcase %d signer private key %q does not match configuration %q", i, s.PrivateKey, testcase.cfg.PrivateKey)
-		}
-		if s.Mode != testcase.cfg.Mode {
-			t.Fatalf("testcase %d signer curve %q does not match expected %q", i, s.Mode, testcase.cfg.Mode)
-		}
+		t.Run(fmt.Sprintf("test-%d", i), func(t *testing.T) {
+			// initialize a signer
+			s, err := New(testcase.cfg)
+			if err != nil {
+				t.Fatalf("testcase %d signer initialization failed with: %v", i, err)
+			}
+			if s.Type != testcase.cfg.Type {
+				t.Fatalf("testcase %d signer type %q does not match configuration %q", i, s.Type, testcase.cfg.Type)
+			}
+			if s.ID != testcase.cfg.ID {
+				t.Fatalf("testcase %d signer id %q does not match configuration %q", i, s.ID, testcase.cfg.ID)
+			}
+			if s.PrivateKey != testcase.cfg.PrivateKey {
+				t.Fatalf("testcase %d signer private key %q does not match configuration %q", i, s.PrivateKey, testcase.cfg.PrivateKey)
+			}
+			if s.Mode != testcase.cfg.Mode {
+				t.Fatalf("testcase %d signer curve %q does not match expected %q", i, s.Mode, testcase.cfg.Mode)
+			}
 
-		// sign input data
-		sig, err := s.SignData(input, nil)
-		if err != nil {
-			t.Fatalf("testcase %d failed to sign data: %v", i, err)
-		}
-		// convert signature to string format
-		sigstr, err := sig.Marshal()
-		if err != nil {
-			t.Fatalf("testcase %d failed to marshal signature: %v", i, err)
-		}
+			// sign input data
+			sig, err := s.SignData(input, nil)
+			if err != nil {
+				t.Fatalf("testcase %d failed to sign data: %v", i, err)
+			}
+			// convert signature to string format
+			sigstr, err := sig.Marshal()
+			if err != nil {
+				t.Fatalf("testcase %d failed to marshal signature: %v", i, err)
+			}
 
-		// convert string format back to signature
-		cs, err := verifier.Unmarshal(sigstr)
-		if err != nil {
-			t.Fatalf("testcase %d failed to unmarshal signature: %v", i, err)
-		}
+			// convert string format back to signature
+			cs, err := verifier.Unmarshal(sigstr)
+			if err != nil {
+				t.Fatalf("testcase %d failed to unmarshal signature: %v", i, err)
+			}
 
-		// make sure we still have the same string representation
-		sigstr2, err := cs.Marshal()
-		if err != nil {
-			t.Fatalf("testcase %d failed to re-marshal signature: %v", i, err)
-		}
-		if sigstr != sigstr2 {
-			t.Fatalf("testcase %d marshalling signature changed its format.\nexpected\t%q\nreceived\t%q",
-				i, sigstr, sigstr2)
-		}
+			// make sure we still have the same string representation
+			sigstr2, err := cs.Marshal()
+			if err != nil {
+				t.Fatalf("testcase %d failed to re-marshal signature: %v", i, err)
+			}
+			if sigstr != sigstr2 {
+				t.Fatalf("testcase %d marshalling signature changed its format.\nexpected\t%q\nreceived\t%q",
+					i, sigstr, sigstr2)
+			}
 
-		if cs.Len != getSignatureLen(s.Mode) {
-			t.Fatalf("testcase %d expected signature len of %d, got %d",
-				i, getSignatureLen(s.Mode), cs.Len)
-		}
-		if cs.Mode != s.Mode {
-			t.Fatalf("testcase %d expected curve name %q, got %q", i, s.Mode, cs.Mode)
-		}
+			if cs.Len != getSignatureLen(s.Mode) {
+				t.Fatalf("testcase %d expected signature len of %d, got %d",
+					i, getSignatureLen(s.Mode), cs.Len)
+			}
+			if cs.Mode != s.Mode {
+				t.Fatalf("testcase %d expected curve name %q, got %q", i, s.Mode, cs.Mode)
+			}
 
-		// verify the signature using the public key of the end entity
-		_, certs, err := GetX5U(buildHTTPClient(), s.X5U)
-		if err != nil {
-			t.Fatalf("testcase %d failed to get X5U %q: %v", i, s.X5U, err)
-		}
-		leaf := certs[0]
-		key := leaf.PublicKey.(*ecdsa.PublicKey)
-		if !sig.(*verifier.ContentSignature).VerifyData([]byte(input), key) {
-			t.Fatalf("testcase %d failed to verify signature", i)
-		}
+			// verify the signature using the public key of the end entity
+			_, certs, err := GetX5U(buildHTTPClient(), s.X5U)
+			if err != nil {
+				t.Fatalf("testcase %d failed to get X5U %q: %v", i, s.X5U, err)
+			}
+			leaf := certs[0]
+			key := leaf.PublicKey.(*ecdsa.PublicKey)
+			if !sig.(*verifier.ContentSignature).VerifyData([]byte(input), key) {
+				t.Fatalf("testcase %d failed to verify signature", i)
+			}
 
-		if leaf.Subject.CommonName != testcase.expectedCommonName {
-			t.Errorf("testcase %d expected common name %#v, got %#v", i, testcase.expectedCommonName, leaf.Subject.CommonName)
-		}
+			if leaf.Subject.CommonName != testcase.expectedCommonName {
+				t.Errorf("testcase %d expected common name %#v, got %#v", i, testcase.expectedCommonName, leaf.Subject.CommonName)
+			}
+		})
 	}
 }
 

--- a/signer/contentsignaturepki/contentsignature_test.go
+++ b/signer/contentsignaturepki/contentsignature_test.go
@@ -10,6 +10,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -75,7 +76,7 @@ func TestSign(t *testing.T) {
 			}
 
 			// verify the signature using the public key of the end entity
-			_, certs, err := GetX5U(buildHTTPClient(), s.X5U)
+			_, certs, err := GetX5U(http.DefaultClient, s.X5U)
 			if err != nil {
 				t.Fatalf("testcase %d failed to get X5U %q: %v", i, s.X5U, err)
 			}

--- a/signer/contentsignaturepki/upload.go
+++ b/signer/contentsignaturepki/upload.go
@@ -98,7 +98,7 @@ func GetX5U(client *http.Client, x5u string) ([]byte, []*x509.Certificate, error
 	}
 	var bodyReader io.ReadCloser
 	switch parsedURL.Scheme {
-	case "https":
+	case "https", "http":
 		resp, err := client.Get(x5u)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to retrieve x5u from %#v: %w", x5u, err)

--- a/signer/contentsignaturepki/upload.go
+++ b/signer/contentsignaturepki/upload.go
@@ -87,11 +87,6 @@ func writeLocalFile(data, name string, target *url.URL) error {
 	return os.WriteFile(filepath.Join(target.Path, name), []byte(data), 0755)
 }
 
-// buildHTTPClient returns the default HTTP.Client for fetching X5Us
-func buildHTTPClient() *http.Client {
-	return &http.Client{}
-}
-
 // GetX5U retrieves a chain file of certs from upload location, parses
 // and verifies it, then returns a byte slice of the response body and
 // a slice of parsed certificates.

--- a/signer/contentsignaturepki/upload.go
+++ b/signer/contentsignaturepki/upload.go
@@ -20,7 +20,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	csigverifier "github.com/mozilla-services/autograph/verifier/contentsignature"
-	log "github.com/sirupsen/logrus"
 )
 
 // S3UploadAPI is an interface to accommodate testing
@@ -85,7 +84,6 @@ func writeLocalFile(data, name string, target *url.URL) error {
 		}
 	}
 
-	log.Printf("FIXME writing to %s", filepath.Join(target.Path, name))
 	return os.WriteFile(filepath.Join(target.Path, name), []byte(data), 0755)
 }
 

--- a/signer/contentsignaturepki/x509.go
+++ b/signer/contentsignaturepki/x509.go
@@ -7,6 +7,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
+	"path"
 	"time"
 
 	"github.com/mozilla-services/autograph/database"
@@ -51,7 +52,7 @@ func (s *ContentSigner) makeAndUploadChain() (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to upload chain: %w", err)
 	}
-	newX5U := s.X5U + chainName
+	newX5U := path.Join(s.X5U, chainName)
 	_, _, err = GetX5U(buildHTTPClient(), newX5U)
 	if err != nil {
 		return fmt.Errorf("failed to download new chain: %w", err)

--- a/signer/contentsignaturepki/x509.go
+++ b/signer/contentsignaturepki/x509.go
@@ -7,6 +7,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
+	"net/http"
 	"net/url"
 	"time"
 
@@ -55,7 +56,7 @@ func (s *ContentSigner) makeAndUploadChain() error {
 	if err != nil {
 		return fmt.Errorf("failed to join x5u with chain name: %w", err)
 	}
-	_, _, err = GetX5U(buildHTTPClient(), newX5U)
+	_, _, err = GetX5U(http.DefaultClient, newX5U)
 	if err != nil {
 		return fmt.Errorf("failed to download new chain: %w", err)
 	}

--- a/signer/contentsignaturepki/x509.go
+++ b/signer/contentsignaturepki/x509.go
@@ -7,7 +7,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
-	"path"
+	"net/url"
 	"time"
 
 	"github.com/mozilla-services/autograph/database"
@@ -42,9 +42,8 @@ func (s *ContentSigner) findAndSetEE(conf signer.Configuration) (err error) {
 
 // makeAndUploadChain makes a certificate using the end-entity public key,
 // uploads the chain to its destination and creates an X5U download URL
-func (s *ContentSigner) makeAndUploadChain() (err error) {
-	var fullChain, chainName string
-	fullChain, chainName, err = s.makeChain()
+func (s *ContentSigner) makeAndUploadChain() error {
+	fullChain, chainName, err := s.makeChain()
 	if err != nil {
 		return fmt.Errorf("failed to make chain: %w", err)
 	}
@@ -52,13 +51,16 @@ func (s *ContentSigner) makeAndUploadChain() (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to upload chain: %w", err)
 	}
-	newX5U := path.Join(s.X5U, chainName)
+	newX5U, err := url.JoinPath(s.X5U, chainName)
+	if err != nil {
+		return fmt.Errorf("failed to join x5u with chain name: %w", err)
+	}
 	_, _, err = GetX5U(buildHTTPClient(), newX5U)
 	if err != nil {
 		return fmt.Errorf("failed to download new chain: %w", err)
 	}
 	s.X5U = newX5U
-	return
+	return nil
 }
 
 // makeChain issues an end-entity certificate using the ca private key and the first


### PR DESCRIPTION
- **trim leading slash before uploading chains to S3**
- **started as just filepath.Join(target.Path, name) in writeLocalFile**
- **make subtests for easier testing**
- **join the X5U**
- **remove FIXME log**
- **use url.JoinPath to correctly escape and join x5u and chainName**
- **use default http client everywhere now since we're not modifying it**
