### PR TITLE
emit request URI in signature handler response log

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -311,6 +311,7 @@ func (a *autographer) handleSignature(w http.ResponseWriter, r *http.Request) {
 		}
 		log.WithFields(log.Fields{
 			"rid":           rid,
+			"request_uri":   r.URL.RequestURI(),
 			"options":       sigreq.Options,
 			"mode":          sigresps[i].Mode,
 			"ref":           sigresps[i].Ref,


### PR DESCRIPTION
The log entries for the signature handler response don't include the
exact kind of API call it was in them, making it hard to suss out who is
doing certain kinds of traffic.

I was looking to see how was making the tens of /sign/hash requests we
see in production that I saw in the metrics, and couldn't easily
correlate them to the logs to figure out which users were in play.

This would be better as a tracing set up, but Mozilla doesn't have the
observability platform for that right now.
