### PR TITLE
remove verifier replace statement in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,5 +86,3 @@ require (
 	google.golang.org/grpc v1.24.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )
-
-replace github.com/mozilla-services/autograph/verifier/contentsignature => ./verifier/contentsignature/

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -467,4 +467,3 @@ google.golang.org/grpc/tap
 # gopkg.in/yaml.v2 v2.2.8
 ## explicit
 gopkg.in/yaml.v2
-# github.com/mozilla-services/autograph/verifier/contentsignature => ./verifier/contentsignature/


### PR DESCRIPTION
Missed when removing the verfifier/contentsignature go.mod in #899.

This has caused other folks to try to add replace statements that they
didn't need to, and it's useless in any case.

Removed the `replace` and ran `go mod vendor` to clean up the vendoring
(plus a `go mod tidy` just in case).
