### PR TITLE
AUT-250 - Missed that the deploy step also ran on merges to main. Moving monitor zip build to seperate workflow

### DIFF
--- a/.github/workflows/build-monitor.yaml
+++ b/.github/workflows/build-monitor.yaml
@@ -32,7 +32,7 @@ jobs:
         run: |
           EXISTING_RELEASE=$(gh release view $GITHUB_REF_NAME --json="id" || echo '')
           if [[ -z $EXISTING_RELEASE ]]; then
-              gh release create $GITHUB_REF_NAME --generate-notes -d
+              gh release create $GITHUB_REF_NAME --generate-notes --latest
           fi
 
       - name: Upload zip package to release

--- a/.github/workflows/build-monitor.yaml
+++ b/.github/workflows/build-monitor.yaml
@@ -1,0 +1,40 @@
+name: Deploy
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - '[0-9]+.[0-9a-z]+.[0-9a-z]+'
+
+jobs:
+  monitor:
+    name: Build Monitor Lambda Zip
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      
+      - name: Build monitor
+        run: |
+          cd tools/autograph-monitor
+          make build
+      
+      - name: Create release draft if a release doesn't exist yet
+        run: |
+          EXISTING_RELEASE=$(gh release view $GITHUB_REF_NAME --json="id" || echo '')
+          if [[ -z $EXISTING_RELEASE ]]; then
+              gh release create $GITHUB_REF_NAME --generate-notes -d
+          fi
+
+      - name: Upload zip package to release
+        run: |
+          gh release upload $GITHUB_REF_NAME "tools/autograph-monitor/autograph-monitor.zip" --clobber

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -65,36 +65,3 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           context: .
-
-  monitor:
-    name: Build Monitor Lambda Zip
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-    env:
-      GH_TOKEN: ${{ github.token }}
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-      
-      - name: Build monitor
-        run: |
-          cd tools/autograph-monitor
-          make build
-      
-      - name: Create release draft if a release doesn't exist yet
-        run: |
-          EXISTING_RELEASE=$(gh release view $GITHUB_REF_NAME --json="id" || echo '')
-          if [[ -z $EXISTING_RELEASE ]]; then
-              gh release create $GITHUB_REF_NAME --generate-notes -d
-          fi
-
-      - name: Upload zip package to release
-        run: |
-          gh release upload $GITHUB_REF_NAME "$RUNNER_TEMP/tools/autograph-monitor/autograph-monitor.zip" --clobber


### PR DESCRIPTION
On the previous PR, I overlooked that the deploy workflow also runs on merges to main. 
We only want the monitor lambda build to happen on tags.
Moving to a separate workflow.