### PR TITLE
AUT-254: install git to fix coverage report generation

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -91,6 +91,7 @@ jobs:
       - name: Run Tests
         shell: bash
         run: |
+          /usr/bin/git show -s --format=%cN HEAD
           docker compose run unit-test
 
   integration-tests:

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get update && \
         apksigner \
         golang-${GO_VERSION} \
         gcc \
+        # needed for accurately collecting coverage data
+        git \
         g++ \
         libc6-dev \
         pkg-config \


### PR DESCRIPTION
Coveralls needs git installed to properly report coverage information.