### PR TITLE
add goimports to the linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,6 +5,7 @@ linters:
     # TODO(AUT-202): errcheck is too handy to leave out but requires more churn
     # at time of writing
     # - errcheck
+    - goimports
     - gosimple
     - govet
     - ineffassign

--- a/crypto11/aead.go
+++ b/crypto11/aead.go
@@ -25,6 +25,7 @@ import (
 	"crypto/cipher"
 	"errors"
 	"fmt"
+
 	"github.com/miekg/pkcs11"
 )
 

--- a/crypto11/block.go
+++ b/crypto11/block.go
@@ -23,6 +23,7 @@ package crypto11
 
 import (
 	"fmt"
+
 	"github.com/miekg/pkcs11"
 )
 

--- a/crypto11/blockmode.go
+++ b/crypto11/blockmode.go
@@ -25,9 +25,10 @@ import (
 	"context"
 	"crypto/cipher"
 	"fmt"
+	"runtime"
+
 	"github.com/miekg/pkcs11"
 	"github.com/youtube/vitess/go/pools"
-	"runtime"
 )
 
 // cipher.BlockMode -----------------------------------------------------

--- a/crypto11/common.go
+++ b/crypto11/common.go
@@ -100,7 +100,7 @@ func dsaGeneric(slot uint, key pkcs11.ObjectHandle, mechanism uint, digest []byt
 
 // Pick a random label for a key
 func generateKeyLabel() ([]byte, error) {
-	rawLabel := make([]byte, labelLength / 2)
+	rawLabel := make([]byte, labelLength/2)
 	var rand PKCS11RandReader
 	sz, err := rand.Read(rawLabel)
 	if err != nil {

--- a/crypto11/crypto11.go
+++ b/crypto11/crypto11.go
@@ -21,7 +21,7 @@
 
 // Package crypto11 enables access to cryptographic keys from PKCS#11 using Go crypto API.
 //
-// Simple use
+// # Simple use
 //
 // 1. Either write a configuration file (see ConfigureFromFile) or
 // define a configuration in your application (see PKCS11Config and
@@ -40,7 +40,7 @@
 // or to *PKCS11PrivateKeyDSA, *PKCS11PrivateKeyECDSA or
 // *PKCS11PrivateKeyRSA.
 //
-// Sessions and concurrency
+// # Sessions and concurrency
 //
 // Note that PKCS#11 session handles must not be used concurrently
 // from multiple threads. Consumers of the Signer interface know
@@ -64,7 +64,7 @@
 //
 // See also https://golang.org/pkg/crypto/
 //
-// Limitations
+// # Limitations
 //
 // The PKCS1v15DecryptOptions SessionKeyLen field is not implemented
 // and an error is returned if it is nonzero.

--- a/crypto11/hmac.go
+++ b/crypto11/hmac.go
@@ -25,9 +25,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash"
+
 	"github.com/miekg/pkcs11"
 	"github.com/youtube/vitess/go/pools"
-	"hash"
 )
 
 const (

--- a/crypto11/sessions.go
+++ b/crypto11/sessions.go
@@ -25,10 +25,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/miekg/pkcs11"
-	"github.com/youtube/vitess/go/pools"
 	"log"
 	"sync"
+
+	"github.com/miekg/pkcs11"
+	"github.com/youtube/vitess/go/pools"
 )
 
 // PKCS11Session is a pair of PKCS#11 context and a reference to a loaded session handle.

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -129,7 +129,7 @@ type Configuration struct {
 	SignerOpts crypto.SignerOpts `json:"signer_opts,omitempty" yaml:"signeropts,omitempty"`
 
 	isHsmAvailable bool
-	Hsm HSM
+	Hsm            HSM
 }
 
 // InitHSM indicates that an HSM has been initialized

--- a/tools/autograph-monitor/notifier.go
+++ b/tools/autograph-monitor/notifier.go
@@ -1,7 +1,5 @@
 package main
 
-import ()
-
 // Notifier is an interface for sending and resolving warning notifications
 type Notifier interface {
 	// Send writes a message with an id to a notification channel


### PR DESCRIPTION
I noticed my editor was making import ordering changes in recent code
(like in GH-1000).

To avoid that kind of churn, this patch adds the fairly standard `goimports`  tool to golangci-lint.

I then ran `golangci-lint run --fix`.

The comment changes are changes to godoc where the "#" format for
section headings was added in go 1.19 (see
<https://tip.golang.org/doc/comment>) and were created when running
`--fix`.
