### PR TITLE
bundle top-level aws-sdk-go-v2 in dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,4 @@ updates:
         applies-to: version-updates
         patterns:
           - "github.com/aws/aws-sdk-go-v2/*"
+          - "github.com/aws/aws-sdk-go-v2"


### PR DESCRIPTION
Obvious in retrospect, but the top-level github.com/aws/aws-sdk-go-v2
module is not included in the pattern "github.com/aws/aws-sdk-go-v2/*"
for the dependabot group. But it would be nice to bundle it in there. It
usually will show up in that dependabot group PR anyway, but as we've
seen today, it'll also get a separate PR.
