### PR TITLE
AUT-251 - Use the same rand in SignHash method

### DIFF
--- a/signer/contentsignature/contentsignature.go
+++ b/signer/contentsignature/contentsignature.go
@@ -3,7 +3,6 @@ package contentsignature // import "github.com/mozilla-services/autograph/signer
 import (
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/rand"
 	"crypto/sha256"
 	"crypto/sha512"
 	"crypto/x509"
@@ -154,7 +153,7 @@ func (s *ContentSigner) SignHash(input []byte, options interface{}) (signer.Sign
 		ID:   s.ID,
 	}
 
-	asn1Sig, err := s.priv.(crypto.Signer).Sign(rand.Reader, input, nil)
+	asn1Sig, err := s.priv.(crypto.Signer).Sign(s.rand, input, nil)
 	if err != nil {
 		return nil, fmt.Errorf("contentsignature: failed to sign hash: %w", err)
 	}


### PR DESCRIPTION
As part of initializing the contentsignature signer we [call conf.GetRand()](https://github.com/mozilla-services/autograph/blob/19c4068ab8bb2041c913b5212152c7f36478f3cb/signer/contentsignature/contentsignature.go#L77). This will be either [a rand.Reader or crypto11.PKCSRandReader](https://github.com/mozilla-services/autograph/blob/19c4068ab8bb2041c913b5212152c7f36478f3cb/signer/signer.go#L253-L256) depending on whether or not an HSM is available. However, the SignHash method ends up just [using rand.Reader directly](https://github.com/mozilla-services/autograph/blob/19c4068ab8bb2041c913b5212152c7f36478f3cb/signer/contentsignature/contentsignature.go#L157), and s.rand goes unused altogether.

Make sure `SignHash` uses the same rand as the initialized `ContentSigner` by using `s.rand`.

Fix AUT-251