### PR TITLE
Explicitly state DOCKER_DEFAULT_PLATFORM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG LIBKMSP11_VERSION=1.6
 #------------------------------------------------------------------------------
 # Base Debian Image
 #------------------------------------------------------------------------------
-FROM debian:bookworm as base
+FROM --platform=linux/amd64 debian:bookworm as base
 ARG GO_VERSION
 
 ENV DEBIAN_FRONTEND='noninteractive' \


### PR DESCRIPTION
When running `docker pull mozilla/autograph && docker run mozilla/autograph` on MacOS, no build is pulled because of the OS/ARCH mismatch ([see all the Autograph tags](https://hub.docker.com/r/mozilla/autograph/tags)). Explicitly stating the platform to `linux/amd64` fixes this.