### PR TITLE
refresh makecsr and add it to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ ADD . /app/src/autograph
 RUN cd /app/src/autograph && go install .
 RUN cd /app/src/autograph/tools/autograph-monitor && go build -o /go/bin/autograph-monitor .
 RUN cd /app/src/autograph/tools/autograph-client && go build -o /go/bin/autograph-client .
+RUN cd /app/src/autograph/tools/makecsr && go build -o /go/bin/makecsr .
 
 #------------------------------------------------------------------------------
 # Deployment Stage

--- a/tools/makecsr/README.md
+++ b/tools/makecsr/README.md
@@ -5,10 +5,10 @@ hosted in our HSMs. It's used particularly to issue the CS and AMO intermediates
 used by autograph. See our private hsm repo for how we've invoked it.
 
 Note: nearly all of the CSRs attributes can be overridden at signing time, so
-this is not a complete picture (esp. of the name constraints). From SAN to
-signature algorithm. But we include those out of a desire to be as explicit as
-we can be, at the cost of perhaps confusing ourselves about all the places those
-attributes must be specified.
+this is not a complete picture of what will be signed. But we include attributes
+like subject alternative names and signature algorithm out of a desire to be as
+explicit as we can be. This comes at the cost of perhaps confusing ourselves
+about all the places those attributes must be specified.
 
 If you're invoking in GCP, be sure to set the `KMS_PKCS11_CONFIG` env var to the
 YAML config file that the libkmsp11 library requires.

--- a/tools/makecsr/README.md
+++ b/tools/makecsr/README.md
@@ -1,8 +1,52 @@
-makecsr
-=======
+# makecsr
 
-This is a small helper used to generate a CSR from a private key hosted in HSM.
-It's used particularly to issue the CS and AMO intermediates used by autograph.
+This is a small helper used to generate a PEM-encoded CSR from a private key
+hosted in our HSMs. It's used particularly to issue the CS and AMO intermediates
+used by autograph. See our private hsm repo for how we've invoked it.
+
+Note: nearly all of the CSRs attributes can be overridden at signing time, so
+this is not a complete picture (esp. of the name constraints). From SAN to
+signature algorithm. But we include those out of a desire to be as explicit as
+we can be, at the cost of perhaps confusing ourselves about all the places those
+attributes must be specified.
+
+If you're invoking in GCP, be sure to set the `KMS_PKCS11_CONFIG` env var to the
+YAML config file that the libkmsp11 library requires.
+
+This code also requires a crypto11 JSON configuration file at whereever the
+`-cryptoConfig` arg says (the default is `./crypto11-config.json`).
+
+For AWS, that file will look something like:
+
+```json
+{
+  "Path": "/opt/cloudhsm/lib/libcloudhsm_pkcs11.so",
+  "TokenLabel": "cavium",
+  "Pin": "$CRYPTO_USER:$PASSWORD"
+}
+```
+
+For GCP, that file will look something like:
+
+```json
+{
+  "Path": "/path/to/libkmsp11.so",
+  "TokenLabel": "gcp"
+}
+```
+
+You will additionally need to be logged into gcloud locally (`gcloud auth login
+--update-adc`). And you'll need a kmsp11 yml configuration file created and
+specified in the `KMS_PKCS11_CONFIG` environment variable. This will look
+something like:
+
+```yaml
+tokens:
+  - key_ring: projects/autograph/locations/us-west-2/keyRings/autograph-keyring
+  - label: gcp
+```
+
+Note that the `label` must match between the two configuration files.
 
 For more information, see
 https://mana.mozilla.org/wiki/pages/viewpage.action?pageId=87365053

--- a/tools/makecsr/makecsr_test.go
+++ b/tools/makecsr/makecsr_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestGoldenPath(t *testing.T) {
+	testcases := []struct {
+		privKey       crypto.PrivateKey
+		orgUnit       string
+		commonName    string
+		email         string
+		dnsNames      []string
+		sigAlg        x509.SignatureAlgorithm
+		expectedError error
+	}{
+		{generateRSAKey(t), "MozOrg", "MozCN", "", []string{"example.com", "biff.com"}, x509.SHA256WithRSA, nil},
+		{generateRSAKey(t), "MozOrg", "MozCN", "", []string{"okay.com"}, x509.SHA384WithRSA, nil},
+		{generateRSAKey(t), "MozOrg", "MozCN/email=foobar.com", "", []string{"okay.com"}, x509.SHA256WithRSA, nil},
+		{generateRSAKey(t), "MozOrg", "MozCN", "welp@foobar.com", []string{"okay.com"}, x509.SHA256WithRSA, nil},
+		{generateECDSAKey(t), "Foo", "foocN", "", []string{"okay.com"}, x509.ECDSAWithSHA256, nil},
+		{generateECDSAKey(t), "Foo", "foocN", "", []string{"okay.com"}, x509.ECDSAWithSHA384, nil},
+		{generateRSAKey(t), "MozOrg", "MozCN", "", []string{"failed.com"}, x509.ECDSAWithSHA256, errors.New("x509: requested SignatureAlgorithm does not match private key type")},
+	}
+	for i, tc := range testcases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			out, err := generatePEMEncodedCSR(tc.privKey, tc.orgUnit, tc.commonName, tc.email, tc.dnsNames, tc.sigAlg)
+			if tc.expectedError != nil {
+				if err == nil {
+					t.Fatalf("expectedError: want %v, got nil", tc.expectedError)
+				}
+
+				if !errors.Is(err, tc.expectedError) && !strings.Contains(err.Error(), tc.expectedError.Error()) {
+					t.Fatalf("expectedError: want %v, got %v", tc.expectedError, err)
+				}
+
+				// return early because there's no valid `out` value to check
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected generatePEMEncodedCSR error: %v", err)
+			}
+
+			csrBytes, rest := pem.Decode(out)
+			if len(rest) != 0 {
+				t.Fatalf("unexpected trailing data: %v", rest)
+			}
+
+			csr, err := x509.ParseCertificateRequest(csrBytes.Bytes)
+			if err != nil {
+				t.Fatalf("unexpected x509.ParseCertificateRequest error: %v", err)
+			}
+			t.Logf("csr pem:\n%s", out)
+			if csr.Subject.CommonName != tc.commonName {
+				t.Errorf("want CommonName %q, got %q", tc.commonName, csr.Subject.CommonName)
+			}
+			if len(csr.Subject.OrganizationalUnit) != 1 || csr.Subject.OrganizationalUnit[0] != tc.orgUnit {
+				t.Errorf("want OrganizationalUnit %q, got %q", []string{tc.orgUnit}, csr.Subject.OrganizationalUnit[0])
+			}
+			if tc.email == "" {
+				if len(csr.EmailAddresses) != 0 {
+					t.Errorf("want no EmailAddresses, got %q", csr.EmailAddresses)
+				}
+			} else if len(csr.EmailAddresses) != 1 || csr.EmailAddresses[0] != tc.email {
+				t.Errorf("want EmailAddresses %q, got %q", []string{tc.email}, csr.EmailAddresses)
+			}
+			if csr.Subject.Country[0] != "US" {
+				t.Errorf("want Country %q, got %q", "US", csr.Subject.Country[0])
+			}
+			if !slices.Equal(csr.DNSNames, tc.dnsNames) {
+				t.Errorf("want DNSNames %q, got %q", tc.dnsNames, csr.DNSNames)
+			}
+		})
+	}
+}
+
+func generateRSAKey(t *testing.T) crypto.PrivateKey {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("unexpected rsa.GenerateKey error: %v", err)
+	}
+	return privKey
+}
+
+func generateECDSAKey(t *testing.T) crypto.PrivateKey {
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("unexpected ecdsa.GenerateKey error: %v", err)
+	}
+	return privKey
+}


### PR DESCRIPTION
The makecsr tool is used to generate a CSR for our addon and
contentsignaturepki intermediates

This patch does a mild refactoring to bring it under test and adds it to
the docker image so it can be used from our private hsm tooling repo.

We also add setting the Subject Alternative Name DNS names to it. This
will make it easier for future tooling that's dealing with Name
Constraints verify it correctly.

Along the way, we also require passing in a signature algorithm.
Signature algorithm, like the name constraints, is something that can be
overridden at CA signing time, but this removes some of the per-cloud
implicit configuration that was in the tool.

Updates AUT-279
Updates AUT-280
