### PR TITLE
AUT-313: break up too-large-for-GCP random reads before sending them to libkmsp11

### DIFF
--- a/signer/entropy_test.go
+++ b/signer/entropy_test.go
@@ -23,7 +23,7 @@ func shannonEntropy(data []byte) (entropy float64) {
 }
 
 func TestRng(t *testing.T) {
-	for i, testcase := range PASSINGTESTCASES {
+	for i, testcase := range passingTestCases {
 		rng := testcase.cfg.GetRand()
 		randomData := make([]byte, 512)
 		_, err := rng.Read(randomData)


### PR DESCRIPTION
This allows for the reading of random bytes of any size, which is needed by various operations that Autograph performs.