### PR TITLE
AUT-251 Use the same rand on SignHash as the ContentSigner

### DIFF
--- a/signer/contentsignature/contentsignature.go
+++ b/signer/contentsignature/contentsignature.go
@@ -107,7 +107,9 @@ func (s *ContentSigner) SignData(input []byte, options interface{}) (signer.Sign
 	}
 	alg, hash := makeTemplatedHash(input, s.Mode)
 	sig, err := s.SignHash(hash, options)
-	sig.(*verifier.ContentSignature).HashName = alg
+	if err == nil {
+		sig.(*verifier.ContentSignature).HashName = alg
+	}
 	return sig, err
 }
 

--- a/signer/contentsignature/contentsignature.go
+++ b/signer/contentsignature/contentsignature.go
@@ -3,7 +3,6 @@ package contentsignature // import "github.com/mozilla-services/autograph/signer
 import (
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/rand"
 	"crypto/sha256"
 	"crypto/sha512"
 	"crypto/x509"
@@ -154,7 +153,8 @@ func (s *ContentSigner) SignHash(input []byte, options interface{}) (signer.Sign
 		ID:   s.ID,
 	}
 
-	asn1Sig, err := s.priv.(crypto.Signer).Sign(rand.Reader, input, nil)
+	// asn1Sig, err := s.priv.(crypto.Signer).Sign(rand.Reader, input, nil)
+	asn1Sig, err := s.priv.(crypto.Signer).Sign(s.rand, input, nil)
 	if err != nil {
 		return nil, fmt.Errorf("contentsignature: failed to sign hash: %w", err)
 	}

--- a/signer/contentsignature/contentsignature.go
+++ b/signer/contentsignature/contentsignature.go
@@ -105,13 +105,14 @@ func (s *ContentSigner) SignData(input []byte, options interface{}) (signer.Sign
 	if len(input) < 10 {
 		return nil, fmt.Errorf("contentsignature: refusing to sign input data shorter than 10 bytes")
 	}
+
 	alg, hash := makeTemplatedHash(input, s.Mode)
 	sig, err := s.SignHash(hash, options)
-
-	if sig != nil {
-		// sig could be nil when there is misconfigured permission or the kms is not available
-		sig.(*verifier.ContentSignature).HashName = alg
+	if err != nil {
+		return nil, err
 	}
+
+	sig.(*verifier.ContentSignature).HashName = alg
 	return sig, err
 }
 

--- a/signer/contentsignature/contentsignature.go
+++ b/signer/contentsignature/contentsignature.go
@@ -107,7 +107,9 @@ func (s *ContentSigner) SignData(input []byte, options interface{}) (signer.Sign
 	}
 	alg, hash := makeTemplatedHash(input, s.Mode)
 	sig, err := s.SignHash(hash, options)
-	if err == nil {
+
+	if sig != nil {
+		// sig could be nil when there is misconfigured permission or the kms is not available
 		sig.(*verifier.ContentSignature).HashName = alg
 	}
 	return sig, err
@@ -155,7 +157,6 @@ func (s *ContentSigner) SignHash(input []byte, options interface{}) (signer.Sign
 		ID:   s.ID,
 	}
 
-	// asn1Sig, err := s.priv.(crypto.Signer).Sign(rand.Reader, input, nil)
 	asn1Sig, err := s.priv.(crypto.Signer).Sign(s.rand, input, nil)
 	if err != nil {
 		return nil, fmt.Errorf("contentsignature: failed to sign hash: %w", err)

--- a/signer/contentsignature/contentsignature_test.go
+++ b/signer/contentsignature/contentsignature_test.go
@@ -218,3 +218,71 @@ func TestNoShortData(t *testing.T) {
 		t.Fatalf("expected to fail with input data too short but failed with: %v", err)
 	}
 }
+
+// Reproduce nil error
+var NILTESTCASE = []struct {
+	cfg signer.Configuration
+}{
+	// 	{cfg: signer.Configuration{
+	// 		Type: Type,
+	// 		ID:   P256ECDSA,
+	// 		X5U:  "https://foo.bar/chain.pem",
+	// 		PrivateKey: `
+	// -----BEGIN EC PARAMETERS-----
+	// BggqhkjOPQMBBw==
+	// -----END EC PARAMETERS-----
+	// -----BEGIN EC PRIVATE KEY-----
+	// MHcCAQEEII+Is30aP9wrB/H6AkKrJjMG8EVY2WseSFHTfWGCIk7voAoGCCqGSM49
+	// AwEHoUQDQgAEMdzAsqkWQiP8Fo89qTleJcuEjBtp2c6z16sC7BAS5KXvUGghURYq
+	// 3utZw8En6Ik/4Om8c7EW/+EO+EkHShhgdA==
+	// -----END EC PRIVATE KEY-----`,
+	// 	}},
+	{cfg: signer.Configuration{
+		Type:       Type,
+		ID:         "",
+		X5U:        "",
+		PrivateKey: "",
+	}},
+}
+
+func TestNilErrorOnSignData(t *testing.T) {
+	input := []byte("foobarbaz1234abcd")
+	for i, testcase := range NILTESTCASE {
+		// initialize a signer
+		s, err := New(testcase.cfg)
+		// if err != nil {
+		// 	t.Fatalf("testcase %d signer initialization failed with: %v", i, err)
+		// }
+		// if s.Type != testcase.cfg.Type {
+		// 	t.Fatalf("testcase %d signer type %q does not match configuration %q", i, s.Type, testcase.cfg.Type)
+		// }
+		// if s.ID != testcase.cfg.ID {
+		// 	t.Fatalf("testcase %d signer id %q does not match configuration %q", i, s.ID, testcase.cfg.ID)
+		// }
+		// if s.PrivateKey != testcase.cfg.PrivateKey {
+		// 	t.Fatalf("testcase %d signer private key %q does not match configuration %q", i, s.PrivateKey, testcase.cfg.PrivateKey)
+		// }
+		// if s.Mode != testcase.cfg.ID {
+		// 	t.Fatalf("testcase %d signer curve %q does not match expected %q", i, s.Mode, testcase.cfg.ID)
+		// }
+
+		// compare configs
+		c1, err := json.Marshal(s)
+		if err != nil {
+			t.Fatalf("testcase %d failed to json marshal signer: %v", i, err)
+		}
+		c2, err := json.Marshal(s.Config())
+		if err != nil {
+			t.Fatalf("testcase %d failed to json marshal signer config: %v", i, err)
+		}
+		if string(c1) != string(c2) {
+			t.Fatalf("testcase %d configurations don't match:\nc1=%s\nc2=%s", i, c1, c2)
+		}
+
+		// sign input data
+		_, err_nil := s.SignData(input, nil)
+		if err_nil != nil {
+			t.Fatalf("testcase %d failed to sign data: %v", i, err)
+		}
+	}
+}

--- a/signer/contentsignature/contentsignature_test.go
+++ b/signer/contentsignature/contentsignature_test.go
@@ -227,13 +227,13 @@ func (e *ErrorReader) Read(p []byte) (n int, err error) {
 	return 0, errors.New("read error")
 }
 
-func TestNilErrorOnSignData(t *testing.T) {
+func TestRandReadFailureOnSignHash(t *testing.T) {
 	input := []byte("foobarbaz1234abcd")
 	testcase := PASSINGTESTCASES[0]
 	s, _ := New(testcase.cfg)
 	s.rand = &ErrorReader{}
 	_, err_nil := s.SignData(input, nil)
 	if err_nil == nil {
-		t.Fatal("Should have failed to sign data with error in SignHash.")
+		t.Fatal("Should have failed to sign data with error in the SignHash.")
 	}
 }

--- a/signer/contentsignature/contentsignature_test.go
+++ b/signer/contentsignature/contentsignature_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -220,69 +221,19 @@ func TestNoShortData(t *testing.T) {
 }
 
 // Reproduce nil error
-var NILTESTCASE = []struct {
-	cfg signer.Configuration
-}{
-	// 	{cfg: signer.Configuration{
-	// 		Type: Type,
-	// 		ID:   P256ECDSA,
-	// 		X5U:  "https://foo.bar/chain.pem",
-	// 		PrivateKey: `
-	// -----BEGIN EC PARAMETERS-----
-	// BggqhkjOPQMBBw==
-	// -----END EC PARAMETERS-----
-	// -----BEGIN EC PRIVATE KEY-----
-	// MHcCAQEEII+Is30aP9wrB/H6AkKrJjMG8EVY2WseSFHTfWGCIk7voAoGCCqGSM49
-	// AwEHoUQDQgAEMdzAsqkWQiP8Fo89qTleJcuEjBtp2c6z16sC7BAS5KXvUGghURYq
-	// 3utZw8En6Ik/4Om8c7EW/+EO+EkHShhgdA==
-	// -----END EC PRIVATE KEY-----`,
-	// 	}},
-	{cfg: signer.Configuration{
-		Type:       Type,
-		ID:         "",
-		X5U:        "",
-		PrivateKey: "",
-	}},
+type ErrorReader struct{}
+
+func (e *ErrorReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("read error")
 }
 
 func TestNilErrorOnSignData(t *testing.T) {
 	input := []byte("foobarbaz1234abcd")
-	for i, testcase := range NILTESTCASE {
-		// initialize a signer
-		s, err := New(testcase.cfg)
-		// if err != nil {
-		// 	t.Fatalf("testcase %d signer initialization failed with: %v", i, err)
-		// }
-		// if s.Type != testcase.cfg.Type {
-		// 	t.Fatalf("testcase %d signer type %q does not match configuration %q", i, s.Type, testcase.cfg.Type)
-		// }
-		// if s.ID != testcase.cfg.ID {
-		// 	t.Fatalf("testcase %d signer id %q does not match configuration %q", i, s.ID, testcase.cfg.ID)
-		// }
-		// if s.PrivateKey != testcase.cfg.PrivateKey {
-		// 	t.Fatalf("testcase %d signer private key %q does not match configuration %q", i, s.PrivateKey, testcase.cfg.PrivateKey)
-		// }
-		// if s.Mode != testcase.cfg.ID {
-		// 	t.Fatalf("testcase %d signer curve %q does not match expected %q", i, s.Mode, testcase.cfg.ID)
-		// }
-
-		// compare configs
-		c1, err := json.Marshal(s)
-		if err != nil {
-			t.Fatalf("testcase %d failed to json marshal signer: %v", i, err)
-		}
-		c2, err := json.Marshal(s.Config())
-		if err != nil {
-			t.Fatalf("testcase %d failed to json marshal signer config: %v", i, err)
-		}
-		if string(c1) != string(c2) {
-			t.Fatalf("testcase %d configurations don't match:\nc1=%s\nc2=%s", i, c1, c2)
-		}
-
-		// sign input data
-		_, err_nil := s.SignData(input, nil)
-		if err_nil != nil {
-			t.Fatalf("testcase %d failed to sign data: %v", i, err)
-		}
+	testcase := PASSINGTESTCASES[0]
+	s, _ := New(testcase.cfg)
+	s.rand = &ErrorReader{}
+	_, err_nil := s.SignData(input, nil)
+	if err_nil == nil {
+		t.Fatal("Should have failed to sign data with error in SignHash.")
 	}
 }

--- a/signer/contentsignature/contentsignature_test.go
+++ b/signer/contentsignature/contentsignature_test.go
@@ -220,7 +220,6 @@ func TestNoShortData(t *testing.T) {
 	}
 }
 
-// Reproduce nil error
 type ErrorReader struct{}
 
 func (e *ErrorReader) Read(p []byte) (n int, err error) {
@@ -231,9 +230,10 @@ func TestRandReadFailureOnSignHash(t *testing.T) {
 	input := []byte("foobarbaz1234abcd")
 	testcase := PASSINGTESTCASES[0]
 	s, _ := New(testcase.cfg)
+	// TODO: Add a configurable rand.Reader
 	s.rand = &ErrorReader{}
-	_, err_nil := s.SignData(input, nil)
-	if err_nil == nil {
+	_, err := s.SignData(input, nil)
+	if err == nil {
 		t.Fatal("Should have failed to sign data with error in the SignHash.")
 	}
 }

--- a/signer/contentsignaturepki/contentsignature.go
+++ b/signer/contentsignaturepki/contentsignature.go
@@ -218,7 +218,9 @@ func (s *ContentSigner) SignData(input []byte, options interface{}) (signer.Sign
 	}
 	alg, hash := MakeTemplatedHash(input, s.Mode)
 	sig, err := s.SignHash(hash, options)
-	sig.(*verifier.ContentSignature).HashName = alg
+	if sig != nil {
+		sig.(*verifier.ContentSignature).HashName = alg
+	}
 	return sig, err
 }
 
@@ -260,7 +262,7 @@ func (s *ContentSigner) SignHash(input []byte, options interface{}) (signer.Sign
 		X5U:  s.X5U,
 		ID:   s.ID,
 	}
-	// TODO: check to see if this should also be updated to s.rand
+
 	asn1Sig, err := s.eePriv.(crypto.Signer).Sign(s.rand, input, nil)
 	if err != nil {
 		return nil, fmt.Errorf("contentsignaturepki %q: failed to sign hash: %w", s.ID, err)

--- a/signer/contentsignaturepki/contentsignature.go
+++ b/signer/contentsignaturepki/contentsignature.go
@@ -3,7 +3,6 @@ package contentsignaturepki // import "github.com/mozilla-services/autograph/sig
 import (
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/rand"
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/asn1"
@@ -261,8 +260,8 @@ func (s *ContentSigner) SignHash(input []byte, options interface{}) (signer.Sign
 		X5U:  s.X5U,
 		ID:   s.ID,
 	}
-
-	asn1Sig, err := s.eePriv.(crypto.Signer).Sign(rand.Reader, input, nil)
+	// TODO: check to see if this should also be updated to s.rand
+	asn1Sig, err := s.eePriv.(crypto.Signer).Sign(s.rand, input, nil)
 	if err != nil {
 		return nil, fmt.Errorf("contentsignaturepki %q: failed to sign hash: %w", s.ID, err)
 	}

--- a/signer/contentsignaturepki/contentsignature.go
+++ b/signer/contentsignaturepki/contentsignature.go
@@ -216,11 +216,14 @@ func (s *ContentSigner) SignData(input []byte, options interface{}) (signer.Sign
 	if len(input) < 10 {
 		return nil, fmt.Errorf("contentsignaturepki %q: refusing to sign input data shorter than 10 bytes", s.ID)
 	}
+
 	alg, hash := MakeTemplatedHash(input, s.Mode)
 	sig, err := s.SignHash(hash, options)
-	if sig != nil {
-		sig.(*verifier.ContentSignature).HashName = alg
+	if err != nil {
+		return nil, err
 	}
+
+	sig.(*verifier.ContentSignature).HashName = alg
 	return sig, err
 }
 

--- a/signer/contentsignaturepki/contentsignature_test.go
+++ b/signer/contentsignaturepki/contentsignature_test.go
@@ -280,7 +280,6 @@ func TestNoShortData(t *testing.T) {
 	}
 }
 
-// Reproduce nil error
 type ErrorReader struct{}
 
 func (e *ErrorReader) Read(p []byte) (n int, err error) {
@@ -291,9 +290,10 @@ func TestReadRandFailureOnSignHash(t *testing.T) {
 	input := []byte("foobarbaz1234abcd")
 	testcase := PASSINGTESTCASES[0]
 	s, _ := New(testcase.cfg)
+	// TODO: Add a configurable rand.Reader
 	s.rand = &ErrorReader{}
-	_, err_nil := s.SignData(input, nil)
-	if err_nil == nil {
+	_, err := s.SignData(input, nil)
+	if err == nil {
 		t.Fatal("Should have failed to sign data with error in the SignHash")
 	}
 }

--- a/signer/contentsignaturepki/contentsignature_test.go
+++ b/signer/contentsignaturepki/contentsignature_test.go
@@ -8,6 +8,7 @@ package contentsignaturepki
 
 import (
 	"crypto/ecdsa"
+	"errors"
 	"strings"
 	"testing"
 
@@ -276,5 +277,23 @@ func TestNoShortData(t *testing.T) {
 	}
 	if err.Error() != `contentsignaturepki "testsigner0": refusing to sign input data shorter than 10 bytes` {
 		t.Fatalf("expected to fail with input data too short but failed with: %v", err)
+	}
+}
+
+// Reproduce nil error
+type ErrorReader struct{}
+
+func (e *ErrorReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("read error")
+}
+
+func TestReadRandFailureOnSignHash(t *testing.T) {
+	input := []byte("foobarbaz1234abcd")
+	testcase := PASSINGTESTCASES[0]
+	s, _ := New(testcase.cfg)
+	s.rand = &ErrorReader{}
+	_, err_nil := s.SignData(input, nil)
+	if err_nil == nil {
+		t.Fatal("Should have failed to sign data with error in the SignHash")
 	}
 }


### PR DESCRIPTION
While testing PR 1023, we found that the KMS permission was not added to the dev environment resulting in the error:
```
panic: interface conversion: signer.Signature is nil, not *contentsignature.ContentSignature

goroutine 101 [running]:
github.com/mozilla-services/autograph/signer/contentsignature.(*ContentSigner).SignData(0xc0003cc1a0, {0x20054d0?, 0xc0006b4418?, 0xc0006b4120?}, {0x0, 0x0})
	/app/src/autograph/signer/contentsignature/contentsignature.go:110 +0xfa
main.(*monitor).checkSigners(0xc0003d3830)
	/app/src/autograph/monitor.go:77 +0xc62
main.(*monitor).start(0xc0003d3830, 0xc00014a7e0?)
	/app/src/autograph/monitor.go:54 +0xe5
created by main.newMonitor in goroutine 1
	/app/src/autograph/monitor.go:148 +0x214
```
The real error on not being able to read the random stream is not returned and instead swallowed by the error trying to assign the signature’s hash name: https://github.com/mozilla-services/autograph/blob/1ca235057db53c8be20664d8c1b7d7ea7d4fff63/signer/contentsignature/contentsignature.go#L111

The fix was to check for the `ContentSigner` being `nil` before updating values to it.
The rand update was also applied to `SignData` in `ContentSignaturePKI`: https://github.com/mozilla-services/autograph/blob/1ca235057db53c8be20664d8c1b7d7ea7d4fff63/signer/contentsignaturepki/contentsignature.go#L265

# Note
Related #1028 and #1023
Dev permission to KMS updated on https://github.com/mozilla-it/webservices-infra/pull/3020
Fix AUT-251