### PR TITLE
crypto11: handle nil returns from pcks11.New

### DIFF
--- a/crypto11/crypto11_test.go
+++ b/crypto11/crypto11_test.go
@@ -1,0 +1,16 @@
+package crypto11
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestFailedFactoryFuncDoesntCausePanics(t *testing.T) {
+	expectedErr := errors.New("cool error")
+	_, err := Configure(&PKCS11Config{Path: "/nonexistent"}, func(ctx *PKCS11Config) (PKCS11Context, error) {
+		return nil, expectedErr
+	})
+	if !errors.Is(err, expectedErr) {
+		t.Errorf("expected error %v, got %v", expectedErr, err)
+	}
+}

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -324,8 +324,8 @@ var rejectedFileNames = []string{
 }
 
 func mockedPKCS11ContextFactory(ctx crypto11.PKCS11Context) crypto11.PKCS11ContextFactory {
-	wrapped := func(_ *crypto11.PKCS11Config) crypto11.PKCS11Context {
-		return ctx
+	wrapped := func(_ *crypto11.PKCS11Config) (crypto11.PKCS11Context, error) {
+		return ctx, nil
 	}
 	return wrapped
 }


### PR DESCRIPTION
Previous to this patch, a busted Path configuration passed to crypto11
would cause nil pointer panics.

This is because attempt to check the nil pointer of the PKCS11Context
interface would run into the usual "nil interface" problems where the
pointer would not be technically "nil" but calling methods on it would
cause nil pointer panics. See <https://go.dev/tour/methods/12> and
<https://trstringer.com/go-nil-interface-and-interface-with-nil-concrete-value/>
for details.

So, to handle this correctly, we need to return an error along with our
interface context type.

It's pretty surprising that `pkcs11.New` can return nil, but we do what
we must.

Updates AUT-283
