### PR TITLE
Adding libengine-pkcs11-openssl package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update && \
         libc6-dev \
         pkg-config \
         curl \
-        jq
+        jq \
+        libengine-pkcs11-openssl
 
 # Cleanup after package installation
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Adding libengine-pkcs11-openssl package to docker image so devs can do more work with it in interactive mode.