### PR TITLE
add benchmarks for GKE random generators

### DIFF
--- a/tools/benchrand/benchrand_test.go
+++ b/tools/benchrand/benchrand_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"crypto/rand"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/mozilla-services/autograph/crypto11"
+)
+
+func BenchmarkHSMRandGen(b *testing.B) {
+	if os.Getenv("KUBERNETES_SERVICE_HOST") == "" {
+		b.Skip("skipping benchmark outside of GKE")
+	}
+
+	modulePath := os.Getenv("KMS_PKCS11_MODULE")
+	if modulePath == "" {
+		b.Skip("skipping benchmark without KMS_PKCS11_MODULE")
+	}
+
+	crypto11Config := &crypto11.PKCS11Config{Path: modulePath, TokenLabel: "gcp-autograph-token"}
+	_, err := crypto11.Configure(crypto11Config, crypto11.NewDefaultPKCS11Context)
+	if err != nil {
+		b.Fatal(err)
+	}
+	reader := &crypto11.PKCS11RandReader{}
+	benchRand(b, reader)
+}
+
+func BenchmarkLocalRandGen(b *testing.B) {
+	if os.Getenv("KUBERNETES_SERVICE_HOST") == "" {
+		b.Skip("skipping benchmark outside of GKE")
+	}
+	benchRand(b, rand.Reader)
+}
+
+// TODO(AUT-335): remove this and the benches that depend on it.
+func benchRand(b *testing.B, reader io.Reader) {
+	data := make([]byte, 1024)
+	for i := 0; i < b.N; i++ {
+		n, err := reader.Read(data)
+		if n != 1024 {
+			b.Errorf("expected to read 1024 bytes, got %d", n)
+		}
+		if err != nil {
+			b.Errorf("unexpected error: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
These are to be run in the GKE to confirm my hypothesis about the
performance of the GCP KMS GenerateRandom RPC vs the local random data
generator. I suspect that we're not getting much benefit from the KMS
GenerateRandom (which is called by libkmsp11). The security properties
of it are also not sufficiently different than the modern, very good
random number generators available on Linux in the Go standard library.

Updates AUT-335
