### PR TITLE
use crane to exactly copy our image during deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -45,7 +45,7 @@ jobs:
       - id: gcp-auth
         uses: google-github-actions/auth@v2
         with:
-          token_format: 'access_token'
+          token_format: "access_token"
           service_account: artifact-writer@${{ vars.GCP_PROJECT_ID}}.iam.gserviceaccount.com
           workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
 
@@ -74,6 +74,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           context: .
 
+      - name: Set up crane
+        if: ${{ github.event_name == 'release' }}
+        uses: imjasonh/setup-crane@v0.4
+
       - name: Tag and push
         # For releases, we specifically do _not_ want to rebuild, just tag the
         # existing image and push. There's no officially maintained action for
@@ -86,8 +90,8 @@ jobs:
           TAGS: ${{ steps.meta.outputs.tags }}
           SRC: ${{ vars.DOCKERHUB_REPO}}:sha-${{ github.sha }}
         run: |
-          docker pull $SRC
+          crane digest $SRC
+          crane manifest $SRC
           for tag in $TAGS; do
-            docker tag $SRC $tag
-            docker push $tag
+            crane copy $SRC $tag
           done


### PR DESCRIPTION
The new docker tag and docker push calls were creating new manifests for
the images with mismatched digest values. Those new manifests were of
the `application/vnd.docker.distribution.manifest.v2+json` type, while
our AWS-specific image verification code was expecting
`application/vnd.oci.image.manifest.v1+json` and the sha256 digests in
the manifest for the newly tagged images, because of this change, would
no longer match.

So, we attempts to fix both problems by using `crane` to exactly copy
the docker image from one tag to another. See
https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md
for more information on crane.
