### PR TITLE
build our docker images for multiple platforms

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,6 +20,9 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -73,6 +76,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           context: .
+          platforms: linux/amd64,linux/arm64
 
       # copypasta from https://github.com/imjasonh/setup-crane/blob/main/action.yml
       - name: Set up crane
@@ -91,7 +95,6 @@ jobs:
           PATH=${PATH}:${tmp}
           echo "${tmp}" >> $GITHUB_PATH
           echo "${{ github.token }}" | crane auth login ghcr.io --username "dummy" --password-stdin
-
 
       - name: Tag and push
         # For releases, we specifically do _not_ want to rebuild, just tag the

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG LIBKMSP11_VERSION=1.6
 #------------------------------------------------------------------------------
 # Base Debian Image
 #------------------------------------------------------------------------------
-FROM --platform=linux/amd64 debian:bookworm as base
+FROM debian:bookworm AS base
 ARG GO_VERSION
 
 ENV DEBIAN_FRONTEND='noninteractive' \
@@ -38,7 +38,7 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 #------------------------------------------------------------------------------
 # Pre-build dependency caching
 #------------------------------------------------------------------------------
-FROM base as prebuild
+FROM base AS prebuild
 ARG LIBKMSP11_VERSION
 
 COPY google-pkcs12-release-signing-key.pem /app/src/autograph/
@@ -56,7 +56,7 @@ RUN curl -o /usr/local/share/old-rds-ca-bundle.pem https://s3.amazonaws.com/rds-
 #------------------------------------------------------------------------------
 # Build Stage
 #------------------------------------------------------------------------------
-FROM prebuild as builder
+FROM prebuild AS builder
 
 ADD . /app/src/autograph
 RUN cd /app/src/autograph && go install .


### PR DESCRIPTION
Following this documentation:
https://docs.docker.com/build/ci/github-actions/multi-platform/

This clears up a warning in our build, and makes it easier for folks on
arm64 (like us macOS people) to pull and use the images.

Along the way, I also fixed the warnings about using lowercase `as` when
we use uppercase commands in our Dockerfile.
