### PR TITLE
stop creating tags of the sha256 of the image

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,7 +39,6 @@ jobs:
           tags: |
             type=semver,pattern={{raw}}
             type=raw,value=latest,enable=${{ github.event_name == 'push' }}
-            type=sha,format=long,enable=${{ github.event_name == 'push' }}
 
       - name: Generate version.json
         shell: bash


### PR DESCRIPTION
On every commit pushed to `main`, we were making a docker tag with the
sha256 of the image.

This causes the AWS stage deploy to be deployed to on every commit,
which was not what we wanted (dev was the place for that).
