### PR TITLE
correct our CMD in the main Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,5 +83,5 @@ COPY --from=builder /tmp/libkmsp11.so /app
 RUN useradd --uid 10001 --home-dir /app --shell /sbin/nologin app
 USER app
 WORKDIR /app
-CMD /go/bin/autograph
+CMD ["/go/bin/autograph"]
 


### PR DESCRIPTION
This change will mean autograph will correctly see SIGTERM and SIGKILL
signals coming from systemd and kubernetes. This may change its behavior
somewhat, but, long term, for the better.

This fixes the warning we were getting from docker when building our main Dockerfile:

```
- JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 86)
```

See https://docs.docker.com/reference/build-checks/json-args-recommended/
