### PR TITLE
require db for contentsignaturepki gnight

### DIFF
--- a/database/connect.go
+++ b/database/connect.go
@@ -119,3 +119,10 @@ func GetTestDBHost() string {
 	}
 	return host
 }
+
+// ClearDatabase removes all the data from the given database. It's meant only
+// for use in the tests.
+func ClearDatabase(db *Handler) error {
+	_, err := db.DB.Exec("truncate table endentities;")
+	return err
+}

--- a/database/connect.go
+++ b/database/connect.go
@@ -120,9 +120,9 @@ func GetTestDBHost() string {
 	return host
 }
 
-// ClearDatabase removes all the data from the given database. It's meant only
+// DeleteAllIn removes all the data from the given database. It's meant only
 // for use in the tests.
-func ClearDatabase(db *Handler) error {
+func DeleteAllIn(db *Handler) error {
 	_, err := db.DB.Exec("truncate table endentities;")
 	return err
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,7 @@ services:
 
   unit-test:
     container_name: autograph-unit-test
+    image: autograph-app
     build:
       context: .
     environment:
@@ -115,4 +116,7 @@ services:
       - db
     user: "0"
     working_dir: "/app/src/autograph/"
-    command: ["./bin/run_unit_tests.sh"]
+    command:
+      [
+        "./bin/run_unit_tests.sh"
+      ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,6 @@ services:
 
   unit-test:
     container_name: autograph-unit-test
-    image: autograph-app
     build:
       context: .
     environment:
@@ -116,7 +115,4 @@ services:
       - db
     user: "0"
     working_dir: "/app/src/autograph/"
-    command:
-      [
-        "./bin/run_unit_tests.sh"
-      ]
+    command: ["./bin/run_unit_tests.sh"]

--- a/main_test.go
+++ b/main_test.go
@@ -60,7 +60,7 @@ func newTestAutographer(t *testing.T) (*autographer, configuration) {
 			MonitorPollInterval: 10 * time.Second,
 		})
 		if err == nil {
-			db.Exec("truncate table endentities;")
+			database.ClearDatabase(db)
 		}
 		close(ag.exit)
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -60,7 +60,7 @@ func newTestAutographer(t *testing.T) (*autographer, configuration) {
 			MonitorPollInterval: 10 * time.Second,
 		})
 		if err == nil {
-			database.ClearDatabase(db)
+			database.DeleteAllIn(db)
 		}
 		close(ag.exit)
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -25,6 +25,22 @@ func newTestAutographer(t *testing.T) (*autographer, configuration) {
 		log.Fatal(err)
 	}
 	ag := newAutographer(1)
+	// FIXME refactor helper
+	host := database.GetTestDBHost()
+	err = ag.addDB(database.Config{
+		Name:                "autograph",
+		User:                "myautographdbuser",
+		Password:            "myautographdbpassword",
+		Host:                host + ":5432",
+		MonitorPollInterval: 10 * time.Second,
+	})
+	if err != nil {
+		log.Fatalf("newTestAutographer: failed to connect to db: %s", err)
+	}
+	err = database.DeleteAllIn(ag.db)
+	if err != nil {
+		log.Fatalf("newTestAutographer: failed to delete all in db %s", err)
+	}
 	err = ag.addSigners(conf.Signers)
 	if err != nil {
 		log.Fatal(err)

--- a/signer/contentsignaturepki/contentsignature.go
+++ b/signer/contentsignaturepki/contentsignature.go
@@ -83,6 +83,9 @@ func New(conf signer.Configuration) (s *ContentSigner, err error) {
 	s.chainUploadLocation = conf.ChainUploadLocation
 	s.caCert = conf.CaCert
 	s.db = conf.DB
+	if s.db == nil {
+		return nil, fmt.Errorf("contentsignaturepki %q: a database is required by this signer type but none have been configured", s.ID)
+	}
 	s.subdomainOverride = conf.SubdomainOverride
 
 	if conf.Type != Type {

--- a/signer/contentsignaturepki/contentsignature.go
+++ b/signer/contentsignaturepki/contentsignature.go
@@ -84,7 +84,7 @@ func New(conf signer.Configuration) (s *ContentSigner, err error) {
 	s.caCert = conf.CaCert
 	s.db = conf.DB
 	if s.db == nil {
-		return nil, fmt.Errorf("contentsignaturepki %q: a database is required by this signer type but none have been configured", s.ID)
+		return nil, fmt.Errorf("contentsignaturepki %q: a database is required by the contentsignaturepki signer type but none have been configured", s.ID)
 	}
 	s.subdomainOverride = conf.SubdomainOverride
 

--- a/signer/contentsignaturepki/contentsignature_test.go
+++ b/signer/contentsignaturepki/contentsignature_test.go
@@ -357,5 +357,15 @@ func testDBHandler(t *testing.T) *database.Handler {
 	if err != nil {
 		t.Fatalf("failed to connect to test database: %v", err)
 	}
+	_, err = dbHandler.DB.Exec("truncate table endentities;")
+	if err != nil {
+		t.Fatalf("failed to truncate endentities table before running test: %v", err)
+	}
+	t.Cleanup(func() {
+		_, err = dbHandler.DB.Exec("truncate table endentities;")
+		if err != nil {
+			t.Fatalf("failed to truncate endentities table after running test: %v", err)
+		}
+	})
 	return dbHandler
 }

--- a/signer/contentsignaturepki/contentsignature_test.go
+++ b/signer/contentsignaturepki/contentsignature_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mozilla-services/autograph/database"
 	"github.com/mozilla-services/autograph/signer"
 	verifier "github.com/mozilla-services/autograph/verifier/contentsignature"
 )
@@ -125,9 +126,11 @@ mpvOMOT3falDgXh0iOgdIA==
 		},
 	}
 
+	dbHandler := testDBHandler(t)
 	input := []byte("foobarbaz1234abcd")
 	for i, testcase := range testcases {
 		// initialize a signer
+		testcase.cfg.DB = dbHandler
 		s, err := New(testcase.cfg)
 		if err != nil {
 			t.Fatalf("testcase %d signer initialization failed with: %v", i, err)
@@ -242,6 +245,7 @@ func TestNoShortData(t *testing.T) {
 		IssuerPrivKey:       keys.issuerPrivKey,
 		IssuerCert:          keys.issuerCert,
 		CaCert:              keys.caCert,
+		DB:                  testDBHandler(t),
 	}
 	s, err := New(cfg)
 	if err != nil {
@@ -274,6 +278,7 @@ func TestReadRandFailureOnSignHash(t *testing.T) {
 		IssuerPrivKey:       keys.issuerPrivKey,
 		IssuerCert:          keys.issuerCert,
 		CaCert:              keys.caCert,
+		DB:                  testDBHandler(t),
 	}
 	s, err := New(cfg)
 	if err != nil {
@@ -336,4 +341,18 @@ nsbYLErV5grBhN+UxzmY9YwlOl6j6CoBiNkCMQCVBh9UBkWNkUfMUGImrCNDLvlw
 //Vb8kLBsJmLQjZNbXt+ikjYkWGqppp2pVwwgf4=
 -----END CERTIFICATE-----`,
 	}
+}
+
+func testDBHandler(t *testing.T) *database.Handler {
+	host := database.GetTestDBHost()
+	dbHandler, err := database.Connect(database.Config{
+		Name:     "autograph",
+		User:     "myautographdbuser",
+		Password: "myautographdbpassword",
+		Host:     host + ":5432",
+	})
+	if err != nil {
+		t.Fatalf("failed to connect to test database: %v", err)
+	}
+	return dbHandler
 }

--- a/signer/contentsignaturepki/contentsignature_test.go
+++ b/signer/contentsignaturepki/contentsignature_test.go
@@ -19,6 +19,8 @@ import (
 
 func TestSign(t *testing.T) {
 	keys := goodKeys()
+	dbHandler := testDBHandler(t)
+
 	var testcases = []struct {
 		cfg                signer.Configuration
 		expectedCommonName string
@@ -32,6 +34,7 @@ func TestSign(t *testing.T) {
 			IssuerPrivKey:       keys.issuerPrivKey,
 			IssuerCert:          keys.issuerCert,
 			CaCert:              keys.caCert,
+			DB:                  dbHandler,
 		},
 			expectedCommonName: "testsigner0.content-signature.mozilla.org",
 		},
@@ -76,6 +79,7 @@ CCsGAQUFBwMDMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwMDSAAwRQIgIBgf
 KkmH7TerRPn/517v/41o/sF9Hd9iGBilyWtVMggCIQClvRXiMM6DrabvybPGHWTt
 mpvOMOT3falDgXh0iOgdIA==
 -----END CERTIFICATE-----`,
+			DB: dbHandler,
 		},
 			expectedCommonName: "testsigner1.content-signature.mozilla.org",
 		},
@@ -121,16 +125,15 @@ CCsGAQUFBwMDMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwMDSAAwRQIgIBgf
 KkmH7TerRPn/517v/41o/sF9Hd9iGBilyWtVMggCIQClvRXiMM6DrabvybPGHWTt
 mpvOMOT3falDgXh0iOgdIA==
 -----END CERTIFICATE-----`,
+			DB: dbHandler,
 		},
 			expectedCommonName: "anothersigner1.content-signature.mozilla.org",
 		},
 	}
 
-	dbHandler := testDBHandler(t)
 	input := []byte("foobarbaz1234abcd")
 	for i, testcase := range testcases {
 		// initialize a signer
-		testcase.cfg.DB = dbHandler
 		s, err := New(testcase.cfg)
 		if err != nil {
 			t.Fatalf("testcase %d signer initialization failed with: %v", i, err)

--- a/signer/contentsignaturepki/contentsignature_test.go
+++ b/signer/contentsignaturepki/contentsignature_test.go
@@ -139,7 +139,7 @@ mpvOMOT3falDgXh0iOgdIA==
 
 	input := []byte("foobarbaz1234abcd")
 	for i, testcase := range testcases {
-		database.ClearDatabase(dbHandler)
+		database.DeleteAllIn(dbHandler)
 
 		// initialize a signer
 		s, err := New(testcase.cfg)
@@ -462,10 +462,10 @@ func newTestDBHandler(t *testing.T) *database.Handler {
 		t.Fatalf("db.CheckConnection failed when it should not have with error: %s", err)
 	}
 
-	database.ClearDatabase(dbHandler)
+	database.DeleteAllIn(dbHandler)
 
 	t.Cleanup(func() {
-		database.ClearDatabase(dbHandler)
+		database.DeleteAllIn(dbHandler)
 		dbHandler.Close()
 	})
 	return dbHandler

--- a/signer/contentsignaturepki/contentsignature_test.go
+++ b/signer/contentsignaturepki/contentsignature_test.go
@@ -17,8 +17,116 @@ import (
 )
 
 func TestSign(t *testing.T) {
+	keys := goodKeys()
+	var testcases = []struct {
+		cfg                signer.Configuration
+		expectedCommonName string
+	}{
+		{cfg: signer.Configuration{
+			Type:                Type,
+			ID:                  "testsigner0",
+			Mode:                P384ECDSA,
+			X5U:                 "file:///tmp/autograph_unit_tests/chains/",
+			ChainUploadLocation: "file:///tmp/autograph_unit_tests/chains/",
+			IssuerPrivKey:       keys.issuerPrivKey,
+			IssuerCert:          keys.issuerCert,
+			CaCert:              keys.caCert,
+		},
+			expectedCommonName: "testsigner0.content-signature.mozilla.org",
+		},
+		{cfg: signer.Configuration{
+			Type:                Type,
+			ID:                  "testsigner1",
+			Mode:                P256ECDSA,
+			X5U:                 "file:///tmp/autograph_unit_tests/chains/",
+			ChainUploadLocation: "file:///tmp/autograph_unit_tests/chains/",
+			IssuerPrivKey: `
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIEABir6WMfkbG2ZyKKDCij1PlSBldaaJqPQ/9ioWvCM5oAoGCCqGSM49
+AwEHoUQDQgAED0x4GeyH3nxaCVQqPFbRkoBg1BJePxTSg1oaRWIgBbrMYaB/TKpL
+WoBQZFUwn11IFDP5y1B6Tt9U5DxQ3tgt+w==
+-----END EC PRIVATE KEY-----`,
+			IssuerCert: `
+-----BEGIN CERTIFICATE-----
+MIICIDCCAcWgAwIBAgIIFYW+N1jIJvAwCgYIKoZIzj0EAwMwXzELMAkGA1UEBhMC
+VVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQK
+EwdNb3ppbGxhMRkwFwYDVQQDExBjc3Jvb3QxNTUwODU0NzkxMB4XDTE4MTIyMTE2
+NTk1MVoXDTI5MDIyMjE2NTk1MVowYDELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNB
+MRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQKEwdNb3ppbGxhMRowGAYD
+VQQDExFjc2ludGVyMTU1MDg1NDc5MTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IA
+BA9MeBnsh958WglUKjxW0ZKAYNQSXj8U0oNaGkViIAW6zGGgf0yqS1qAUGRVMJ9d
+SBQz+ctQek7fVOQ8UN7YLfujajBoMA4GA1UdDwEB/wQEAwIBhjATBgNVHSUEDDAK
+BggrBgEFBQcDAzAPBgNVHRMBAf8EBTADAQH/MDAGA1UdHgEB/wQmMCSgIjAggh4u
+Y29udGVudC1zaWduYXR1cmUubW96aWxsYS5vcmcwCgYIKoZIzj0EAwMDSQAwRgIh
+AJYQbM1zDA9RkmNwEc4LafBwL98Z+aGy31z80HeC5Y8hAiEA4KEG+ZNinz5yZItW
+NYDcA5Hvd1xXeRQi6SWj6Z2qT7w=
+-----END CERTIFICATE-----`,
+			CaCert: `
+-----BEGIN CERTIFICATE-----
+MIIB7DCCAZKgAwIBAgIIFYW+N1i+RHgwCgYIKoZIzj0EAwMwXzELMAkGA1UEBhMC
+VVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQK
+EwdNb3ppbGxhMRkwFwYDVQQDExBjc3Jvb3QxNTUwODU0NzkxMB4XDTE4MTIyMDE2
+NTk1MVoXDTQ5MDIyMjE2NTk1MVowXzELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNB
+MRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQKEwdNb3ppbGxhMRkwFwYD
+VQQDExBjc3Jvb3QxNTUwODU0NzkxMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE
+SZakSnBD3qkp15bQ+qzcKCn2+OmoOJKVgrSezyrx7IHjtEbCYUz8Zp+HhKg3NXLY
+6ZMjO0zYnq3gTdAzH3amOqM4MDYwDgYDVR0PAQH/BAQDAgGGMBMGA1UdJQQMMAoG
+CCsGAQUFBwMDMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwMDSAAwRQIgIBgf
+KkmH7TerRPn/517v/41o/sF9Hd9iGBilyWtVMggCIQClvRXiMM6DrabvybPGHWTt
+mpvOMOT3falDgXh0iOgdIA==
+-----END CERTIFICATE-----`,
+		},
+			expectedCommonName: "testsigner1.content-signature.mozilla.org",
+		},
+		{cfg: signer.Configuration{
+			Type:                Type,
+			ID:                  "testsigner1",
+			SubdomainOverride:   "anothersigner1",
+			Mode:                P256ECDSA,
+			X5U:                 "file:///tmp/autograph_unit_tests/chains/dedup-path-anothersigner1",
+			ChainUploadLocation: "file:///tmp/autograph_unit_tests/chains/dedup-path-anothersigner1",
+			IssuerPrivKey: `
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIEABir6WMfkbG2ZyKKDCij1PlSBldaaJqPQ/9ioWvCM5oAoGCCqGSM49
+AwEHoUQDQgAED0x4GeyH3nxaCVQqPFbRkoBg1BJePxTSg1oaRWIgBbrMYaB/TKpL
+WoBQZFUwn11IFDP5y1B6Tt9U5DxQ3tgt+w==
+-----END EC PRIVATE KEY-----`,
+			IssuerCert: `
+-----BEGIN CERTIFICATE-----
+MIICIDCCAcWgAwIBAgIIFYW+N1jIJvAwCgYIKoZIzj0EAwMwXzELMAkGA1UEBhMC
+VVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQK
+EwdNb3ppbGxhMRkwFwYDVQQDExBjc3Jvb3QxNTUwODU0NzkxMB4XDTE4MTIyMTE2
+NTk1MVoXDTI5MDIyMjE2NTk1MVowYDELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNB
+MRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQKEwdNb3ppbGxhMRowGAYD
+VQQDExFjc2ludGVyMTU1MDg1NDc5MTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IA
+BA9MeBnsh958WglUKjxW0ZKAYNQSXj8U0oNaGkViIAW6zGGgf0yqS1qAUGRVMJ9d
+SBQz+ctQek7fVOQ8UN7YLfujajBoMA4GA1UdDwEB/wQEAwIBhjATBgNVHSUEDDAK
+BggrBgEFBQcDAzAPBgNVHRMBAf8EBTADAQH/MDAGA1UdHgEB/wQmMCSgIjAggh4u
+Y29udGVudC1zaWduYXR1cmUubW96aWxsYS5vcmcwCgYIKoZIzj0EAwMDSQAwRgIh
+AJYQbM1zDA9RkmNwEc4LafBwL98Z+aGy31z80HeC5Y8hAiEA4KEG+ZNinz5yZItW
+NYDcA5Hvd1xXeRQi6SWj6Z2qT7w=
+-----END CERTIFICATE-----`,
+			CaCert: `
+-----BEGIN CERTIFICATE-----
+MIIB7DCCAZKgAwIBAgIIFYW+N1i+RHgwCgYIKoZIzj0EAwMwXzELMAkGA1UEBhMC
+VVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQK
+EwdNb3ppbGxhMRkwFwYDVQQDExBjc3Jvb3QxNTUwODU0NzkxMB4XDTE4MTIyMDE2
+NTk1MVoXDTQ5MDIyMjE2NTk1MVowXzELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNB
+MRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQKEwdNb3ppbGxhMRkwFwYD
+VQQDExBjc3Jvb3QxNTUwODU0NzkxMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE
+SZakSnBD3qkp15bQ+qzcKCn2+OmoOJKVgrSezyrx7IHjtEbCYUz8Zp+HhKg3NXLY
+6ZMjO0zYnq3gTdAzH3amOqM4MDYwDgYDVR0PAQH/BAQDAgGGMBMGA1UdJQQMMAoG
+CCsGAQUFBwMDMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwMDSAAwRQIgIBgf
+KkmH7TerRPn/517v/41o/sF9Hd9iGBilyWtVMggCIQClvRXiMM6DrabvybPGHWTt
+mpvOMOT3falDgXh0iOgdIA==
+-----END CERTIFICATE-----`,
+		},
+			expectedCommonName: "anothersigner1.content-signature.mozilla.org",
+		},
+	}
+
 	input := []byte("foobarbaz1234abcd")
-	for i, testcase := range PASSINGTESTCASES {
+	for i, testcase := range testcases {
 		// initialize a signer
 		s, err := New(testcase.cfg)
 		if err != nil {
@@ -88,151 +196,8 @@ func TestSign(t *testing.T) {
 		}
 	}
 }
-
-var PASSINGTESTCASES = []struct {
-	cfg                signer.Configuration
-	expectedCommonName string
-}{
-	{cfg: signer.Configuration{
-		Type:                Type,
-		ID:                  "testsigner0",
-		Mode:                P384ECDSA,
-		X5U:                 "file:///tmp/autograph_unit_tests/chains/",
-		ChainUploadLocation: "file:///tmp/autograph_unit_tests/chains/",
-		IssuerPrivKey: `
------BEGIN EC PRIVATE KEY-----
-MIGkAgEBBDBcwxsHPTSHIVY1qLobCqBtnjRe0UZWOro1xtg2oV4rkypbkkgHHnSA
-s8p0PlGIknKgBwYFK4EEACKhZANiAAQMBfcDj4r/9aAXcUsjjun3vCpBSQoskcdi
-iF4bE+AcFmPABh6AnwTZv0sHYPjkovk3R3RfuXlKyoqhuD73VqBhkuK7R6mN2snh
-fRkWmi6SzHWZIXPzFScoCaHnJrFzNjs=
------END EC PRIVATE KEY-----`,
-		IssuerCert: `
------BEGIN CERTIFICATE-----
-MIICXDCCAeKgAwIBAgIIFYW6xg9HrnAwCgYIKoZIzj0EAwMwXzELMAkGA1UEBhMC
-VVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQK
-EwdNb3ppbGxhMRkwFwYDVQQDExBjc3Jvb3QxNTUwODUxMDA2MB4XDTE4MTIyMTE1
-NTY0NloXDTI5MDIyMjE1NTY0NlowYDELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNB
-MRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQKEwdNb3ppbGxhMRowGAYD
-VQQDExFjc2ludGVyMTU1MDg1MTAwNjB2MBAGByqGSM49AgEGBSuBBAAiA2IABAwF
-9wOPiv/1oBdxSyOO6fe8KkFJCiyRx2KIXhsT4BwWY8AGHoCfBNm/Swdg+OSi+TdH
-dF+5eUrKiqG4PvdWoGGS4rtHqY3ayeF9GRaaLpLMdZkhc/MVJygJoecmsXM2O6Nq
-MGgwDgYDVR0PAQH/BAQDAgGGMBMGA1UdJQQMMAoGCCsGAQUFBwMDMA8GA1UdEwEB
-/wQFMAMBAf8wMAYDVR0eAQH/BCYwJKAiMCCCHi5jb250ZW50LXNpZ25hdHVyZS5t
-b3ppbGxhLm9yZzAKBggqhkjOPQQDAwNoADBlAjBss+GLdMdLT2Y/g73OE9x0WyUG
-vqzO7klt20yytmhaYMIPT/zRnWsHZbqEijHMzGsCMQDEoKetuWkyBkzAytS6l+ss
-mYigBlwySY+gTqsjuIrydWlKaOv1GU+PXbwX0cQuaN8=
------END CERTIFICATE-----`,
-		CaCert: `
------BEGIN CERTIFICATE-----
-MIICKTCCAa+gAwIBAgIIFYW6xg2sw4QwCgYIKoZIzj0EAwMwXzELMAkGA1UEBhMC
-VVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQK
-EwdNb3ppbGxhMRkwFwYDVQQDExBjc3Jvb3QxNTUwODUxMDA2MB4XDTE4MTIyMDE1
-NTY0NloXDTQ5MDIyMjE1NTY0NlowXzELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNB
-MRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQKEwdNb3ppbGxhMRkwFwYD
-VQQDExBjc3Jvb3QxNTUwODUxMDA2MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAENrUI
-9GJFild/ZVNwh7885643BhJlqTqZSas8mAUkYRDKv9lXk/r+CpLPclrwz/Po21xn
-5SlibnOTXaOZdMlDcWCCKqNNGRyi1xPHJIfvtF6+CswJnrkthpy6dimqd0Tyozgw
-NjAOBgNVHQ8BAf8EBAMCAYYwEwYDVR0lBAwwCgYIKwYBBQUHAwMwDwYDVR0TAQH/
-BAUwAwEB/zAKBggqhkjOPQQDAwNoADBlAjB3fOCz2SQvxNZ65juSotQNRvXhB4TZ
-nsbYLErV5grBhN+UxzmY9YwlOl6j6CoBiNkCMQCVBh9UBkWNkUfMUGImrCNDLvlw
-//Vb8kLBsJmLQjZNbXt+ikjYkWGqppp2pVwwgf4=
------END CERTIFICATE-----`,
-	},
-		expectedCommonName: "testsigner0.content-signature.mozilla.org",
-	},
-	{cfg: signer.Configuration{
-		Type:                Type,
-		ID:                  "testsigner1",
-		Mode:                P256ECDSA,
-		X5U:                 "file:///tmp/autograph_unit_tests/chains/",
-		ChainUploadLocation: "file:///tmp/autograph_unit_tests/chains/",
-		IssuerPrivKey: `
------BEGIN EC PRIVATE KEY-----
-MHcCAQEEIEABir6WMfkbG2ZyKKDCij1PlSBldaaJqPQ/9ioWvCM5oAoGCCqGSM49
-AwEHoUQDQgAED0x4GeyH3nxaCVQqPFbRkoBg1BJePxTSg1oaRWIgBbrMYaB/TKpL
-WoBQZFUwn11IFDP5y1B6Tt9U5DxQ3tgt+w==
------END EC PRIVATE KEY-----`,
-		IssuerCert: `
------BEGIN CERTIFICATE-----
-MIICIDCCAcWgAwIBAgIIFYW+N1jIJvAwCgYIKoZIzj0EAwMwXzELMAkGA1UEBhMC
-VVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQK
-EwdNb3ppbGxhMRkwFwYDVQQDExBjc3Jvb3QxNTUwODU0NzkxMB4XDTE4MTIyMTE2
-NTk1MVoXDTI5MDIyMjE2NTk1MVowYDELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNB
-MRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQKEwdNb3ppbGxhMRowGAYD
-VQQDExFjc2ludGVyMTU1MDg1NDc5MTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IA
-BA9MeBnsh958WglUKjxW0ZKAYNQSXj8U0oNaGkViIAW6zGGgf0yqS1qAUGRVMJ9d
-SBQz+ctQek7fVOQ8UN7YLfujajBoMA4GA1UdDwEB/wQEAwIBhjATBgNVHSUEDDAK
-BggrBgEFBQcDAzAPBgNVHRMBAf8EBTADAQH/MDAGA1UdHgEB/wQmMCSgIjAggh4u
-Y29udGVudC1zaWduYXR1cmUubW96aWxsYS5vcmcwCgYIKoZIzj0EAwMDSQAwRgIh
-AJYQbM1zDA9RkmNwEc4LafBwL98Z+aGy31z80HeC5Y8hAiEA4KEG+ZNinz5yZItW
-NYDcA5Hvd1xXeRQi6SWj6Z2qT7w=
------END CERTIFICATE-----`,
-		CaCert: `
------BEGIN CERTIFICATE-----
-MIIB7DCCAZKgAwIBAgIIFYW+N1i+RHgwCgYIKoZIzj0EAwMwXzELMAkGA1UEBhMC
-VVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQK
-EwdNb3ppbGxhMRkwFwYDVQQDExBjc3Jvb3QxNTUwODU0NzkxMB4XDTE4MTIyMDE2
-NTk1MVoXDTQ5MDIyMjE2NTk1MVowXzELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNB
-MRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQKEwdNb3ppbGxhMRkwFwYD
-VQQDExBjc3Jvb3QxNTUwODU0NzkxMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE
-SZakSnBD3qkp15bQ+qzcKCn2+OmoOJKVgrSezyrx7IHjtEbCYUz8Zp+HhKg3NXLY
-6ZMjO0zYnq3gTdAzH3amOqM4MDYwDgYDVR0PAQH/BAQDAgGGMBMGA1UdJQQMMAoG
-CCsGAQUFBwMDMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwMDSAAwRQIgIBgf
-KkmH7TerRPn/517v/41o/sF9Hd9iGBilyWtVMggCIQClvRXiMM6DrabvybPGHWTt
-mpvOMOT3falDgXh0iOgdIA==
------END CERTIFICATE-----`,
-	},
-		expectedCommonName: "testsigner1.content-signature.mozilla.org",
-	},
-	{cfg: signer.Configuration{
-		Type:                Type,
-		ID:                  "testsigner1",
-		SubdomainOverride:   "anothersigner1",
-		Mode:                P256ECDSA,
-		X5U:                 "file:///tmp/autograph_unit_tests/chains/dedup-path-anothersigner1",
-		ChainUploadLocation: "file:///tmp/autograph_unit_tests/chains/dedup-path-anothersigner1",
-		IssuerPrivKey: `
------BEGIN EC PRIVATE KEY-----
-MHcCAQEEIEABir6WMfkbG2ZyKKDCij1PlSBldaaJqPQ/9ioWvCM5oAoGCCqGSM49
-AwEHoUQDQgAED0x4GeyH3nxaCVQqPFbRkoBg1BJePxTSg1oaRWIgBbrMYaB/TKpL
-WoBQZFUwn11IFDP5y1B6Tt9U5DxQ3tgt+w==
------END EC PRIVATE KEY-----`,
-		IssuerCert: `
------BEGIN CERTIFICATE-----
-MIICIDCCAcWgAwIBAgIIFYW+N1jIJvAwCgYIKoZIzj0EAwMwXzELMAkGA1UEBhMC
-VVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQK
-EwdNb3ppbGxhMRkwFwYDVQQDExBjc3Jvb3QxNTUwODU0NzkxMB4XDTE4MTIyMTE2
-NTk1MVoXDTI5MDIyMjE2NTk1MVowYDELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNB
-MRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQKEwdNb3ppbGxhMRowGAYD
-VQQDExFjc2ludGVyMTU1MDg1NDc5MTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IA
-BA9MeBnsh958WglUKjxW0ZKAYNQSXj8U0oNaGkViIAW6zGGgf0yqS1qAUGRVMJ9d
-SBQz+ctQek7fVOQ8UN7YLfujajBoMA4GA1UdDwEB/wQEAwIBhjATBgNVHSUEDDAK
-BggrBgEFBQcDAzAPBgNVHRMBAf8EBTADAQH/MDAGA1UdHgEB/wQmMCSgIjAggh4u
-Y29udGVudC1zaWduYXR1cmUubW96aWxsYS5vcmcwCgYIKoZIzj0EAwMDSQAwRgIh
-AJYQbM1zDA9RkmNwEc4LafBwL98Z+aGy31z80HeC5Y8hAiEA4KEG+ZNinz5yZItW
-NYDcA5Hvd1xXeRQi6SWj6Z2qT7w=
------END CERTIFICATE-----`,
-		CaCert: `
------BEGIN CERTIFICATE-----
-MIIB7DCCAZKgAwIBAgIIFYW+N1i+RHgwCgYIKoZIzj0EAwMwXzELMAkGA1UEBhMC
-VVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQK
-EwdNb3ppbGxhMRkwFwYDVQQDExBjc3Jvb3QxNTUwODU0NzkxMB4XDTE4MTIyMDE2
-NTk1MVoXDTQ5MDIyMjE2NTk1MVowXzELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNB
-MRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQKEwdNb3ppbGxhMRkwFwYD
-VQQDExBjc3Jvb3QxNTUwODU0NzkxMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE
-SZakSnBD3qkp15bQ+qzcKCn2+OmoOJKVgrSezyrx7IHjtEbCYUz8Zp+HhKg3NXLY
-6ZMjO0zYnq3gTdAzH3amOqM4MDYwDgYDVR0PAQH/BAQDAgGGMBMGA1UdJQQMMAoG
-CCsGAQUFBwMDMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwMDSAAwRQIgIBgf
-KkmH7TerRPn/517v/41o/sF9Hd9iGBilyWtVMggCIQClvRXiMM6DrabvybPGHWTt
-mpvOMOT3falDgXh0iOgdIA==
------END CERTIFICATE-----`,
-	},
-		expectedCommonName: "anothersigner1.content-signature.mozilla.org",
-	},
-}
-
 func TestNewFailure(t *testing.T) {
-	TESTCASES := []struct {
+	testcases := []struct {
 		err string
 		cfg signer.Configuration
 	}{
@@ -255,7 +220,7 @@ w2hKSJpdD11n9tJEQ7MieRzrqr58rqm9tymUH0rKIg==
 -----END RSA PRIVATE KEY-----`,
 		}},
 	}
-	for _, testcase := range TESTCASES {
+	for _, testcase := range testcases {
 		_, err := New(testcase.cfg)
 		if !strings.Contains(err.Error(), testcase.err) {
 			t.Fatalf("expected to fail with '%s' but failed with '%s' instead", testcase.err, err)
@@ -267,7 +232,18 @@ w2hKSJpdD11n9tJEQ7MieRzrqr58rqm9tymUH0rKIg==
 }
 
 func TestNoShortData(t *testing.T) {
-	s, err := New(PASSINGTESTCASES[0].cfg)
+	keys := goodKeys()
+	cfg := signer.Configuration{
+		Type:                Type,
+		ID:                  "testsigner0",
+		Mode:                P384ECDSA,
+		X5U:                 "file:///tmp/autograph_unit_tests/chains/",
+		ChainUploadLocation: "file:///tmp/autograph_unit_tests/chains/",
+		IssuerPrivKey:       keys.issuerPrivKey,
+		IssuerCert:          keys.issuerCert,
+		CaCert:              keys.caCert,
+	}
+	s, err := New(cfg)
 	if err != nil {
 		t.Fatalf("signer initialization failed with: %v", err)
 	}
@@ -288,12 +264,76 @@ func (e *ErrorReader) Read(p []byte) (n int, err error) {
 
 func TestReadRandFailureOnSignHash(t *testing.T) {
 	input := []byte("foobarbaz1234abcd")
-	testcase := PASSINGTESTCASES[0]
-	s, _ := New(testcase.cfg)
+	keys := goodKeys()
+	cfg := signer.Configuration{
+		Type:                Type,
+		ID:                  "testsigner0",
+		Mode:                P384ECDSA,
+		X5U:                 "file:///tmp/autograph_unit_tests/chains/",
+		ChainUploadLocation: "file:///tmp/autograph_unit_tests/chains/",
+		IssuerPrivKey:       keys.issuerPrivKey,
+		IssuerCert:          keys.issuerCert,
+		CaCert:              keys.caCert,
+	}
+	s, err := New(cfg)
+	if err != nil {
+		t.Fatalf("signer initialization failed with: %v", err)
+	}
 	// TODO: Add a configurable rand.Reader
 	s.rand = &ErrorReader{}
-	_, err := s.SignData(input, nil)
+	_, err = s.SignData(input, nil)
 	if err == nil {
 		t.Fatal("Should have failed to sign data with error in the SignHash")
+	}
+}
+
+type signerKeys struct {
+	issuerPrivKey string
+	issuerCert    string
+	caCert        string
+}
+
+// goodKeys is a lil helper for providing a set of ecdsa keys that will work for
+// testing.
+func goodKeys() signerKeys {
+	return signerKeys{
+		issuerPrivKey: `
+-----BEGIN EC PRIVATE KEY-----
+MIGkAgEBBDBcwxsHPTSHIVY1qLobCqBtnjRe0UZWOro1xtg2oV4rkypbkkgHHnSA
+s8p0PlGIknKgBwYFK4EEACKhZANiAAQMBfcDj4r/9aAXcUsjjun3vCpBSQoskcdi
+iF4bE+AcFmPABh6AnwTZv0sHYPjkovk3R3RfuXlKyoqhuD73VqBhkuK7R6mN2snh
+fRkWmi6SzHWZIXPzFScoCaHnJrFzNjs=
+-----END EC PRIVATE KEY-----`,
+		issuerCert: `
+-----BEGIN CERTIFICATE-----
+MIICXDCCAeKgAwIBAgIIFYW6xg9HrnAwCgYIKoZIzj0EAwMwXzELMAkGA1UEBhMC
+VVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQK
+EwdNb3ppbGxhMRkwFwYDVQQDExBjc3Jvb3QxNTUwODUxMDA2MB4XDTE4MTIyMTE1
+NTY0NloXDTI5MDIyMjE1NTY0NlowYDELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNB
+MRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQKEwdNb3ppbGxhMRowGAYD
+VQQDExFjc2ludGVyMTU1MDg1MTAwNjB2MBAGByqGSM49AgEGBSuBBAAiA2IABAwF
+9wOPiv/1oBdxSyOO6fe8KkFJCiyRx2KIXhsT4BwWY8AGHoCfBNm/Swdg+OSi+TdH
+dF+5eUrKiqG4PvdWoGGS4rtHqY3ayeF9GRaaLpLMdZkhc/MVJygJoecmsXM2O6Nq
+MGgwDgYDVR0PAQH/BAQDAgGGMBMGA1UdJQQMMAoGCCsGAQUFBwMDMA8GA1UdEwEB
+/wQFMAMBAf8wMAYDVR0eAQH/BCYwJKAiMCCCHi5jb250ZW50LXNpZ25hdHVyZS5t
+b3ppbGxhLm9yZzAKBggqhkjOPQQDAwNoADBlAjBss+GLdMdLT2Y/g73OE9x0WyUG
+vqzO7klt20yytmhaYMIPT/zRnWsHZbqEijHMzGsCMQDEoKetuWkyBkzAytS6l+ss
+mYigBlwySY+gTqsjuIrydWlKaOv1GU+PXbwX0cQuaN8=
+-----END CERTIFICATE-----`,
+		caCert: `
+-----BEGIN CERTIFICATE-----
+MIICKTCCAa+gAwIBAgIIFYW6xg2sw4QwCgYIKoZIzj0EAwMwXzELMAkGA1UEBhMC
+VVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQK
+EwdNb3ppbGxhMRkwFwYDVQQDExBjc3Jvb3QxNTUwODUxMDA2MB4XDTE4MTIyMDE1
+NTY0NloXDTQ5MDIyMjE1NTY0NlowXzELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNB
+MRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRAwDgYDVQQKEwdNb3ppbGxhMRkwFwYD
+VQQDExBjc3Jvb3QxNTUwODUxMDA2MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAENrUI
+9GJFild/ZVNwh7885643BhJlqTqZSas8mAUkYRDKv9lXk/r+CpLPclrwz/Po21xn
+5SlibnOTXaOZdMlDcWCCKqNNGRyi1xPHJIfvtF6+CswJnrkthpy6dimqd0Tyozgw
+NjAOBgNVHQ8BAf8EBAMCAYYwEwYDVR0lBAwwCgYIKwYBBQUHAwMwDwYDVR0TAQH/
+BAUwAwEB/zAKBggqhkjOPQQDAwNoADBlAjB3fOCz2SQvxNZ65juSotQNRvXhB4TZ
+nsbYLErV5grBhN+UxzmY9YwlOl6j6CoBiNkCMQCVBh9UBkWNkUfMUGImrCNDLvlw
+//Vb8kLBsJmLQjZNbXt+ikjYkWGqppp2pVwwgf4=
+-----END CERTIFICATE-----`,
 	}
 }


### PR DESCRIPTION
- **require a database in contentsignaturepki**
- **refactor tests in contentsignaturepki**
- **pass in test handler but now hsm errors happen**
- **more testhandler refactor**
- **add truncates to contentsignaturepki**
- **always rebuild docker image for unit tests**
- **k**
- **almost done**
- **add ClearDatabase and a new test to make sure i didnt break the hsm integration**
- **rename**
