### PR TITLE
add docker to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,13 @@ updates:
         patterns:
           - "github.com/aws/aws-sdk-go-v2/*"
           - "github.com/aws/aws-sdk-go-v2"
+- package-ecosystem: "docker"
+  directories:
+    - "/"
+    - "database"
+    - "tools/autograph-monitor"
+    - "tools/softhsm"
+    - "tools/config-sanitizer"
+  schedule:
+    interval: "weekly"
+    time: "10:00" # UTC


### PR DESCRIPTION
This keeps our Dockerfiles up to date along with everything else.

It won't be perfect (swapping from bookworm to trixie will need a manual
bump), but it gets the basics done.
