### PR TITLE
count signer requests with some useful tags

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -148,6 +148,7 @@ func (a *autographer) handleSignature(w http.ResponseWriter, r *http.Request) {
 		httpError(w, r, http.StatusBadRequest, "failed to parse request body: %v", err)
 		return
 	}
+
 	for i, sigreq := range sigreqs {
 		if r.URL.RequestURI() == "/sign/files" {
 			if sigreq.Input != "" {
@@ -215,6 +216,8 @@ func (a *autographer) handleSignature(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		requestedSignerConfig := requestedSigner.Config()
+		a.stats.Incr("signer.requests", []string{"keyid:" + requestedSignerConfig.ID, "user:" + userid, "request_id:" + rid, usedDefaultSignerTag(sigreq)}, 1.0)
+
 		sigresps[i] = formats.SignatureResponse{
 			Ref:        id(),
 			Type:       requestedSignerConfig.Type,
@@ -512,4 +515,15 @@ func (a *autographer) handleGetAuthKeyIDs(w http.ResponseWriter, r *http.Request
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	w.Write(signerIDsJSON)
+}
+
+// usedDefaultSignerTag returns a statds tag indicating whether the default
+// signer for an authorization was used.
+func usedDefaultSignerTag(sigreq formats.SignatureRequest) string {
+	// TODO(AUT-206): remove this when we've migrate everyone off of the default
+	// keyid
+	if sigreq.KeyID == "" {
+		return "used_default_signer:true"
+	}
+	return "used_default_signer:false"
 }

--- a/handlers.go
+++ b/handlers.go
@@ -216,7 +216,7 @@ func (a *autographer) handleSignature(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		requestedSignerConfig := requestedSigner.Config()
-		a.stats.Incr("signer.requests", []string{"keyid:" + requestedSignerConfig.ID, "user:" + userid, "request_id:" + rid, usedDefaultSignerTag(sigreq)}, 1.0)
+		a.stats.Incr("signer.requests", []string{"keyid:" + requestedSignerConfig.ID, "user:" + userid, usedDefaultSignerTag(sigreq)}, 1.0)
 
 		sigresps[i] = formats.SignatureResponse{
 			Ref:        id(),


### PR DESCRIPTION
This patch records what signers are used, and by whom. This is useful
for a variety of reasons including seeing patterns of problems in
roughly real time and tracking usage of signers.

It also includes whether the user used their "default" signer id
(`keyid` in the API itself). We're trying to move folks away from using
the default signer id and requiring `keyid` to be set. We want that
because we want our clients to be more easily moved from one signer to
another as our keys and algorithm requirements change. (Folks had to
change their code during the add-ons and content-signature root
certificate succession instead of just changing some configs because
they relied on the default signer id.)

Updates AUT-206
