### PR TITLE
bump Go min version to 1.23.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mozilla-services/autograph
 
-go 1.22.1
+go 1.23.4
 
 require (
 	github.com/DataDog/datadog-go v4.8.3+incompatible


### PR DESCRIPTION
This bumps the required Go version to 1.23.4 to take advantage of new
APIs and language features. See https://golang.org/doc/go1.23 for more
information.

Along the way, we use some of the new APIs to simplify some code in
makecsr.
