### PR TITLE
Removing cleanup step and sleep from endentities testing.

### DIFF
--- a/database/queries_test.go
+++ b/database/queries_test.go
@@ -57,10 +57,6 @@ func TestConcurrentEndEntityOperations(t *testing.T) {
 func waitAndMakeEE(j int, db *Handler, wg *sync.WaitGroup, t *testing.T, signerID string) string {
 	defer wg.Done()
 	t.Logf("TestConcurrentEndEntityOperations: starting routine %d", j)
-	// sleep until the next 10s, then start
-	nextTime := time.Now().Truncate(10 * time.Second)
-	nextTime = nextTime.Add(10 * time.Second)
-	time.Sleep(time.Until(nextTime))
 
 	label, _, err := db.GetLabelOfLatestEE(signerID, 15*time.Second)
 	switch err {

--- a/main_test.go
+++ b/main_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mozilla-services/autograph/database"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -51,17 +50,6 @@ func newTestAutographer(t *testing.T) (*autographer, configuration) {
 	}
 
 	t.Cleanup(func() {
-		host := database.GetTestDBHost()
-		db, err := database.Connect(database.Config{
-			Name:                "autograph",
-			User:                "myautographdbuser",
-			Password:            "myautographdbpassword",
-			Host:                host + ":5432",
-			MonitorPollInterval: 10 * time.Second,
-		})
-		if err == nil {
-			db.Exec("truncate table endentities;")
-		}
 		close(ag.exit)
 	})
 


### PR DESCRIPTION
[AUT-371](https://mozilla-hub.atlassian.net/browse/AUT-371)

The test cleanup process is truncating the `endentities` table while tests are still running, causing this test to be flaky.

This PR:

1. Removes the `endentities` truncate post-test step as there is only one test hitting that table but other tests are finishing in parallel and truncating the table for us.
2. Removes a 10 second delay at the start of `TestConcurrentEndEntityOperations` that doesn't do anything for us.

Created [AUT-376](https://mozilla-hub.atlassian.net/browse/AUT-376) as a follow-up ticket.


[AUT-371]: https://mozilla-hub.atlassian.net/browse/AUT-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AUT-376]: https://mozilla-hub.atlassian.net/browse/AUT-376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ