### PR TITLE
monitor: remove the unneeded conf.env field

### DIFF
--- a/tools/autograph-monitor/monitor.go
+++ b/tools/autograph-monitor/monitor.go
@@ -32,7 +32,6 @@ type configuration struct {
 	origAutographURL string
 	requestURL       string
 	monitoringKey    string
-	env              string
 	rootHashes       []string
 	truststore       *x509.CertPool
 
@@ -68,9 +67,8 @@ func main() {
 	// configure monitor to check responses against Fx stage or
 	// prod or autograph dev code signing PKI roots and CA root
 	// certs defined in constants.go
-	conf.env = os.Getenv("AUTOGRAPH_ENV")
 	var rootErr, depErr error
-	switch conf.env {
+	switch strings.TrimSpace(os.Getenv("AUTOGRAPH_ENV")) {
 	case "dev":
 		conf.truststore, conf.rootHashes, rootErr = loadCertsToTruststore(firefoxPkiDevRoots)
 	case "stage":


### PR DESCRIPTION
The `configuration.env` field is immediately used and never referenced
again. Remove it.

Along the way, strip spaces out to be gentler to the next maintainer.
