### PR TITLE
add prom-only test counter and statsd-only label

### DIFF
--- a/main.go
+++ b/main.go
@@ -252,8 +252,9 @@ func run(conf configuration, listen string, debug bool) {
 		router.PathPrefix(prefix).Handler(http.StripPrefix(prefix, http.FileServer(http.Dir(parsedURL.Path))))
 	}
 
-	ag.stats.Incr(foobarTestCounterName, nil, 1)
+	ag.stats.Incr(foobarTestCounterName, []string{"statsd:yes"}, 1)
 	foobarTestCounter.Inc()
+	promOnlyFoobarTestCounterName.Inc()
 
 	if conf.DebugServer.Listen != "" {
 		log.Infof("starting debug server on %s", conf.DebugServer.Listen)

--- a/stats.go
+++ b/stats.go
@@ -19,6 +19,10 @@ var (
 		Name: foobarTestCounterName,
 		Help: "A counter used for testing how prometheus and statsd metrics differ",
 	})
+	promOnlyFoobarTestCounterName = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "prom_only_foobar_test",
+		Help: "A counter used for testing how prometheus and statsd metrics differ",
+	})
 )
 
 func loadStatsd(conf configuration) (*statsd.Client, error) {


### PR DESCRIPTION
Just making sure we're right about how the direct prometheus monitoring
isn't running.

Updates AUT-393
