### PR TITLE
add direct-to-prometheus metric for signer requests

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -23,6 +23,11 @@ var (
 		Name: "prom_only_foobar_test",
 		Help: "A counter used for testing how prometheus and statsd metrics differ",
 	})
+
+	signerRequestsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "signer_requests",
+		Help: "A counter for how many authenticated and authorized requests are made to a given signer",
+	}, []string{"keyid", "user", "used_default_signer"})
 )
 
 func loadStatsd(conf configuration) (*statsd.Client, error) {


### PR DESCRIPTION
We could have misunderstood what the problem is by looking at a metric
that only changed before the first scrape.

Updates AUT-393
Updates AUT-199
