### PR TITLE
delay test metrics by some minutes

### DIFF
--- a/main.go
+++ b/main.go
@@ -252,9 +252,12 @@ func run(conf configuration, listen string, debug bool) {
 		router.PathPrefix(prefix).Handler(http.StripPrefix(prefix, http.FileServer(http.Dir(parsedURL.Path))))
 	}
 
-	ag.stats.Incr(foobarTestCounterName, []string{"statsd:yes"}, 1)
-	foobarTestCounter.Inc()
-	promOnlyFoobarTestCounterName.Inc()
+	go func() {
+		time.Sleep(5 * time.Minute)
+		ag.stats.Incr(foobarTestCounterName, []string{"statsd:yes"}, 1)
+		foobarTestCounter.Inc()
+		promOnlyFoobarTestCounterName.Inc()
+	}()
 
 	if conf.DebugServer.Listen != "" {
 		log.Infof("starting debug server on %s", conf.DebugServer.Listen)


### PR DESCRIPTION
This also provides evidence for the hypothesis that we're just
incrementing before the first scrape, causing the confusion.

Hopefully, by 5 minutes, the prometheus collector is collecting on
healthy pods.

Updates AUT-393
Updates AUT-199
