### PR TITLE
add prometheus metrics for our http handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -221,14 +221,14 @@ func run(conf configuration, listen string, debug bool) {
 	stats := ag.stats
 
 	router := mux.NewRouter().StrictSlash(true)
-	router.HandleFunc("/__heartbeat__", statsMiddleware(ag.handleHeartbeat, "http.nonapi.heartbeat", stats)).Methods("GET")
-	router.HandleFunc("/__lbheartbeat__", statsMiddleware(handleLBHeartbeat, "http.nonapi.lbheartbeat", stats)).Methods("GET")
-	router.HandleFunc("/__version__", statsMiddleware(handleVersion, "http.nonapi.version", stats)).Methods("GET")
-	router.HandleFunc("/__monitor__", statsMiddleware(monitor.handleMonitor, "http.nonapi.monitor", stats)).Methods("GET")
-	router.HandleFunc("/sign/files", apiStatsMiddleware(ag.handleSignature, "http.api.sign/files", stats)).Methods("POST")
-	router.HandleFunc("/sign/file", apiStatsMiddleware(ag.handleSignature, "http.api.sign/file", stats)).Methods("POST")
-	router.HandleFunc("/sign/data", apiStatsMiddleware(ag.handleSignature, "http.api.sign/data", stats)).Methods("POST")
-	router.HandleFunc("/sign/hash", apiStatsMiddleware(ag.handleSignature, "http.api.sign/hash", stats)).Methods("POST")
+	router.HandleFunc("/__heartbeat__", nonAPIstatsMiddleware(ag.handleHeartbeat, "heartbeat", stats)).Methods("GET")
+	router.HandleFunc("/__lbheartbeat__", nonAPIstatsMiddleware(handleLBHeartbeat, "lbheartbeat", stats)).Methods("GET")
+	router.HandleFunc("/__version__", nonAPIstatsMiddleware(handleVersion, "version", stats)).Methods("GET")
+	router.HandleFunc("/__monitor__", nonAPIstatsMiddleware(monitor.handleMonitor, "monitor", stats)).Methods("GET")
+	router.HandleFunc("/sign/files", apiStatsMiddleware(ag.handleSignature, "sign/files", stats)).Methods("POST")
+	router.HandleFunc("/sign/file", apiStatsMiddleware(ag.handleSignature, "sign/file", stats)).Methods("POST")
+	router.HandleFunc("/sign/data", apiStatsMiddleware(ag.handleSignature, "sign/data", stats)).Methods("POST")
+	router.HandleFunc("/sign/hash", apiStatsMiddleware(ag.handleSignature, "sign/hash", stats)).Methods("POST")
 	router.HandleFunc("/auths/{auth_id:[a-zA-Z0-9-_]{1,255}}/keyids", apiStatsMiddleware(ag.handleGetAuthKeyIDs, "http.api.getauthkeyids", stats)).Methods("GET")
 	if os.Getenv("AUTOGRAPH_PROFILE") == "1" {
 		err = setRuntimeConfig()

--- a/stats_test.go
+++ b/stats_test.go
@@ -67,3 +67,60 @@ func TestWrappingStatsResponseWriteWritesAllMetrics(t *testing.T) {
 		t.Fatalf("expected status code %d, got %d", http.StatusInternalServerError, recorder.Code)
 	}
 }
+
+func TestPromResponseWriterWritesResponseMetricOnce(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStats := mockstatsd.NewMockClientInterface(ctrl)
+	mockStats.EXPECT().Incr("myhandler.response.status.4xx", []string(nil), 1.0).Times(1)
+	mockStats.EXPECT().Incr("myhandler.response.success", []string(nil), 1.0).Times(1)
+	mockStats.EXPECT().Incr("myhandler.response.status.400", []string(nil), 1.0).Times(1)
+
+	recorder := httptest.NewRecorder()
+	statsWriter := newStatsdWriter(recorder, "myhandler", mockStats)
+	statsWriter.WriteHeader(http.StatusBadRequest)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected status code %d, got %d", http.StatusBadRequest, recorder.Code)
+	}
+
+	statsWriter.WriteHeader(http.StatusCreated)
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("tried to write to the headers again: Expected status code %d, got %d", http.StatusBadRequest, recorder.Code)
+	}
+}
+
+func TestPromResponseWriterWritesToHeaderOnWrite(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStats := mockstatsd.NewMockClientInterface(ctrl)
+	mockStats.EXPECT().Incr("myhandler.response.status.2xx", []string(nil), 1.0).Times(1)
+	mockStats.EXPECT().Incr("myhandler.response.success", []string(nil), 1.0).Times(1)
+	mockStats.EXPECT().Incr("myhandler.response.status.200", []string(nil), 1.0).Times(1)
+
+	recorder := httptest.NewRecorder()
+	statsWriter := newStatsdWriter(recorder, "myhandler", mockStats)
+	statsWriter.Write([]byte("hello"))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status code %d, got %d", http.StatusOK, recorder.Code)
+	}
+}
+
+func TestWrappingPromResponseWriteWritesAllMetrics(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockStats := mockstatsd.NewMockClientInterface(ctrl)
+	mockStats.EXPECT().Incr("inner.response.status.5xx", []string(nil), 1.0).Times(1)
+	mockStats.EXPECT().Incr("inner.response.status.500", []string(nil), 1.0).Times(1)
+	mockStats.EXPECT().Incr("wrapper.response.status.5xx", []string(nil), 1.0).Times(1)
+	mockStats.EXPECT().Incr("wrapper.response.status.500", []string(nil), 1.0).Times(1)
+
+	recorder := httptest.NewRecorder()
+	inner := newStatsdWriter(recorder, "inner", mockStats)
+	wrapper := newStatsdWriter(inner, "wrapper", mockStats)
+
+	wrapper.WriteHeader(http.StatusInternalServerError)
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status code %d, got %d", http.StatusInternalServerError, recorder.Code)
+	}
+}


### PR DESCRIPTION
We're migrating from statsd to prometheus and this is one step in it.
This also gives us the chance to correct how we export our API metrics
from having them rolled up by name to have them rolled up by label, as
promql (used by yardstick and Google Metrics Explorer) and prometheus
wants.

We also give up having the success rate's denominator be based on the
requests that are in flight and move to using only the ones returned and
then use the loadbalancer's view of the success rate plus the in-flight
requests to detect requests that are stuck.

(We also need to set up some more request timeouts, but that's not this
patch.)

Updates AUT-199
