### PR TITLE
correct signer_requests prometheus metric

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -24,7 +24,7 @@ var (
 		Help: "A counter used for testing how prometheus and statsd metrics differ",
 	})
 
-	signerRequestsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+	signerRequestsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "signer_requests",
 		Help: "A counter for how many authenticated and authorized requests are made to a given signer",
 	}, []string{"keyid", "user", "used_default_signer"})


### PR DESCRIPTION
Forgot to use `promauto` to automatically register the metric with the
default prometheus registry (`prometheus.DefaultRegistry`).

Without this or a call to `prometheus.Registry.Register` somewhere, the
metric doesn't actually get emitted.

Updates AUT-199
Updates AUT-393
