### PR TITLE
AUT-199 - Adding quantile objectives to signer request timing metric.

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -28,6 +28,11 @@ var (
 		Name:      "signer_request_timing",
 		Namespace: statsNamespace,
 		Help:      "A summary vector for request timing",
+		Objectives: map[float64]float64{ // the quantiles we want to track
+			0.5:  0.05,
+			0.95: 0.01,
+			0.99: 0.001,
+		},
 	}, []string{"step"})
 
 	responseStatusCounter = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
[AUT-199](https://mozilla-hub.atlassian.net/browse/AUT-199)
statsd used to emit raw metrics for timing. But prometheus per-aggregates these and by default only produces `sum` and `count` metrics. This will only give us total timing per step and an average. Specifying the quantiles we want to report and track against. 

We really only care about .99 right now. But specifying .5 and .95 so we can analyze data later if needed.

[AUT-199]: https://mozilla-hub.atlassian.net/browse/AUT-199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ