### PR TITLE
Use gauge metrics on requests and response

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -221,6 +221,12 @@ func (a *autographer) handleSignature(w http.ResponseWriter, r *http.Request) {
 			// TODO(AUT-206): remove this when we've migrate everyone off of the default keyid
 			"used_default_signer": strconv.FormatBool(sigreq.KeyID == ""),
 		}).Inc()
+		signerRequestsGauge.With(prometheus.Labels{
+			"keyid": requestedSignerConfig.ID,
+			"user":  userid,
+			// TODO(AUT-206): remove this when we've migrate everyone off of the default keyid
+			"used_default_signer": strconv.FormatBool(sigreq.KeyID == ""),
+		}).Inc()
 
 		sigresps[i] = formats.SignatureResponse{
 			Ref:        id(),

--- a/stats.go
+++ b/stats.go
@@ -18,8 +18,20 @@ var (
 		Help:      "A counter for how many requests are made to a given handler",
 	}, []string{"handler"})
 
+	requestGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name:      "request_gauge",
+		Namespace: statsNamespace,
+		Help:      "A counter for how many requests are made to a given handler",
+	}, []string{"handler"})
+
 	signerRequestsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:      "signer_requests",
+		Namespace: statsNamespace,
+		Help:      "A counter for how many authenticated and authorized requests are made to a given signer",
+	}, []string{"keyid", "user", "used_default_signer"})
+
+	signerRequestsGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name:      "signer_requests_gauge",
 		Namespace: statsNamespace,
 		Help:      "A counter for how many authenticated and authorized requests are made to a given signer",
 	}, []string{"keyid", "user", "used_default_signer"})
@@ -41,8 +53,20 @@ var (
 		Help:      "A counter for response status codes for a given handler",
 	}, []string{"handler", "statusCode"})
 
+	responseStatusGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name:      "response_status_gauge",
+		Namespace: statsNamespace,
+		Help:      "A counter for response status codes for a given handler",
+	}, []string{"handler", "statusCode"})
+
 	responseSuccessCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:      "response_success",
+		Namespace: statsNamespace,
+		Help:      "A counter for succesful vs failed response status codes",
+	}, []string{"handler", "status"})
+
+	responseSuccessGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name:      "response_success_gauge",
 		Namespace: statsNamespace,
 		Help:      "A counter for succesful vs failed response status codes",
 	}, []string{"handler", "status"})
@@ -77,9 +101,17 @@ func (w *statsWriter) WriteHeader(statusCode int) {
 			"handler":    w.handlerName,
 			"statusCode": fmt.Sprintf("%d", statusCode),
 		}).Inc()
+		responseStatusGauge.With(prometheus.Labels{
+			"handler":    w.handlerName,
+			"statusCode": fmt.Sprintf("%d", statusCode),
+		}).Inc()
 
 		if statusCode >= 200 && statusCode < 300 {
 			responseSuccessCounter.With(prometheus.Labels{
+				"handler": w.handlerName,
+				"status":  "success",
+			}).Inc()
+			responseSuccessGauge.With(prometheus.Labels{
 				"handler": w.handlerName,
 				"status":  "success",
 			}).Inc()
@@ -88,8 +120,16 @@ func (w *statsWriter) WriteHeader(statusCode int) {
 				"handler": w.handlerName,
 				"status":  "client_failure",
 			}).Inc()
+			responseSuccessGauge.With(prometheus.Labels{
+				"handler": w.handlerName,
+				"status":  "client_failure",
+			}).Inc()
 		} else {
 			responseSuccessCounter.With(prometheus.Labels{
+				"handler": w.handlerName,
+				"status":  "failure",
+			}).Inc()
+			responseSuccessGauge.With(prometheus.Labels{
 				"handler": w.handlerName,
 				"status":  "failure",
 			}).Inc()
@@ -107,6 +147,9 @@ func (w *statsWriter) WriteHeader(statusCode int) {
 func statsMiddleware(h http.HandlerFunc, handlerName string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		requestCounter.With(prometheus.Labels{
+			"handler": handlerName,
+		}).Inc()
+		requestGauge.With(prometheus.Labels{
 			"handler": handlerName,
 		}).Inc()
 		w = newStatsWriter(w, handlerName)

--- a/stats_test.go
+++ b/stats_test.go
@@ -12,6 +12,8 @@ import (
 func TestStatsResponseWriterWritesResponseMetricOnce(t *testing.T) {
 	responseSuccessCounter.Reset()
 	responseStatusCounter.Reset()
+	responseSuccessGauge.Reset()
+	responseStatusGauge.Reset()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -34,11 +36,22 @@ func TestStatsResponseWriterWritesResponseMetricOnce(t *testing.T) {
 	if testutil.ToFloat64(responseStatusCounter.WithLabelValues("myhandler", "400")) != float64(1) {
 		t.Fatalf("Expected responseStatusCounter to be 1, got %f", testutil.ToFloat64(responseStatusCounter.WithLabelValues("myhandler", "400")))
 	}
+
+	// With Gauge Metric
+	if testutil.ToFloat64(responseSuccessGauge.WithLabelValues("myhandler", "client_failure")) != float64(1) {
+		t.Fatalf("Expected responseSuccessGauge to be 1, got %f", testutil.ToFloat64(responseSuccessGauge.WithLabelValues("myhandler", "client_failure")))
+	}
+
+	if testutil.ToFloat64(responseStatusGauge.WithLabelValues("myhandler", "400")) != float64(1) {
+		t.Fatalf("Expected responseStatusGauge to be 1, got %f", testutil.ToFloat64(responseStatusGauge.WithLabelValues("myhandler", "400")))
+	}
 }
 
 func TestStatsResponseWriterWritesToHeaderOnWrite(t *testing.T) {
 	responseSuccessCounter.Reset()
 	responseStatusCounter.Reset()
+	responseSuccessGauge.Reset()
+	responseStatusGauge.Reset()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -56,6 +69,15 @@ func TestStatsResponseWriterWritesToHeaderOnWrite(t *testing.T) {
 
 	if testutil.ToFloat64(responseStatusCounter.WithLabelValues("myhandler", "200")) != float64(1) {
 		t.Fatalf("Expected responseStatusCounter to be 1, got %f", testutil.ToFloat64(responseStatusCounter.WithLabelValues("myhandler", "200")))
+	}
+
+	// With Gauge Metric
+	if testutil.ToFloat64(responseSuccessGauge.WithLabelValues("myhandler", "success")) != float64(1) {
+		t.Fatalf("Expected responseSuccessGauge to be 1, got %f", testutil.ToFloat64(responseSuccessGauge.WithLabelValues("myhandler", "success")))
+	}
+
+	if testutil.ToFloat64(responseStatusGauge.WithLabelValues("myhandler", "200")) != float64(1) {
+		t.Fatalf("Expected responseStatusGauge to be 1, got %f", testutil.ToFloat64(responseStatusGauge.WithLabelValues("myhandler", "200")))
 	}
 }
 
@@ -86,7 +108,24 @@ func TestWrappingStatsResponseWriteWritesAllMetrics(t *testing.T) {
 		t.Fatalf("Expected responseSuccessCounter to be 1, got %f", testutil.ToFloat64(responseSuccessCounter.WithLabelValues("myhandler", "failure")))
 	}
 
-	if testutil.ToFloat64(responseStatusCounter.WithLabelValues("inner", "500")) != float64(1) {
-		t.Fatalf("Expected responseStatusCounter to be 1, got %f", testutil.ToFloat64(responseStatusCounter.WithLabelValues("myhandler", "500")))
+	// With Gauge Metric
+	if testutil.ToFloat64(responseStatusGauge.WithLabelValues("inner", "500")) != float64(1) {
+		t.Fatalf("Expected responseStatusGauge to be 1, got %f", testutil.ToFloat64(responseStatusGauge.WithLabelValues("myhandler", "500")))
+	}
+
+	if testutil.ToFloat64(responseSuccessGauge.WithLabelValues("wrapper", "failure")) != float64(1) {
+		t.Fatalf("Expected responseSuccessGauge to be 1, got %f", testutil.ToFloat64(responseSuccessGauge.WithLabelValues("myhandler", "failure")))
+	}
+
+	if testutil.ToFloat64(responseStatusGauge.WithLabelValues("wrapper", "500")) != float64(1) {
+		t.Fatalf("Expected responseStatusGauge to be 1, got %f", testutil.ToFloat64(responseStatusGauge.WithLabelValues("myhandler", "500")))
+	}
+
+	if testutil.ToFloat64(responseSuccessGauge.WithLabelValues("inner", "failure")) != float64(1) {
+		t.Fatalf("Expected responseSuccessGauge to be 1, got %f", testutil.ToFloat64(responseSuccessGauge.WithLabelValues("myhandler", "failure")))
+	}
+
+	if testutil.ToFloat64(responseStatusGauge.WithLabelValues("inner", "500")) != float64(1) {
+		t.Fatalf("Expected responseStatusGauge to be 1, got %f", testutil.ToFloat64(responseStatusGauge.WithLabelValues("myhandler", "500")))
 	}
 }


### PR DESCRIPTION
According to the co-founder of Prometheus counters should not be used as an absolute value as it does not account for when the metric is reset ([video](https://youtu.be/fhx0ehppMGM?t=237)):

> Coming to PromQL again, you'll almost never want to look at the absolute value of a counter. If you think about it, counters are just cumulative counts over some arbitrary amount of time that totally depends on when the counter start from zero ... And the absolute value doesn't tell you anything useful at all.

So I'm testing the data with gauge to see it handles the metric reset better. I'm also [reading](https://iximiuz.com/en/posts/prometheus-functions-agg-over-time/) that `sum_over_time()` works better with gauges which is what we want to do instead of going sampling the sum of the increase (instant vector) which is what `sum by(namespace, keyid, user) (autograph_signer_requests{namespace=~"autograph-$env"}[$__rate_interval])` seem to be doing.

Fix AUT-393