### PR TITLE
fix(prometheus): Initialize known labels to 0

### DIFF
--- a/main.go
+++ b/main.go
@@ -201,6 +201,14 @@ func run(conf configuration, listen string, debug bool) {
 		ag.enableDebug()
 	}
 
+	// Initialize known prometheus labels to 0
+	for _, authorization := range conf.Authorizations {
+		for _, signer := range authorization.Signers {
+			signerRequestsCounter.WithLabelValues(signer, authorization.ID, "false")
+			signerRequestsCounter.WithLabelValues(signer, authorization.ID, "true")
+		}
+	}
+
 	ag.startCleanupHandler()
 
 	// Initialize a monitor.


### PR DESCRIPTION
Google Managed Prometheus ignores the first datapoint for counters. This
means that the first request incrementing a counter will set the counter
to 1, but GMP will only capture that the time series was created.

> This can result in significant errors for very slow counters.
> The label set always includes the pod name, so every time a new pod is
> started a new counter time series is started as well, even in the
> absence of other labels.
