### PR TITLE
Revert "Remove request and reponse counter metrics (#1127)"

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -216,6 +216,12 @@ func (a *autographer) handleSignature(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		requestedSignerConfig := requestedSigner.Config()
+		signerRequestsCounter.With(prometheus.Labels{
+			"keyid": requestedSignerConfig.ID,
+			"user":  userid,
+			// TODO(AUT-206): remove this when we've migrate everyone off of the default keyid
+			"used_default_signer": strconv.FormatBool(sigreq.KeyID == ""),
+		}).Inc()
 		signerRequestsGauge.With(prometheus.Labels{
 			"keyid": requestedSignerConfig.ID,
 			"user":  userid,

--- a/stats.go
+++ b/stats.go
@@ -12,18 +12,28 @@ import (
 const statsNamespace = "autograph"
 
 var (
-	// Using gauge metrics types instead of counter due to counters being dropped on
-	// first event, more info in AUT-393.
+	requestCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:      "requests",
+		Namespace: statsNamespace,
+		Help:      "A counter for how many requests are made to a given handler",
+	}, []string{"handler"})
+
 	requestGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name:      "request_gauge",
 		Namespace: statsNamespace,
-		Help:      "A gauge for how many requests are made to a given handler",
+		Help:      "A counter for how many requests are made to a given handler",
 	}, []string{"handler"})
+
+	signerRequestsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:      "signer_requests",
+		Namespace: statsNamespace,
+		Help:      "A counter for how many authenticated and authorized requests are made to a given signer",
+	}, []string{"keyid", "user", "used_default_signer"})
 
 	signerRequestsGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name:      "signer_requests_gauge",
 		Namespace: statsNamespace,
-		Help:      "A gauge for how many authenticated and authorized requests are made to a given signer",
+		Help:      "A counter for how many authenticated and authorized requests are made to a given signer",
 	}, []string{"keyid", "user", "used_default_signer"})
 
 	signerRequestsTiming = promauto.NewSummaryVec(prometheus.SummaryOpts{
@@ -37,16 +47,28 @@ var (
 		},
 	}, []string{"step"})
 
+	responseStatusCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:      "response_status",
+		Namespace: statsNamespace,
+		Help:      "A counter for response status codes for a given handler",
+	}, []string{"handler", "statusCode"})
+
 	responseStatusGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name:      "response_status_gauge",
 		Namespace: statsNamespace,
-		Help:      "A gauge for response status codes for a given handler",
+		Help:      "A counter for response status codes for a given handler",
 	}, []string{"handler", "statusCode"})
+
+	responseSuccessCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:      "response_success",
+		Namespace: statsNamespace,
+		Help:      "A counter for succesful vs failed response status codes",
+	}, []string{"handler", "status"})
 
 	responseSuccessGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name:      "response_success_gauge",
 		Namespace: statsNamespace,
-		Help:      "A gauge for succesful vs failed response status codes",
+		Help:      "A counter for succesful vs failed response status codes",
 	}, []string{"handler", "status"})
 )
 
@@ -75,22 +97,38 @@ func (w *statsWriter) Write(b []byte) (int, error) {
 
 func (w *statsWriter) WriteHeader(statusCode int) {
 	if w.headerWritten.CompareAndSwap(false, true) {
+		responseStatusCounter.With(prometheus.Labels{
+			"handler":    w.handlerName,
+			"statusCode": fmt.Sprintf("%d", statusCode),
+		}).Inc()
 		responseStatusGauge.With(prometheus.Labels{
 			"handler":    w.handlerName,
 			"statusCode": fmt.Sprintf("%d", statusCode),
 		}).Inc()
 
 		if statusCode >= 200 && statusCode < 300 {
+			responseSuccessCounter.With(prometheus.Labels{
+				"handler": w.handlerName,
+				"status":  "success",
+			}).Inc()
 			responseSuccessGauge.With(prometheus.Labels{
 				"handler": w.handlerName,
 				"status":  "success",
 			}).Inc()
 		} else if statusCode >= 400 && statusCode < 500 {
+			responseSuccessCounter.With(prometheus.Labels{
+				"handler": w.handlerName,
+				"status":  "client_failure",
+			}).Inc()
 			responseSuccessGauge.With(prometheus.Labels{
 				"handler": w.handlerName,
 				"status":  "client_failure",
 			}).Inc()
 		} else {
+			responseSuccessCounter.With(prometheus.Labels{
+				"handler": w.handlerName,
+				"status":  "failure",
+			}).Inc()
 			responseSuccessGauge.With(prometheus.Labels{
 				"handler": w.handlerName,
 				"status":  "failure",
@@ -108,6 +146,9 @@ func (w *statsWriter) WriteHeader(statusCode int) {
 // "<handlerName>.request.attempts".
 func statsMiddleware(h http.HandlerFunc, handlerName string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		requestCounter.With(prometheus.Labels{
+			"handler": handlerName,
+		}).Inc()
 		requestGauge.With(prometheus.Labels{
 			"handler": handlerName,
 		}).Inc()


### PR DESCRIPTION
While using gauge metric type correctly increments the metric even when it is initialized for the first time, there are no function that grabs the exact difference between the two data points in an interval. We are revisiting the decision to use Prometheus to set alerts for this. See more details in [Jira comment](https://mozilla-hub.atlassian.net/browse/AUT-393?focusedCommentId=1033959).

This reverts commit 0904ead762c4fa55178d7ea7fd810df6aa66721e.
Update AUT-393
