### PR TITLE
AUT-202: enable errcheck and correct errors in golangci lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,9 +2,7 @@ linters:
   disable-all: true
   enable:
     - depguard
-    # TODO(AUT-202): errcheck is too handy to leave out but requires more churn
-    # at time of writing
-    # - errcheck
+    - errcheck
     - goimports
     - gosimple
     - govet

--- a/authorize_test.go
+++ b/authorize_test.go
@@ -299,7 +299,8 @@ func TestHawkTimestampSkewFail(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ag.addAuthorizations([]authorization{
+	_ = ag.addAuthorizations([]authorization{
+
 		{
 			ID:      "alice",
 			Key:     "1862300e9bd18eafab2eb8d6",

--- a/database/queries.go
+++ b/database/queries.go
@@ -28,7 +28,7 @@ func (db *Handler) BeginEndEntityOperations() (*Transaction, error) {
 	_, err = tx.Exec("LOCK TABLE endentities_lock IN ACCESS EXCLUSIVE MODE")
 	if err != nil {
 		err = fmt.Errorf("failed to lock endentities table: %w", err)
-		tx.Rollback()
+		_ = tx.Rollback()
 		return nil, err
 	}
 	var id uint64
@@ -36,7 +36,7 @@ func (db *Handler) BeginEndEntityOperations() (*Transaction, error) {
 				VALUES ($1) RETURNING id`,
 		true).Scan(&id)
 	if err != nil {
-		tx.Rollback()
+		_ = tx.Rollback()
 		err = fmt.Errorf("failed to lock endentities table: %w", err)
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (tx *Transaction) InsertEE(x5u, label, signerID string) (err error) {
 	_, err = tx.Exec(`INSERT INTO endentities(x5u, label, signer_id, hsm_handle, is_current)
 				VALUES ($1, $2, $3, $4, $5)`, x5u, label, signerID, -1, true)
 	if err != nil {
-		tx.Rollback()
+		_ = tx.Rollback()
 		err = fmt.Errorf("failed to insert new key in database: %w", err)
 		return
 	}
@@ -81,7 +81,7 @@ func (tx *Transaction) InsertEE(x5u, label, signerID string) (err error) {
 		signerID, label)
 	if err != nil {
 		err = fmt.Errorf("failed to update is_current status of keys in database: %w", err)
-		tx.Rollback()
+		_ = tx.Rollback()
 		return
 	}
 	return nil
@@ -92,13 +92,13 @@ func (tx *Transaction) End() error {
 	_, err := tx.Exec("UPDATE endentities_lock SET is_locked=FALSE, freed_at=NOW() WHERE id=$1", tx.ID)
 	if err != nil {
 		err = fmt.Errorf("failed to update is_current status of keys in database: %w", err)
-		tx.Rollback()
+		_ = tx.Rollback()
 		return err
 	}
 	err = tx.Commit()
 	if err != nil {
 		err = fmt.Errorf("failed to commit transaction in database: %w", err)
-		tx.Rollback()
+		_ = tx.Rollback()
 		return err
 	}
 	return nil

--- a/errors.go
+++ b/errors.go
@@ -29,7 +29,10 @@ func httpError(w http.ResponseWriter, r *http.Request, errorCode int, errorMessa
 	// request body is read before writing a response.
 	// https://github.com/golang/go/issues/15789
 	if r.Body != nil {
-		io.Copy(io.Discard, r.Body)
+		_, err := io.Copy(io.Discard, r.Body)
+		if err != nil {
+			log.Errorf("error while copying discard: %v", err)
+		}
 		r.Body.Close()
 	}
 	http.Error(w, msg, errorCode)

--- a/handlers.go
+++ b/handlers.go
@@ -350,7 +350,10 @@ func (a *autographer) handleSignature(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	w.Write(respdata)
+	_, err = w.Write(respdata)
+	if err != nil {
+		log.Errorf("error writing response: %v", err)
+	}
 	log.WithFields(log.Fields{
 		"rid":                  rid,
 		"num_signing_requests": sigReqsCount,
@@ -363,7 +366,10 @@ func handleLBHeartbeat(w http.ResponseWriter, r *http.Request) {
 		httpError(w, r, http.StatusMethodNotAllowed, "%s method not allowed; endpoint accepts GET only", r.Method)
 		return
 	}
-	w.Write([]byte("ohai"))
+	_, err := w.Write([]byte("ohai"))
+	if err != nil {
+		log.Errorf("error writing response: %v", err)
+	}
 }
 
 // handleHeartbeat checks whether backing services are enabled and
@@ -450,7 +456,10 @@ func (a *autographer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	w.Write(respdata)
+	_, err = w.Write(respdata)
+	if err != nil {
+		log.Errorf("error writing response: %v", err)
+	}
 }
 
 func handleVersion(w http.ResponseWriter, r *http.Request) {
@@ -526,5 +535,8 @@ func (a *autographer) handleGetAuthKeyIDs(w http.ResponseWriter, r *http.Request
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write(signerIDsJSON)
+	_, err = w.Write(signerIDsJSON)
+	if err != nil {
+		log.Errorf("error writing response: %v", err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -112,7 +112,10 @@ func parseArgsAndLoadConfig(args []string) (conf configuration, listen string, d
 	// https://github.com/sirupsen/logrus#level-logging
 	fset.StringVar(&logLevel, "l", "", "Set the logging level. Optional defaulting to info. Options: trace, debug, info, warning, error, fatal and panic")
 	fset.BoolVar(&debug, "D", false, "Sets the log level to debug to print debug logs.")
-	fset.Parse(args)
+	err = fset.Parse(args)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	switch logLevel {
 	case "debug":

--- a/monitor_handler_test.go
+++ b/monitor_handler_test.go
@@ -16,8 +16,11 @@ import (
 func TestMonitorNoConfig(t *testing.T) {
 	tmpag := newAutographer(1)
 	var nomonitor configuration
-	tmpag.addMonitoring(nomonitor.Monitoring)
-	_, err := tmpag.getAuthByID(monitorAuthID)
+	err := tmpag.addMonitoring(nomonitor.Monitoring)
+	if err != nil {
+		t.Fatal("adding monitoring configuration failed")
+	}
+	_, err = tmpag.getAuthByID(monitorAuthID)
 	if err == nil {
 		t.Fatal("monitor configuration found when none was passed")
 	}
@@ -36,8 +39,8 @@ func TestMonitorAddDuplicate(t *testing.T) {
 		}
 	}()
 	// Adding the first one will pass, adding the second one will trigger the panic
-	tmpag.addMonitoring(monitorconf.Monitoring)
-	tmpag.addMonitoring(monitorconf.Monitoring)
+	_ = tmpag.addMonitoring(monitorconf.Monitoring)
+	_ = tmpag.addMonitoring(monitorconf.Monitoring)
 }
 
 func TestMonitorBadRequest(t *testing.T) {
@@ -116,7 +119,7 @@ eNGDpX35+pcEygI=
 =JC6I
 -----END PGP PUBLIC KEY BLOCK-----`
 
-	ag.addSigners([]signer.Configuration{{
+	err := ag.addSigners([]signer.Configuration{{
 		ID:         "testErr1",
 		Type:       "gpg2",
 		Mode:       "gpg2",
@@ -132,7 +135,9 @@ eNGDpX35+pcEygI=
 		PublicKey:  testPublicKey,
 	},
 	})
-
+	if err != nil {
+		t.Fatalf("adding signers failed: %v", err)
+	}
 	mo := newMonitor(ag, conf.MonitorInterval)
 
 	var empty []byte

--- a/signer/apk2/apk2.go
+++ b/signer/apk2/apk2.go
@@ -239,6 +239,9 @@ func Unmarshal(signature string, content []byte) (sig *Signature, err error) {
 // String returns a PEM encoded PKCS7 block
 func (sig *Signature) String() string {
 	var buf bytes.Buffer
-	pem.Encode(&buf, &pem.Block{Type: "PKCS7", Bytes: sig.Data})
+	err := pem.Encode(&buf, &pem.Block{Type: "PKCS7", Bytes: sig.Data})
+	if err != nil {
+		return fmt.Sprintf("error encoding signature to PEM: %v", err)
+	}
 	return buf.String()
 }

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -203,7 +203,10 @@ func TestHSMNotAvailable(t *testing.T) {
 	}()
 	tcfg := new(Configuration)
 	tcfg.InitHSM(nil)
-	tcfg.GetPrivateKey()
+	_, err := tcfg.GetPrivateKey()
+	if err == nil {
+		t.Fatal("expected to fail with no suitable key found but succeeded")
+	}
 }
 
 func TestNoSuitableKeyFound(t *testing.T) {
@@ -417,7 +420,10 @@ func TestMakeKeyAWSECDSA(t *testing.T) {
 	mockCtx.EXPECT().Destroy().Times(1)
 
 	mockFactory := mockedPKCS11ContextFactory(mockCtx)
-	crypto11.Configure(&crypto11.PKCS11Config{}, mockFactory)
+	_, err = crypto11.Configure(&crypto11.PKCS11Config{}, mockFactory)
+	if err != nil {
+		t.Fatalf("failed to configure crypto11: %v", err)
+	}
 	defer crypto11.Close()
 
 	cfg := Configuration{
@@ -498,7 +504,10 @@ func TestMakeKeyAWSRSA(t *testing.T) {
 	mockCtx.EXPECT().Destroy().Times(1)
 
 	mockFactory := mockedPKCS11ContextFactory(mockCtx)
-	crypto11.Configure(&crypto11.PKCS11Config{}, mockFactory)
+	_, err = crypto11.Configure(&crypto11.PKCS11Config{}, mockFactory)
+	if err != nil {
+		t.Fatalf("failed to configure crypto11: %v", err)
+	}
 	defer crypto11.Close()
 	cfg := Configuration{
 		isHsmAvailable: true,
@@ -585,7 +594,10 @@ func TestMakeKeyGCPECDSA(t *testing.T) {
 	mockCtx.EXPECT().Destroy().Times(1)
 
 	mockFactory := mockedPKCS11ContextFactory(mockCtx)
-	crypto11.Configure(&crypto11.PKCS11Config{}, mockFactory)
+	_, err = crypto11.Configure(&crypto11.PKCS11Config{}, mockFactory)
+	if err != nil {
+		t.Fatalf("failed to configure crypto11: %v", err)
+	}
 	defer crypto11.Close()
 
 	cfg := Configuration{
@@ -651,7 +663,10 @@ func TestMakeKeyGCPRSA(t *testing.T) {
 	mockCtx.EXPECT().Destroy().Times(1)
 
 	mockFactory := mockedPKCS11ContextFactory(mockCtx)
-	crypto11.Configure(&crypto11.PKCS11Config{}, mockFactory)
+	_, err = crypto11.Configure(&crypto11.PKCS11Config{}, mockFactory)
+	if err != nil {
+		t.Fatalf("failed to configure crypto11: %v", err)
+	}
 	defer crypto11.Close()
 	cfg := Configuration{
 		isHsmAvailable: true,

--- a/signer/xpi/xpi.go
+++ b/signer/xpi/xpi.go
@@ -532,7 +532,10 @@ func (sig *Signature) VerifyWithChainAt(truststore *x509.CertPool, verificationT
 // String returns a PEM encoded PKCS7 block
 func (sig *Signature) String() string {
 	var buf bytes.Buffer
-	pem.Encode(&buf, &pem.Block{Type: "PKCS7", Bytes: sig.Data})
+	err := pem.Encode(&buf, &pem.Block{Type: "PKCS7", Bytes: sig.Data})
+	if err != nil {
+		return fmt.Sprintf("error encoding signature to PEM: %v", err)
+	}
 	return buf.String()
 }
 

--- a/signer/xpi/xpi_test.go
+++ b/signer/xpi/xpi_test.go
@@ -188,7 +188,10 @@ func TestSignDataAndVerifyWithOpenSSL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	pem.Encode(fd, &pem.Block{Type: "CERTIFICATE", Bytes: s.issuerCert.Raw})
+	err = pem.Encode(fd, &pem.Block{Type: "CERTIFICATE", Bytes: s.issuerCert.Raw})
+	if err != nil {
+		t.Fatal(err)
+	}
 	fd.Close()
 
 	// call openssl to verify the signature on the content using the root

--- a/stats_test.go
+++ b/stats_test.go
@@ -57,8 +57,10 @@ func TestStatsResponseWriterWritesToHeaderOnWrite(t *testing.T) {
 
 	recorder := httptest.NewRecorder()
 	statsWriter := newStatsWriter(recorder, "myhandler")
-	statsWriter.Write([]byte("hello"))
-
+	_, err := statsWriter.Write([]byte("hello"))
+	if err != nil {
+		t.Fatalf("unexpected error writing to statsWriter: %v", err)
+	}
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected status code %d, got %d", http.StatusOK, recorder.Code)
 	}

--- a/tools/autograph-monitor/monitor_test.go
+++ b/tools/autograph-monitor/monitor_test.go
@@ -30,8 +30,16 @@ func TestGoldenPath(t *testing.T) {
 			return
 		}
 		w.WriteHeader(http.StatusCreated)
-		w.Write(respBytes1)
-		w.Write(respBytes2)
+		_, err = w.Write(respBytes1)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		_, err = w.Write(respBytes2)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	})
 	server := httptest.NewTLSServer(mux)
 	defer server.Close()

--- a/tools/autograph-monitor/monitor_test.go
+++ b/tools/autograph-monitor/monitor_test.go
@@ -32,13 +32,11 @@ func TestGoldenPath(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 		_, err = w.Write(respBytes1)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
+			t.Fatalf("failed to write respBytes1: %v", err)
 		}
 		_, err = w.Write(respBytes2)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
+			t.Fatalf("failed to write respBytes2: %v", err)
 		}
 	})
 	server := httptest.NewTLSServer(mux)

--- a/tools/makecsr/make-ev-csr/make-ev-csr.go
+++ b/tools/makecsr/make-ev-csr/make-ev-csr.go
@@ -101,5 +101,8 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	pem.Encode(os.Stdout, &pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes})
+	err = pem.Encode(os.Stdout, &pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes})
+	if err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
This PR enables errcheck in the .golganci.yml and resolves the return errors that arise. This is done by doing error handling and dropping the error using the blank identifier