### PR TITLE
Update README for makecsr and explicitly use linux/amd64 for libkmsp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,13 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 #------------------------------------------------------------------------------
 FROM base AS prebuild
 ARG LIBKMSP11_VERSION
+ARG BUILDOS
+ARG BUILDARCH
 
 COPY google-pkcs12-release-signing-key.pem /app/src/autograph/
 
 # Download and verify the Google KMS library
-RUN cd /tmp && curl -L https://github.com/GoogleCloudPlatform/kms-integrations/releases/download/pkcs11-v${LIBKMSP11_VERSION}/libkmsp11-${LIBKMSP11_VERSION}-linux-amd64.tar.gz | tar -zx --strip-components=1
+RUN cd /tmp && curl -L https://github.com/GoogleCloudPlatform/kms-integrations/releases/download/pkcs11-v${LIBKMSP11_VERSION}/libkmsp11-${LIBKMSP11_VERSION}-${BUILDOS}-${BUILDARCH}.tar.gz | tar -zx --strip-components=1
 RUN openssl dgst -sha384 -verify /app/src/autograph/google-pkcs12-release-signing-key.pem -signature /tmp/libkmsp11.so.sig /tmp/libkmsp11.so
 
 # fetch the RDS CA bundles

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ ARG BUILDARCH
 COPY google-pkcs12-release-signing-key.pem /app/src/autograph/
 
 # Download and verify the Google KMS library
+RUN echo "Download Google KMS library for ${BUILDOS} and ${BUILDARCH}."
 RUN cd /tmp && curl -L https://github.com/GoogleCloudPlatform/kms-integrations/releases/download/pkcs11-v${LIBKMSP11_VERSION}/libkmsp11-${LIBKMSP11_VERSION}-${BUILDOS}-${BUILDARCH}.tar.gz | tar -zx --strip-components=1
 RUN openssl dgst -sha384 -verify /app/src/autograph/google-pkcs12-release-signing-key.pem -signature /tmp/libkmsp11.so.sig /tmp/libkmsp11.so
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,14 +36,14 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 #------------------------------------------------------------------------------
 FROM base AS prebuild
 ARG LIBKMSP11_VERSION
-ARG BUILDOS
-ARG BUILDARCH
+ARG TARGETOS
+ARG TARGETARCH
 
 COPY google-pkcs12-release-signing-key.pem /app/src/autograph/
 
 # Download and verify the Google KMS library
-RUN echo "Download Google KMS library for ${BUILDOS} and ${BUILDARCH}."
-RUN cd /tmp && curl -L https://github.com/GoogleCloudPlatform/kms-integrations/releases/download/pkcs11-v${LIBKMSP11_VERSION}/libkmsp11-${LIBKMSP11_VERSION}-${BUILDOS}-${BUILDARCH}.tar.gz | tar -zx --strip-components=1
+RUN echo "Download Google KMS library for ${TARGETOS} and ${TARGETARCH}."
+RUN cd /tmp && curl -L https://github.com/GoogleCloudPlatform/kms-integrations/releases/download/pkcs11-v${LIBKMSP11_VERSION}/libkmsp11-${LIBKMSP11_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz | tar -zx --strip-components=1
 RUN openssl dgst -sha384 -verify /app/src/autograph/google-pkcs12-release-signing-key.pem -signature /tmp/libkmsp11.so.sig /tmp/libkmsp11.so
 
 # fetch the RDS CA bundles

--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,9 @@ gpg-test-clean:
 # app-hsm -> monitor-hsm(app-hsm writes chains and updated config to shared /tmp volume)
 #
 build: generate
-	DOCKER_BUILDKIT=0 COMPOSE_DOCKER_CLI_BUILD=0 docker compose build --parallel app db
-	DOCKER_BUILDKIT=0 COMPOSE_DOCKER_CLI_BUILD=0 docker compose build --parallel app-hsm monitor
-	DOCKER_BUILDKIT=0 COMPOSE_DOCKER_CLI_BUILD=0 docker compose build --parallel monitor monitor-hsm
+	COMPOSE_DOCKER_CLI_BUILD=0 docker compose build --parallel app db
+	COMPOSE_DOCKER_CLI_BUILD=0 docker compose build --parallel app-hsm monitor
+	COMPOSE_DOCKER_CLI_BUILD=0 docker compose build --parallel monitor monitor-hsm
 
 test-in-docker: build
 	$(SHELL) -c " \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     image: autograph-app
     build:
       context: .
+      platforms:
+        - "linux/amd64"
     environment:
       - AUTOGRAPH_DB_DSN=host=db user=myautographdbuser dbname=autograph password=myautographdbpassword sslmode=verify-full sslrootcert=/opt/db-root.crt
     links:

--- a/tools/makecsr/README.md
+++ b/tools/makecsr/README.md
@@ -52,23 +52,29 @@ For more information, see
 https://mana.mozilla.org/wiki/pages/viewpage.action?pageId=87365053
 
 ### Putting it all together, practical GCP example
-1. Have your keys created in GCP KMS and be sure that your user account has the `cloudkms.signerVerifier` role attached.
+1. Have your keys created in GCP KMS and be sure that your user account has the `cloudkms.signerVerifier` role attached. If role not attached, follow [example PR in mozilla/webservices-infra](https://github.com/mozilla/webservices-infra/pull/11578) to add role.
+
+> [!TIP]
+> Leave PR open to give role and use the same PR to remove the role once the work is complete.
 
 2. Create a read only libkmsp11-config.yaml file like this
 ```
 tokens:
-  - key_ring: projects/my-project/locations/global/keyRings/my-key-ring
+  - key_ring: projects/my-project-id/locations/global/keyRings/my-key-ring
     label: gcp-token
-# Note: This file should be read-only. You can do `chmod -w libkmsp11-config.yaml` after you create it.
 ```
+> [!Note]
+> This file should be read-only because GCP expects the file to be read-only. You can do `chmod -w libkmsp11-config.yaml` after you create it.
 
 3. Create a crypto11-config.json file like this
 ```
 {
   "Path": "/app/libkmsp11.so",
-  "TokenLabel": "gcp-autograph-token"
+  "TokenLabel": "gcp-token"
 }
 ```
+> [!IMPORTANT]
+> `TokenLabel` in crypto11-config.json and `label` from libkmsp11-config.yaml both need to be same value.
 
 4. Get authenticated with GCP. Ex: `gcloud auth login --update-adc`
 
@@ -84,6 +90,8 @@ docker run -it --rm --user 0:0 \
     -v "${PWD}/crypto11-config.json:/mnt/crypto11-config.json" \
     "mozilla/autograph:latest" /bin/bash
 ```
+> [!NOTE]
+> If using MacOS, add `--platform=linux/amd64` during `docker run` command. PKCS #11 Library for Cloud KMS, the `libkmsp11.so`, is only available in Windows and AMD64 ([doc](https://github.com/GoogleCloudPlatform/kms-integrations/blob/master/kmsp11/docs/user_guide.md#getting-started)).
 
 7. Run the makecsr command with the options you want.
 ```

--- a/tools/makecsr/README.md
+++ b/tools/makecsr/README.md
@@ -91,7 +91,7 @@ docker run -it --rm --user 0:0 \
     "mozilla/autograph:latest" /bin/bash
 ```
 > [!NOTE]
-> If using MacOS, add `--platform=linux/amd64` during `docker run` command. PKCS #11 Library for Cloud KMS, the `libkmsp11.so`, is only available in Windows and AMD64 ([doc](https://github.com/GoogleCloudPlatform/kms-integrations/blob/master/kmsp11/docs/user_guide.md#getting-started)).
+> If using arm64 (ex: macOS or arm linux) add `--platform=linux/amd64` during `docker run` command. PKCS #11 Library for Cloud KMS, the `libkmsp11.so`, is only available in Windows and AMD64 ([doc](https://github.com/GoogleCloudPlatform/kms-integrations/blob/master/kmsp11/docs/user_guide.md#getting-started)).
 
 7. Run the makecsr command with the options you want.
 ```


### PR DESCRIPTION
- Use Docker buildkit arguments to dynamically pull libkmsp package depending on OS and architecture.
  - Old reason for disabling buildkit from https://github.com/mozilla-services/autograph/commit/e426a7f8b4e54017af28c58323ed3b84686ffeac
- Add helpful tips for using the `makecsr` command

Fix AUT-618

[Build output diff](https://www.diffchecker.com/OoV7lDpn/)