### PR TITLE
Update docker compose and make commands to use linux/amd64 as platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,16 +97,15 @@ integration-test:
 # build the docker image, and run it locally with our source code mounted under /app/src/autograph
 # run as root to allow for changes, package installs, etc
 build-and-run-interactive:
-	docker build -t mozilla/autograph:latest .
-	docker run --rm -it --user 0:0 \
+	docker compose build app
+	docker compose run --rm -it --user 0:0 \
 		-v "./:/app/src/autograph" \
-		mozilla/autograph:latest /bin/bash
+		app /bin/bash
 
 # using unit-test configuration build the docker image,
 # and run it locally with our source code mounted under /app/src/autograph
 # run as root to allow for changes, package installs, etc
-build-and-run-test-interactive:
-	docker compose build
+build-and-run-test-interactive: build
 	docker compose up -d db
 	docker compose up -d app
 	docker compose run --entrypoint /bin/bash -v "$(pwd):/app/src/autograph" -u 0:0 unit-test

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ gpg-test-clean:
 build: generate
 	COMPOSE_DOCKER_CLI_BUILD=0 docker compose build --parallel app db
 	COMPOSE_DOCKER_CLI_BUILD=0 docker compose build --parallel app-hsm monitor
-	COMPOSE_DOCKER_CLI_BUILD=0 docker compose build --parallel monitor monitor-hsm
+	COMPOSE_DOCKER_CLI_BUILD=0 docker compose build --parallel monitor-hsm
 
 test-in-docker: build
 	$(SHELL) -c " \

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ build-and-run-interactive:
 build-and-run-test-interactive: build
 	docker compose up -d db
 	docker compose up -d app
-	docker compose run --entrypoint /bin/bash -v "$(pwd):/app/src/autograph" -u 0:0 unit-test
+	docker compose run --entrypoint /bin/bash -v "./:/app/src/autograph" -u 0:0 unit-test
 
 # pull the docker image, and run it locally with our source code mounted under /app/src/autograph
 # run as root to allow for changes, package installs, etc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
     image: autograph-app-hsm
     build:
       context: tools/softhsm/
+      platforms:
+        - "linux/amd64"
     environment:
       - AUTOGRAPH_DB_DSN=host=db user=myautographdbuser dbname=autograph password=myautographdbpassword sslmode=verify-full sslrootcert=/opt/db-root.crt
     links:
@@ -74,6 +76,8 @@ services:
     build:
       context: tools/autograph-monitor/
       dockerfile: Dockerfile.monitor-selftest
+      platforms:
+        - "linux/amd64"
     environment:
       - AUTOGRAPH_URL=http://autograph-app:8000/
       - AUTOGRAPH_KEY=19zd4w3xirb5syjgdx8atq6g91m03bdsmzjifs2oddivswlu9qs
@@ -88,6 +92,8 @@ services:
     build:
       context: tools/autograph-monitor/
       dockerfile: Dockerfile.monitor-selftest
+      platforms:
+        - "linux/amd64"
     environment:
       - AUTOGRAPH_URL=http://autograph-app-hsm:8001/
       - AUTOGRAPH_KEY=19zd4w3xirb5syjgdx8atq6g91m03bdsmzjifs2oddivswlu9qs
@@ -103,6 +109,8 @@ services:
     image: autograph-app
     build:
       context: .
+      platforms:
+        - "linux/amd64"
     environment:
       - AUTOGRAPH_DB_DSN=host=db user=myautographdbuser dbname=autograph password=myautographdbpassword sslmode=verify-full sslrootcert=/app/src/autograph/tools/softhsm/db-root.crt
       - AUTOGRAPH_DB_HOST=db


### PR DESCRIPTION
In #1237 we updated the docker-compose command for building app to use the `linux/amd64`. As a result, when running commands to build the rest of the apps in Autograph repository in mac, we received errors like:
```
target monitor: failed to solve: autograph-app: failed to resolve source metadata for docker.io/library/autograph-app:latest: no match for platform in manifest: not found
```

In Mac machine since it is using the emulated `linux/amd64` there is some latency as a result:
```
time make build
user 1.82s 
system 2.23s 
total 3:35.09 

time make test-in-docker 
user 0.80s 
system 0.86s 
total 5:42.81
```
as opposed to:
```
time make build

real	1m51.468s
user 0m1.534s
sys	0m0.932s

time make test-in-docker

real	3m40.182s
user 0m0.697s
sys	0m0.415s
```
built in Linux machine without emulating.

This has been separately filed in AUT-633 for follow-up.

Fix AUT-631