### PR TITLE
AUT-354 - Adding dedicated config property for the hsm connection test signer

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -45,10 +45,10 @@ const (
 type heartbeatConfig struct {
 	HSMCheckTimeout time.Duration
 	DBCheckTimeout  time.Duration
+	HSMTestSignerId *string
 
-	// hsmSignerConf is the signer conf to use to check
-	// HSM connectivity (set to the first signer with an HSM label
-	// in initHSM) when it is non-nil
+	// hsmSignerConf is the cached signer conf to use to check
+	// HSM connectivity. Set based on HSMTestSignerId.
 	hsmSignerConf *signer.Configuration
 }
 

--- a/main.go
+++ b/main.go
@@ -466,7 +466,7 @@ func (a *autographer) initHSM(serviceConf serviceConfig, signerConf signerConfig
 
 			// save the first signer with an HSM label as
 			// the key to test from the heartbeat handler
-			if a.heartbeatConf != nil && a.heartbeatConf.hsmSignerConf == nil {
+			if a.heartbeatConf != nil && a.heartbeatConf.HSMTestSignerId != nil && *a.heartbeatConf.HSMTestSignerId == signerConf.ID {
 				a.heartbeatConf.hsmSignerConf = signerConf
 
 				err := signerConf.CheckHSMConnection()

--- a/main_test.go
+++ b/main_test.go
@@ -90,6 +90,7 @@ server:
 heartbeat:
     hsmchecktimeout: 100ms
     dbchecktimeout: 150ms
+    hsmtestsignerid: signeridhere
 `)},
 	}
 	for i, testcase := range testcases {

--- a/tools/softhsm/autograph.softhsm-service.yaml
+++ b/tools/softhsm/autograph.softhsm-service.yaml
@@ -19,6 +19,7 @@ hsm:
 heartbeat:
     hsmchecktimeout: 100ms
     dbchecktimeout: 150ms
+    hsmtestsignerid: testmar
 
 # allow hawk authorization headers to be valid for up to 10 minutes
 # to account for diverging clocks between client and server


### PR DESCRIPTION
[AUT-354](https://mozilla-hub.atlassian.net/browse/AUT-354)

Adding a dedicated config property under `heartbeat` to identify which test signer to use for the hsm heartbeat check.
A config update is not required to make prevent a breakage as the property is optional.
If an invalid signer id is provided it simply won't match rather than crashing the service.

[AUT-354]: https://mozilla-hub.atlassian.net/browse/AUT-354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ