### PR TITLE
Check for control character in file name

### DIFF
--- a/signer/xpi/jar.go
+++ b/signer/xpi/jar.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"unicode"
 
 	"io"
 	"strings"
@@ -37,6 +38,10 @@ var maxFirstLineByteLen = maxLineByteLen - (len([]byte("Name: ")) + 1) // + 1 fo
 func formatFilename(filename []byte) (formatted []byte, err error) {
 	if !utf8.Valid(filename) {
 		err = fmt.Errorf("xpi: invalid UTF8 in filename %q", filename)
+		return
+	}
+	if bytes.ContainsFunc(filename, unicode.IsControl) {
+		err = fmt.Errorf("xpi: control character in filename %q", filename)
 		return
 	}
 	var (

--- a/signer/xpi/jar.go
+++ b/signer/xpi/jar.go
@@ -101,23 +101,6 @@ func makePKCS7Manifest(input []byte, metafiles []Metafile) (manifest []byte, err
 	return mw.Bytes(), err
 }
 
-// makeJARManifestAndSignatureFile writes hashes for all entries in a zip to a
-// manifest file then hashes the manifest file to write a signature
-// file and returns both
-func makeJARManifestAndSignatureFile(input []byte) (manifest, sigfile []byte, err error) {
-	manifest, err = makeJARManifest(input)
-	if err != nil {
-		return
-	}
-
-	sigfile, err = makeJARSignatureFile(manifest)
-	if err != nil {
-		return
-	}
-
-	return
-}
-
 // makeJARManifest calculates a sha1 and sha256 hash for each zip entry and writes them to a manifest file
 func makeJARManifest(input []byte) (manifest []byte, err error) {
 	inputReader := bytes.NewReader(input)

--- a/signer/xpi/jar_test.go
+++ b/signer/xpi/jar_test.go
@@ -47,6 +47,15 @@ func TestFormatFilenameInvalidUTF8(t *testing.T) {
 	}
 }
 
+func TestFormatFilenameInvalidControlCharacters(t *testing.T) {
+	t.Parallel()
+
+	_, err := formatFilename([]byte("originalFile\nName: anotherFile.js"))
+	if err == nil {
+		t.Fatal("format filename did not error for new line")
+	}
+}
+
 func TestFormatFilenameWithControlCharacter(t *testing.T) {
 	t.Parallel()
 

--- a/signer/xpi/jar_test.go
+++ b/signer/xpi/jar_test.go
@@ -56,22 +56,6 @@ func TestFormatFilenameInvalidControlCharacters(t *testing.T) {
 	}
 }
 
-func TestFormatFilenameWithControlCharacter(t *testing.T) {
-	t.Parallel()
-
-	// Both are the same, really, but `expected` is slightly more readable.
-	fn := []byte("some/file\x0d")
-	expected := []byte("some/file\r")
-
-	formatted, err := formatFilename(fn)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(formatted, expected) {
-		t.Fatalf("manifest filename mismatch Expected:\n%q\nGot:\n%q", expected, formatted)
-	}
-}
-
 func TestFormatFilenameTooLong(t *testing.T) {
 	t.Parallel()
 
@@ -121,17 +105,6 @@ func TestMakingJarManifest(t *testing.T) {
 	}
 	if !bytes.Equal(unsignedEmptyCOSEManifest, manifest) {
 		t.Fatalf("manifest mismatch. Expect:\n%+v\nGot:\n%+v", unsignedEmptyCOSEManifest, manifest)
-	}
-
-	manifest, sigfile, err := makeJARManifestAndSignatureFile(unsignedBootstrap)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(manifest, unsignedBootstrapManifest) {
-		t.Fatalf("manifest mismatch. Expect:\n%q\nGot:\n%q", unsignedBootstrapManifest, manifest)
-	}
-	if !bytes.Equal(sigfile, unsignedBootstrapSignatureFile) {
-		t.Fatalf("signature file mismatch. Expect:\n%q\nGot:\n%q", unsignedBootstrapSignatureFile, sigfile)
 	}
 }
 


### PR DESCRIPTION
Throwing an error to prevent signing of files with control character in the name.

Fix AUT-640